### PR TITLE
解掉Columns的React warnings

### DIFF
--- a/src/components/common/Columns.js
+++ b/src/components/common/Columns.js
@@ -8,8 +8,8 @@ const Columns = ({
   <div className={styles.columns}>
     {
       items.map((props, i) => (
-        <div className={styles.column}>
-          <Item key={i} {...props} />
+        <div key={i} className={styles.column}>
+          <Item {...props} />
         </div>
       ))
     }
@@ -17,7 +17,7 @@ const Columns = ({
 );
 
 Columns.propTypes = {
-  Item: React.PropTypes.node,
+  Item: React.PropTypes.func,
   items: React.PropTypes.array,
 };
 


### PR DESCRIPTION
1. 把map的key放對位置
2. 把`Item`設為`PropTypes.func` (原本的`PropTypes.node`是錯的，node指的是instance而不是class)