### PR TITLE
小教室狀態(Loading&Error) + SSR

### DIFF
--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -21,10 +21,7 @@ const setLaborRightsStatus = (nextStatus, err) => ({
   err,
 });
 
-export const fetchLaborRightsIfNeeded = () => (dispatch, getState) => {
-  if (getState().laborRights.get('status') === status.FETCHED) {
-    return Promise.resolve();
-  }
+export const fetchLaborRights = () => dispatch => {
   dispatch(setLaborRightsStatus(status.FETCHING));
   return contentfulUtils.fetchLaborRights().then(({ items }) =>
     items.map(({
@@ -54,4 +51,11 @@ export const fetchLaborRightsIfNeeded = () => (dispatch, getState) => {
   }).catch(err => {
     dispatch(setLaborRightsStatus(status.ERROR, err));
   });
+};
+
+export const fetchLaborRightsIfNeeded = () => (dispatch, getState) => {
+  if (getState().laborRights.get('status') === status.FETCHED) {
+    return Promise.resolve();
+  }
+  return dispatch(fetchLaborRights());
 };

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -1,35 +1,56 @@
 import contentfulUtils from '../utils/contentfulUtils';
 
-export const SET_LABOR_RIGHTS = 'SET_LABOR_RIGHTS';
+export const SET_LABOR_RIGHTS_STATUS = '@@laborRights/SET_LABOR_RIGHTS_STATUS';
+export const SET_LABOR_RIGHTS = '@@laborRights/SET_LABOR_RIGHTS';
+
+export const status = {
+  UNFETCHED: 'UNFETCHED',
+  FETCHED: 'FETCHED',
+  FETCHING: 'FETCHING',
+  ERROR: 'ERROR',
+};
 
 const setLaborRights = items => ({
   type: SET_LABOR_RIGHTS,
   items,
 });
 
-export const loadLaborRights = () => dispatch =>
-  contentfulUtils.fetchLaborRights().then(({ items }) =>
-    items.map(({
-      sys: { id },
-      fields: {
+const setLaborRightsStatus = (nextStatus, err) => ({
+  type: SET_LABOR_RIGHTS_STATUS,
+  nextStatus,
+  err,
+});
+
+export const fetchLaborRights = () => dispatch =>
+  Promise.resolve(
+    dispatch(setLaborRightsStatus(status.FETCHING))
+  ).then(() =>
+    contentfulUtils.fetchLaborRights().then(({ items }) =>
+      items.map(({
+        sys: { id },
+        fields: {
+          title,
+          description,
+          content,
+          coverImage: { fields: { file: { url: coverUrl } } },
+          seoTitle,
+          seoDescription,
+          hidingText,
+        },
+      }) => ({
+        id,
         title,
         description,
         content,
-        coverImage: { fields: { file: { url: coverUrl } } },
+        coverUrl,
         seoTitle,
         seoDescription,
         hidingText,
-      },
-    }) => ({
-      id,
-      title,
-      description,
-      content,
-      coverUrl,
-      seoTitle,
-      seoDescription,
-      hidingText,
-    }))
-  ).then(items => {
-    dispatch(setLaborRights(items));
-  }).catch(() => {});
+      }))
+    ).then(items => {
+      dispatch(setLaborRights(items));
+      dispatch(setLaborRightsStatus(status.FETCHED));
+    }).catch(err => {
+      dispatch(setLaborRightsStatus(status.ERROR, err));
+    })
+  );

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -21,36 +21,34 @@ const setLaborRightsStatus = (nextStatus, err) => ({
   err,
 });
 
-export const fetchLaborRights = () => dispatch =>
-  Promise.resolve(
-    dispatch(setLaborRightsStatus(status.FETCHING))
-  ).then(() =>
-    contentfulUtils.fetchLaborRights().then(({ items }) =>
-      items.map(({
-        sys: { id },
-        fields: {
-          title,
-          description,
-          content,
-          coverImage: { fields: { file: { url: coverUrl } } },
-          seoTitle,
-          seoDescription,
-          hidingText,
-        },
-      }) => ({
-        id,
+export const fetchLaborRights = () => dispatch => {
+  dispatch(setLaborRightsStatus(status.FETCHING));
+  return contentfulUtils.fetchLaborRights().then(({ items }) =>
+    items.map(({
+      sys: { id },
+      fields: {
         title,
         description,
         content,
-        coverUrl,
+        coverImage: { fields: { file: { url: coverUrl } } },
         seoTitle,
         seoDescription,
         hidingText,
-      }))
-    ).then(items => {
-      dispatch(setLaborRights(items));
-      dispatch(setLaborRightsStatus(status.FETCHED));
-    }).catch(err => {
-      dispatch(setLaborRightsStatus(status.ERROR, err));
-    })
-  );
+      },
+    }) => ({
+      id,
+      title,
+      description,
+      content,
+      coverUrl,
+      seoTitle,
+      seoDescription,
+      hidingText,
+    }))
+  ).then(items => {
+    dispatch(setLaborRights(items));
+    dispatch(setLaborRightsStatus(status.FETCHED));
+  }).catch(err => {
+    dispatch(setLaborRightsStatus(status.ERROR, err));
+  });
+};

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -21,7 +21,7 @@ const setLaborRightsStatus = (nextStatus, err) => ({
   err,
 });
 
-export const fetchLaborRights = () => (dispatch, getState) => {
+export const fetchLaborRightsIfNeeded = () => (dispatch, getState) => {
   if (getState().laborRights.get('status') === status.FETCHED) {
     return Promise.resolve();
   }

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -21,7 +21,10 @@ const setLaborRightsStatus = (nextStatus, err) => ({
   err,
 });
 
-export const fetchLaborRights = () => dispatch => {
+export const fetchLaborRights = () => (dispatch, getState) => {
+  if (getState().laborRights.get('status') === status.FETCHED) {
+    return Promise.resolve();
+  }
   dispatch(setLaborRightsStatus(status.FETCHING));
   return contentfulUtils.fetchLaborRights().then(({ items }) =>
     items.map(({

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -54,7 +54,7 @@ LaborRightsMenu.propTypes = {
   items: ImmutablePropTypes.list.isRequired,
   fetchLaborRightsIfNeeded: React.PropTypes.func.isRequired,
   status: React.PropTypes.string.isRequired,
-  error: React.PropTypes.object,
+  error: React.PropTypes.instanceOf(Error),
 };
 
 export default LaborRightsMenu;

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -2,18 +2,18 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-import { status, fetchLaborRights } from '../../actions/laborRights';
+import { status, fetchLaborRightsIfNeeded } from '../../actions/laborRights';
 import Columns from '../common/Columns';
 import Container from './Container';
 import LaborRightsEntry from './LaborRightsEntry';
 
 class LaborRightsMenu extends React.Component {
   static fetchData({ store }) {
-    return store.dispatch(fetchLaborRights());
+    return store.dispatch(fetchLaborRightsIfNeeded());
   }
 
   componentDidMount() {
-    this.props.fetchLaborRights();
+    this.props.fetchLaborRightsIfNeeded();
   }
 
   render() {
@@ -52,7 +52,7 @@ class LaborRightsMenu extends React.Component {
 
 LaborRightsMenu.propTypes = {
   items: ImmutablePropTypes.list.isRequired,
-  fetchLaborRights: React.PropTypes.func.isRequired,
+  fetchLaborRightsIfNeeded: React.PropTypes.func.isRequired,
   status: React.PropTypes.string.isRequired,
   error: React.PropTypes.object,
 };

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -2,26 +2,47 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
+import { status } from '../../actions/laborRights';
 import Columns from '../common/Columns';
 import Container from './Container';
 import LaborRightsEntry from './LaborRightsEntry';
 
 class LaborRightsMenu extends React.Component {
   componentDidMount() {
-    this.props.loadLaborRights();
+    if (this.props.status !== status.FETCHED) {
+      this.props.fetchLaborRights();
+    }
   }
 
   render() {
     return (
       <main>
         <Helmet title="勞動小教室" />
-        <Container>
-          <p className="headingL">勞動小教室</p>
-          <Columns
-            Item={LaborRightsEntry}
-            items={this.props.items.toJS()}
-          />
-        </Container>
+        {
+          this.props.status === status.FETCHING &&
+            <Container>
+              <h1 className="headingL">LOADING</h1>
+            </Container>
+        }
+        {
+          this.props.status === status.ERROR &&
+            this.props.error &&
+              <Container>
+                <h1 className="headingL">
+                  {this.props.error.toString()}
+                </h1>
+              </Container>
+        }
+        {
+          this.props.status === status.FETCHED &&
+            <Container>
+              <h1 className="headingL">勞動小教室</h1>
+              <Columns
+                Item={LaborRightsEntry}
+                items={this.props.items.toJS()}
+              />
+            </Container>
+        }
       </main>
     );
   }
@@ -29,7 +50,9 @@ class LaborRightsMenu extends React.Component {
 
 LaborRightsMenu.propTypes = {
   items: ImmutablePropTypes.list.isRequired,
-  loadLaborRights: React.PropTypes.func.isRequired,
+  fetchLaborRights: React.PropTypes.func.isRequired,
+  status: React.PropTypes.string.isRequired,
+  error: React.PropTypes.object,
 };
 
 export default LaborRightsMenu;

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -13,9 +13,7 @@ class LaborRightsMenu extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.status !== status.FETCHED) {
-      this.props.fetchLaborRights();
-    }
+    this.props.fetchLaborRights();
   }
 
   render() {

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -2,12 +2,16 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 
-import { status } from '../../actions/laborRights';
+import { status, fetchLaborRights } from '../../actions/laborRights';
 import Columns from '../common/Columns';
 import Container from './Container';
 import LaborRightsEntry from './LaborRightsEntry';
 
 class LaborRightsMenu extends React.Component {
+  static fetchData({ store }) {
+    return store.dispatch(fetchLaborRights());
+  }
+
   componentDidMount() {
     if (this.props.status !== status.FETCHED) {
       this.props.fetchLaborRights();

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -13,16 +13,16 @@ import Pagers from './Pagers';
 import CallToAction from './CallToAction';
 import Seperator from './Seperator';
 
-import { status, fetchLaborRights } from '../../actions/laborRights';
+import { status, fetchLaborRightsIfNeeded } from '../../actions/laborRights';
 import styles from './LaborRightsSingle.module.css';
 
 class LaborRightsSingle extends React.Component {
   static fetchData({ store }) {
-    return store.dispatch(fetchLaborRights());
+    return store.dispatch(fetchLaborRightsIfNeeded());
   }
 
   componentDidMount() {
-    this.props.fetchLaborRights();
+    this.props.fetchLaborRightsIfNeeded();
   }
 
   render() {
@@ -92,7 +92,7 @@ LaborRightsSingle.propTypes = {
   item: ImmutablePropTypes.map,
   prev: ImmutablePropTypes.map,
   next: ImmutablePropTypes.map,
-  fetchLaborRights: React.PropTypes.func.isRequired,
+  fetchLaborRightsIfNeeded: React.PropTypes.func.isRequired,
   status: React.PropTypes.string.isRequired,
   error: React.PropTypes.object,
 };

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -22,9 +22,7 @@ class LaborRightsSingle extends React.Component {
   }
 
   componentDidMount() {
-    if (this.props.status !== status.FETCHED) {
-      this.props.fetchLaborRights();
-    }
+    this.props.fetchLaborRights();
   }
 
   render() {

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -13,11 +13,14 @@ import Pagers from './Pagers';
 import CallToAction from './CallToAction';
 import Seperator from './Seperator';
 
+import { status } from '../../actions/laborRights';
 import styles from './LaborRightsSingle.module.css';
 
 class LaborRightsSingle extends React.Component {
   componentDidMount() {
-    this.props.loadLaborRights();
+    if (this.props.status !== status.FETCHED) {
+      this.props.fetchLaborRights();
+    }
   }
 
   render() {
@@ -41,24 +44,43 @@ class LaborRightsSingle extends React.Component {
             { property: 'og:image', content: coverUrl },
           ]}
         />
-        <Container>
-          <BackButton />
-          <h1 className={`headingL ${styles.header}`}>
-            {title}
-          </h1>
-          <Body>
-            <HidingText content={hidingText} />
-            <Description content={description} />
-            <MarkdownParser content={content} />
-            <Feedback />
-            <Seperator />
-            <Pagers
-              prev={this.props.prev}
-              next={this.props.next}
-            />
-          </Body>
-          <CallToAction />
-        </Container>
+        {
+          this.props.status === status.FETCHING &&
+            <Container>
+              <h1 className={`headingL ${styles.header}`}>
+                LOADING
+              </h1>
+            </Container>
+        }
+        {
+          this.props.status === status.ERROR &&
+            <Container>
+              <h1 className={`headingL ${styles.header}`}>
+                {this.props.error.toString()}
+              </h1>
+            </Container>
+        }
+        {
+          this.props.status === status.FETCHED &&
+            <Container>
+              <BackButton />
+              <h1 className={`headingL ${styles.header}`}>
+                {title}
+              </h1>
+              <Body>
+                <HidingText content={hidingText} />
+                <Description content={description} />
+                <MarkdownParser content={content} />
+                <Feedback />
+                <Seperator />
+                <Pagers
+                  prev={this.props.prev}
+                  next={this.props.next}
+                />
+              </Body>
+              <CallToAction />
+            </Container>
+        }
       </main>
     );
   }
@@ -68,7 +90,9 @@ LaborRightsSingle.propTypes = {
   item: ImmutablePropTypes.map,
   prev: ImmutablePropTypes.map,
   next: ImmutablePropTypes.map,
-  loadLaborRights: React.PropTypes.func.isRequired,
+  fetchLaborRights: React.PropTypes.func.isRequired,
+  status: React.PropTypes.string.isRequired,
+  error: React.PropTypes.object,
 };
 
 export default LaborRightsSingle;

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -94,7 +94,7 @@ LaborRightsSingle.propTypes = {
   next: ImmutablePropTypes.map,
   fetchLaborRightsIfNeeded: React.PropTypes.func.isRequired,
   status: React.PropTypes.string.isRequired,
-  error: React.PropTypes.object,
+  error: React.PropTypes.instanceOf(Error),
 };
 
 export default LaborRightsSingle;

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -13,10 +13,14 @@ import Pagers from './Pagers';
 import CallToAction from './CallToAction';
 import Seperator from './Seperator';
 
-import { status } from '../../actions/laborRights';
+import { status, fetchLaborRights } from '../../actions/laborRights';
 import styles from './LaborRightsSingle.module.css';
 
 class LaborRightsSingle extends React.Component {
+  static fetchData({ store }) {
+    return store.dispatch(fetchLaborRights());
+  }
+
   componentDidMount() {
     if (this.props.status !== status.FETCHED) {
       this.props.fetchLaborRights();

--- a/src/containers/LaborRightsMenu.js
+++ b/src/containers/LaborRightsMenu.js
@@ -8,6 +8,8 @@ export default connect(
     items: state.laborRights.get('idList').map(id =>
       state.laborRights.getIn(['dataMapById', id])
     ),
+    status: state.laborRights.get('status'),
+    error: state.laborRights.get('error'),
   }),
   dispatch => bindActionCreators(actionCreators, dispatch),
 )(LaborRightsMenu);

--- a/src/containers/LaborRightsSingle.js
+++ b/src/containers/LaborRightsSingle.js
@@ -16,6 +16,8 @@ export default connect(
       item,
       prev,
       next,
+      status: state.laborRights.get('status'),
+      error: state.laborRights.get('error'),
     };
   },
   dispatch => bindActionCreators(actionCreators, dispatch),

--- a/src/reducers/laborRights.js
+++ b/src/reducers/laborRights.js
@@ -1,20 +1,29 @@
 import { List, Map } from 'immutable';
 import createReducer from 'utils/createReducer';
-import { SET_LABOR_RIGHTS } from '../actions/laborRights';
+import {
+  SET_LABOR_RIGHTS_STATUS,
+  SET_LABOR_RIGHTS,
+  status,
+} from '../actions/laborRights';
 
 const preloadedState = Map({
   idList: List(),
   dataMapById: Map(),
+  status: status.UNFETCHED,
 });
 
 export default createReducer(preloadedState, {
+  [SET_LABOR_RIGHTS_STATUS]: (state, { nextStatus, err }) =>
+    state
+      .set('status', nextStatus)
+      .set('error', err),
   [SET_LABOR_RIGHTS]: (state, { items }) => {
     const idList = List(items.map(item => item.id));
     const dataMapById = Map(items.reduce((partialMap, item) => ({
       ...partialMap,
       [item.id]: Map(item),
     }), {}));
-    return Map({
+    return state.merge({
       idList,
       dataMapById,
     });


### PR DESCRIPTION
#55 

1. 新增三種ActionCreator:
- `fetchLaborRights`: Async action，會呼叫contentfulUtil，並利用以下兩個action設定state
- `setLaborRights`: 將下載好的小教室放進store
- `setLaborRightsStatus`: 設定目前小教室的狀態，如下：

  - `UNFETCHED`: 尚未下載的狀態；小教室`componentDidMount`在發現`status==UNFETCHED`才會啟動`LOAD_LABOR_RIGHTS`
  - `FETCHING`: 已啟動下載但尚未收到回應的狀態；會渲染LOADING字樣
  - `FETCHED`: 已啟動下載並收到回應的狀態；會正常顯室小教室內容
  - `ERROR`: 下載發生錯誤的狀態；會渲染Error message

目前status是跟actions/laborRights放一起，不過我覺得可以獨立出來共用

2. SSR
`fetchData`直接`dispatch(fetchLaborRights())`，不需要檢查是否`status==UNFETCHED`