### PR TITLE
eslint config(comma-dangle)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,7 @@
   },
   "rules": {
     "arrow-parens": ["error", "as-needed"],
-    "comma-dangle": "off",
+    "comma-dangle": ["error", "always-multiline"],
     "max-len": ["error", 79, {
       "ignorePattern": " // eslint-disable-line "
     }],


### PR DESCRIPTION
將comma-dangle 這則lint rule 調整為：

comma-dangle: ["error", "always-multiline"]