### PR TITLE
將內容區塊獨立出來

### DIFF
--- a/src/components/Layout/App.module.css
+++ b/src/components/Layout/App.module.css
@@ -5,6 +5,13 @@
 .App {
 
 }
+@media (min-width: 851px) {
+	.content {
+		margin-top: 67px;
+	}
+}
+
+
 
 /* gloabl style start */
 body, html {

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -8,7 +8,9 @@ import Footer from './Footer';
 const App = ({ children }) => (
   <div className={styles.App}>
     <Header />
-    {children}
+    <div className={styles.content}>
+      {children}
+    </div>
     <Footer />
   </div>
 );


### PR DESCRIPTION
這個PR 主要將內容區塊在最上層獨立出來
目的是我發現現在Layout/App 的children 位置會被header 覆蓋住
實在也不必在每個child component 都處理margin
所以乾脆包裹一個wrapper 在children外，專門作所有內容的排版
