### PR TITLE
Lazy load

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "enzyme": "^2.6.0",
     "eslint": "^3.11.1",
     "eslint-config-airbnb": "^13.0.0",
+    "eslint-loader": "^1.6.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.8.0",

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,24 +1,27 @@
-import React from 'react';
-import { Route, IndexRoute } from 'react-router';
 import App from './containers/Layout';
-import * as containers from './containers';
+import LandingPage from './containers/LandingPage';
 
-
-const {
-  LandingPage,
-  AnotherPage,
-  NotFoundPage,
-} = containers;
-
-const routes = () => (
-  <Route
-    path="/"
-    component={App}
-  >
-    <IndexRoute component={LandingPage} />
-    <Route path="/another" component={AnotherPage} />
-    <Route path="*" component={NotFoundPage} />
-  </Route>
-);
+const routes = () => ({
+  path: '/',
+  component: App,
+  indexRoute: {
+    component: LandingPage,
+  },
+  childRoutes: [{
+    path: 'another',
+    getComponent(nextState, cb) {
+      require.ensure([], require => {
+        cb(null, require('./containers/AnotherPage').default);
+      }, 'another');
+    },
+  }, {
+    path: '*',
+    getComponent(nextState, cb) {
+      require.ensure([], require => {
+        cb(null, require('./containers/NotFoundPage').default);
+      }, 'notFound');
+    },
+  }],
+});
 
 export default routes;

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -26,6 +26,13 @@ module.exports = merge.smart(config, {
     }),
   ],
   module: {
+    preLoaders: [
+      {
+        test: /\.jsx?$/,
+        exclude: path.resolve(__dirname, 'node_modules'),
+        loaders: ['eslint-loader'],
+      },
+    ],
     loaders: [
       {
         test: /^((?!\.module).)*\.css$/,

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,7 +10,7 @@ module.exports = merge.smart(config, {
   entry: './src/index',
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle-[chunkhash].js',
+    filename: '[name]-[chunkhash].js',
   },
   plugins: [
     new webpack.optimize.OccurrenceOrderPlugin(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,6 +2200,15 @@ eslint-import-resolver-node@^0.2.0:
     object-assign "^4.0.1"
     resolve "^1.1.6"
 
+eslint-loader@^1.6.3:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/eslint-loader/-/eslint-loader-1.6.3.tgz#52fdcb32e9e8355108f8380dad4efe51a28986f9"
+  dependencies:
+    find-cache-dir "^0.1.1"
+    loader-utils "^1.0.2"
+    object-assign "^4.0.1"
+    object-hash "^1.1.4"
+
 eslint-module-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
@@ -3655,6 +3664,14 @@ loader-utils@0.2.x, loader-utils@^0.2, loader-utils@^0.2.11, loader-utils@^0.2.1
     json5 "^0.5.0"
     object-assign "^4.0.1"
 
+loader-utils@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+
 lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
@@ -4181,6 +4198,10 @@ object-assign@^4.0.1, object-assign@^4.1.0:
 object-component@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/object-component/-/object-component-0.0.3.tgz#f0c69aa50efc95b866c186f400a33769cb2f1291"
+
+object-hash@^1.1.4:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.1.7.tgz#a8d83fdf5d4583a4e2e7ffc18e8915e08482ef52"
 
 object-is@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR enhances the issue #9.

1. 讓專案支援 lazy load.
2. 為 production bundles 的檔名加上 chunk name (若需在正式環境 dubug 時比較容易找到檔案)
3. 修改 development 的 webpack 設定，存檔時可以立刻執行 ESLint.