### PR TITLE
Contentful的getEntry不支援Link resolution

### DIFF
--- a/src/utils/contentfulUtils.js
+++ b/src/utils/contentfulUtils.js
@@ -31,7 +31,6 @@ export default {
     if (items.length === 1) {
       return items.pop();
     }
-    // TODO fix format
     throw new Error('Entry not found only unique');
   }).then(({
     sys: { id },


### PR DESCRIPTION
關於`client.getEntry(id).then(entry => { ... })`

因為小教室`lecturePost`的內容屬於Content，但小教室的圖片卻是算在Assets，兩者不同，所以`lecturePost.coverImage`若要放圖片的話就是放Asset的Link（一種特殊Type）

一般抓`lecturePost`下來會希望拿到的就是包含Asset的所有資料，但實際上這對contentful來說算是多個步驟：抓`lecturePost` -> 解Link -> 抓Assets，解Link這動作叫作resolve

這個Link在`getEntry`是不會resolve的，若要resolve就必須用`getEntries` -- 依官方在Issues的解釋，`getEntry`只會抓該Content，而`getEntries`才會除了抓了Content以外還會連帶抓Link的Assets下來，在client端合併吐出結果

參照：https://github.com/contentful/contentful.js/issues/82

因此想要這裡維持原來寫法（`getEntries`），只是在`items.length !== 1`的時候要怎麼處理，這可以再改