### PR TITLE
Use breaks (follow gfm and contentful preview)

### DIFF
--- a/src/components/LaborRightsSingle/MarkdownParser.js
+++ b/src/components/LaborRightsSingle/MarkdownParser.js
@@ -2,6 +2,10 @@ import React from 'react';
 import marked from 'marked';
 import styles from './MarkdownParser.module.css';
 
+marked.setOptions({
+  breaks: true,
+});
+
 const MarkdownParser = ({ content }) => (
   <div
     className={styles.md}


### PR DESCRIPTION
修改前
![image](https://cloud.githubusercontent.com/assets/1908007/25834875/637fdf68-34ad-11e7-8f48-2dedb4d8d923.png)

修改後
![image](https://cloud.githubusercontent.com/assets/1908007/25834857/455ac2d2-34ad-11e7-8195-c1853fd6767d.png)

這個修改會讓 contentful 的 preview 與上線更一致

不過 style 的 li > p 字體大小會有問題 (1. 的字體大小微小於 2. 的大小)
