### PR TITLE
Feature/api util

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "redux-thunk": "^2.1.0",
     "serialize-javascript": "^1.3.0",
     "serve-favicon": "^2.3.2",
-    "webpack-isomorphic-tools": "^3.0.2"
+    "webpack-isomorphic-tools": "^3.0.2",
+    "serve-favicon": "^2.3.2",
+    "whatwg-fetch": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "classnames": "^2.2.5",
     "eslint-import-resolver-webpack": "^0.8.1",
     "immutable": "^3.8.1",
+    "isomorphic-fetch": "^2.2.1",
     "path": "^0.12.7",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
@@ -75,8 +76,6 @@
     "redux-thunk": "^2.1.0",
     "serialize-javascript": "^1.3.0",
     "serve-favicon": "^2.3.2",
-    "webpack-isomorphic-tools": "^3.0.2",
-    "serve-favicon": "^2.3.2",
-    "whatwg-fetch": "^2.0.3"
+    "webpack-isomorphic-tools": "^3.0.2"
   }
 }

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -2,7 +2,7 @@ import 'whatwg-fetch';
 
 import { getToken } from 'utils/tokenUtil';
 
-const API_BASE_URL = process.env.APIHOST || '127.0.0.1:4001';
+const API_BASE_URL = process.env.APIHOST || 'http://127.0.0.1:12000';
 
 const headerBuilder = token => (
   token ?
@@ -39,6 +39,6 @@ const fetchUtil = endpoint => (method, body) =>
     `${API_BASE_URL}${endpoint}`,
     optionsBuilder(body)(method)
   )
-    .then(checkStatus);
+    .then(checkStatus());
 
 export default fetchUtil;

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -2,7 +2,7 @@ import 'isomorphic-fetch';
 
 import { getToken } from 'utils/tokenUtil';
 
-const API_BASE_URL = process.env.APIHOST || 'http://127.0.0.1:12000';
+const API_BASE_URL = process.env.API_HOST;
 
 const headerBuilder = token => (
   token ?

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -1,0 +1,44 @@
+import 'whatwg-fetch';
+
+import { getToken } from 'utils/tokenUtil';
+
+const API_BASE_URL = process.env.APIHOST || '127.0.0.1:4001';
+
+const headerBuilder = token => (
+  token ?
+  {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  } :
+  {}
+);
+
+const optionsBuilder = body => method => (
+  body ?
+  {
+    method: method.toUpperCase(),
+    headers: headerBuilder(getToken()),
+    body: JSON.stringify(body),
+  } :
+  {
+    method: method.toUpperCase(),
+    headers: headerBuilder(getToken()),
+  }
+);
+
+const checkStatus = handle401 => response => {
+  if (response.status === 401) {
+    return handle401();
+  }
+
+  return response.json();
+};
+
+const fetchUtil = endpoint => (method, body) =>
+  fetch(
+    `${API_BASE_URL}${endpoint}`,
+    optionsBuilder(body)(method)
+  )
+    .then(checkStatus);
+
+export default fetchUtil;

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -1,4 +1,4 @@
-import 'whatwg-fetch';
+import 'isomorphic-fetch';
 
 import { getToken } from 'utils/tokenUtil';
 

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -13,6 +13,15 @@ const headerBuilder = token => (
   {}
 );
 
+const removeContentType = headers => {
+  const {
+    'Content-Type': contentType, // eslint-disable-line no-unused-vars
+    ...rest
+  } = headers;
+
+  return rest;
+};
+
 const optionsBuilder = body => method => (
   body ?
   {
@@ -22,7 +31,7 @@ const optionsBuilder = body => method => (
   } :
   {
     method: method.toUpperCase(),
-    headers: headerBuilder(getToken()),
+    headers: removeContentType(headerBuilder(getToken())),
   }
 );
 

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -1,0 +1,7 @@
+const TOKEN_KEY_NAME = 'apiToken';
+
+export const saveToken = token =>
+  sessionStorage.save(TOKEN_KEY_NAME, token);
+
+export const getToken = () =>
+  sessionStorage.getItem(TOKEN_KEY_NAME);

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -1,7 +1,10 @@
 const TOKEN_KEY_NAME = 'apiToken';
 
+const checkSessionStorage = () =>
+  typeof sessionStorage !== 'undefined';
+
 export const saveToken = token =>
-  sessionStorage.save(TOKEN_KEY_NAME, token);
+  (checkSessionStorage() ? sessionStorage.save(TOKEN_KEY_NAME, token) : null);
 
 export const getToken = () =>
-  sessionStorage.getItem(TOKEN_KEY_NAME);
+  (checkSessionStorage() ? sessionStorage.getItem(TOKEN_KEY_NAME) : null);

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -4,7 +4,9 @@ const checkSessionStorage = () =>
   typeof sessionStorage !== 'undefined';
 
 export const saveToken = token =>
-  (checkSessionStorage() ? sessionStorage.save(TOKEN_KEY_NAME, token) : null);
+  (checkSessionStorage() ?
+    sessionStorage.setItem(TOKEN_KEY_NAME, token) :
+    null);
 
 export const getToken = () =>
   (checkSessionStorage() ? sessionStorage.getItem(TOKEN_KEY_NAME) : null);

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -26,7 +26,6 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
-        NODE_ENV: JSON.stringify('development'),
         API_HOST: JSON.stringify(API_HOST),
       },
     }),

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -1,6 +1,8 @@
 const autoprefixer = require('autoprefixer');
 const nested = require('postcss-nested');
+const webpack = require('webpack');
 
+const API_HOST = process.env.API_HOST || 'http://127.0.0.1:12000';
 
 module.exports = {
   module: {
@@ -22,6 +24,12 @@ module.exports = {
   },
 
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: JSON.stringify('development'),
+        API_HOST: JSON.stringify(API_HOST),
+      },
+    }),
   ],
 
   postcss: [

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -14,7 +14,6 @@ module.exports = merge.smart(config, {
     'webpack-hot-middleware/client',
     'react-hot-loader/patch',
     './src/index',
-    'whatwg-fetch',
   ],
   output: {
     path: path.join(__dirname, 'dist'),

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -14,6 +14,7 @@ module.exports = merge.smart(config, {
     'webpack-hot-middleware/client',
     'react-hot-loader/patch',
     './src/index',
+    'whatwg-fetch',
   ],
   output: {
     path: path.join(__dirname, 'dist'),

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -10,7 +10,10 @@ const config = require('./webpack.config.base');
 
 module.exports = merge.smart(config, {
   devtool: 'cheap-module-source-map',
-  entry: './src/index',
+  entry: [
+    './src/index',
+    'whatwg-fetch',
+  ],
   output: {
     path: path.join(__dirname, 'dist'),
     filename: '[name]-[chunkhash].js',

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -12,7 +12,6 @@ module.exports = merge.smart(config, {
   devtool: 'cheap-module-source-map',
   entry: [
     './src/index',
-    'whatwg-fetch',
   ],
   output: {
     path: path.join(__dirname, 'dist'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3347,7 +3347,7 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isomorphic-fetch@^2.1.1:
+isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   dependencies:
@@ -6471,10 +6471,6 @@ whatwg-encoding@^1.0.1:
 whatwg-fetch@>=0.10.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
-
-whatwg-fetch@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
 
 whatwg-url@^4.1.0:
   version "4.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6472,6 +6472,10 @@ whatwg-fetch@>=0.10.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.1.tgz#078b9461bbe91cea73cbce8bb122a05f9e92b772"
 
+whatwg-fetch@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz#9c84ec2dcf68187ff00bc64e1274b442176e1c84"
+
 whatwg-url@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.3.0.tgz#92aaee21f4f2a642074357d70ef8500a7cbb171a"


### PR DESCRIPTION
#39 

增加可使用的 `fetchUtil`

- 目前還沒討論出要如何統一出理status code === 401 的方式
（應該是登出、跳轉之類的）
所以那部份先留空，之後再加進去即可

- 會直接將response `JSON.parse()` 送回
- 另外有吃build 時的環境變數，若沒指定則以`127.0.0.1:12000` 作預設
 `const API_BASE_URL = process.env.APIHOST || 'http://127.0.0.1:12000';` 

使用範例：

```javascript
import fetchUtil from 'utils/fetchUtil';

const endpoint = '/books';
const api = fetchUtil(endpoint);
const postBody = {
  title: 'Good Job Life',
  author: 'John Doe',
};


const postApi = body => api('post', body); // 有處理method name 大小寫，安心使用

postApi(postBody)
  .then(r => { console.log(r); };
```


