### PR TITLE
讓 configureStore 由外部決定 history

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ Object.keys(window.__data).forEach(key => {
 });
 delete window.__data;
 
-const store = configureStore(preloadedState);
+const store = configureStore(preloadedState, browserHistory);
 const history = syncHistoryWithStore(browserHistory, store);
 const rootElement = document.getElementById('root');
 

--- a/src/server.js
+++ b/src/server.js
@@ -26,7 +26,7 @@ export default (app, webpackIsomorphicTools) => {
 
   app.use((req, res, next) => {
     const memoryHistory = createMemoryHistory(req.originalUrl);
-    const store = configureStore({}, memoryHistory);
+    const store = configureStore(undefined, memoryHistory);
     const history = syncHistoryWithStore(memoryHistory, store);
 
     const location = req.originalUrl;

--- a/src/server.js
+++ b/src/server.js
@@ -26,7 +26,7 @@ export default (app, webpackIsomorphicTools) => {
 
   app.use((req, res, next) => {
     const memoryHistory = createMemoryHistory(req.originalUrl);
-    const store = configureStore();
+    const store = configureStore({}, memoryHistory);
     const history = syncHistoryWithStore(memoryHistory, store);
 
     const location = req.originalUrl;

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -2,7 +2,6 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import createLogger from 'redux-logger';
-import { browserHistory } from 'react-router';
 import { routerMiddleware } from 'react-router-redux';
 import { composeWithDevTools } from 'remote-redux-devtools';
 
@@ -13,9 +12,9 @@ const logger = createLogger({
   level: 'info',
   collapsed: true,
 });
-const router = routerMiddleware(browserHistory);
 
-const configureStore = preloadedState => {
+const configureStore = (preloadedState, history) => {
+  const router = routerMiddleware(history);
   const store = createStore(
     rootReducer,
     preloadedState,

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -1,18 +1,15 @@
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import { browserHistory } from 'react-router';
 import { routerMiddleware } from 'react-router-redux';
 
 import rootReducer from '../reducers';
 
 
-const router = routerMiddleware(browserHistory);
-
-const configureStore = preloadedState =>
+const configureStore = (preloadedState, history) =>
   createStore(
     rootReducer,
     preloadedState,
-    applyMiddleware(thunk, router)
+    applyMiddleware(thunk, routerMiddleware(history))
   );
 
 


### PR DESCRIPTION
1. 根據 react-router-redux ，`routerMiddleware` 會需要 history 來運作

```
import { push } from 'react-router-redux';
store.dispatch(push('/foo'));
```

這樣就可以透過 Action 轉址到 /foo

2. Server Side 端沒有 browserHistory，而只有 memoryHistory，所以
configureStore 就需要 history 這個變數來設定 routerMiddleware

3. 改成這樣之後，ActionCreator 就可以 dispatch 一個 redirect 等 Action
