### PR TITLE
Facebook 登入與 Like Button

### DIFF
--- a/src/components/LaborRightsSingle/Footer.js
+++ b/src/components/LaborRightsSingle/Footer.js
@@ -3,21 +3,24 @@ import cn from 'classnames';
 import { Link } from 'react-router';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import i from 'common/icons';
+import FacebookWrapper from 'common/FacebookWrapper';
 import { formatCanonicalPath } from 'utils/helmetHelper';
 import styles from './Footer.module.css';
 
 const Footer = ({ id, prev, next }) => (
   <div className={cn(styles.footer, 'wrapperM')}>
     <div className={styles.share}>
-      <div
-        className="fb-like"
-        data-href={formatCanonicalPath(`/labor-rights/${id}`)}
-        data-layout="button_count"
-        data-action="like"
-        data-size="large"
-        data-show-faces="false"
-        data-share="true"
-      />
+      <FacebookWrapper appId="1750608541889151">
+        <div
+          className="fb-like"
+          data-href={formatCanonicalPath(`/labor-rights/${id}`)}
+          data-layout="button_count"
+          data-action="like"
+          data-size="large"
+          data-show-faces="false"
+          data-share="true"
+        />
+      </FacebookWrapper>
     </div>
     <div className={styles.pagers}>
       <Link to="/labor-rights" className={styles.back}>

--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import cn from 'classnames';
 import i from 'common/icons';
+import FacebookProvider from 'common/FacebookProvider';
 import styles from './Header.module.css';
 import SiteMenu from './SiteMenu';
 
@@ -12,6 +13,7 @@ class Header extends React.Component {
     };
     this.toggleNav = this.toggleNav.bind(this);
     this.closeNav = this.closeNav.bind(this);
+    this.facebookReady = this.facebookReady.bind(this);
   }
 
   toggleNav() {
@@ -23,6 +25,13 @@ class Header extends React.Component {
   closeNav() {
     this.setState({
       isNavOpen: false,
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  facebookReady(FB) {
+    FB.getLoginStatus(response => {
+      console.log(response);
     });
   }
 
@@ -45,6 +54,7 @@ class Header extends React.Component {
           >
             <SiteMenu />
           </nav>
+          <FacebookProvider appId="1750608541889151" onReady={this.facebookReady} />
         </div>
       </header>
     );

--- a/src/components/common/FacebookProvider.js
+++ b/src/components/common/FacebookProvider.js
@@ -1,0 +1,34 @@
+import { Component, PropTypes } from 'react';
+import Facebook from '../../utils/facebook';
+
+// 一個 utils/facebook 的 instance，FacebookProvider 共用同一個
+let facebookInstance;
+
+export default class FacebookProvider extends Component {
+  componentDidMount() {
+    if (!this.facebook) {
+      if (!facebookInstance) {
+        facebookInstance = new Facebook(this.props.appId);
+      }
+
+      this.facebook = facebookInstance;
+    }
+
+    this.facebook.init()
+      .then(FB => {
+        if (this.props.onReady) {
+          this.props.onReady(FB);
+        }
+      });
+  }
+
+  render() {
+    return this.props.children || null;
+  }
+}
+
+FacebookProvider.propTypes = {
+  appId: PropTypes.string.isRequired,
+  onReady: PropTypes.func,
+  children: PropTypes.node,
+};

--- a/src/components/common/FacebookWrapper.js
+++ b/src/components/common/FacebookWrapper.js
@@ -1,0 +1,43 @@
+import React, { Component, PropTypes } from 'react';
+import FacebookProvider from './FacebookProvider';
+
+export default class FacebookWrapper extends Component {
+  constructor(props) {
+    super(props);
+    this.handleContainer = this.handleContainer.bind(this);
+    this.handleFacebookReady = this.handleFacebookReady.bind(this);
+  }
+
+  // 讓 FB 重新 parse children
+  componentDidUpdate() {
+    if (this.FB) {
+      this.FB.XFBML.parse(this.container);
+    }
+  }
+
+  handleContainer(container) {
+    this.container = container;
+  }
+
+  handleFacebookReady(FB) {
+    this.FB = FB;
+    this.FB.XFBML.parse(this.container);
+  }
+
+  render() {
+    const { appId, children } = this.props;
+
+    return (
+      <FacebookProvider appId={appId} onReady={this.handleFacebookReady}>
+        <div ref={this.handleContainer}>
+          {children}
+        </div>
+      </FacebookProvider>
+    );
+  }
+}
+
+FacebookWrapper.propTypes = {
+  appId: PropTypes.string.isRequired,
+  children: PropTypes.node,
+};

--- a/src/utils/facebook.js
+++ b/src/utils/facebook.js
@@ -1,0 +1,46 @@
+/*
+ * FB SDK 包裝
+ */
+// reference: https://github.com/CherryProjects/react-facebook/blob/master/src/Facebook.js
+// 由於需要 DOM，所以 Server Side Rendering 不能使用
+
+export default class Facebook {
+  constructor(appId) {
+    this.appId = appId;
+  }
+
+  init() {
+    // 第二次 init 時可以取用之前的結果
+    if (this.loadingPromise) {
+      return this.loadingPromise;
+    }
+
+    this.loadingPromise = new Promise(resolve => {
+      const appId = this.appId;
+
+      // FB SDK loading 後會觸發 window.fbAsyncInit
+      window.fbAsyncInit = () => {
+        window.FB.init({
+          appId,
+          cookie: true,
+          xfbml: true,
+          version: 'v2.6',
+        });
+
+        resolve(window.FB);
+      };
+
+      // FB SDK
+      // eslint-disable-next-line
+      (function (d, s, id) {
+        const fjs = d.getElementsByTagName(s)[0];
+        if (d.getElementById(id)) return;
+        const js = d.createElement(s); js.id = id;
+        js.src = '//connect.facebook.net/zh_TW/sdk.js';
+        fjs.parentNode.insertBefore(js, fjs);
+      })(document, 'script', 'facebook-jssdk');
+    });
+
+    return this.loadingPromise;
+  }
+}


### PR DESCRIPTION
這個 PR 分成兩個部分

1. 將 FB SDK 引入
2. 與我們現有的 Component 搭配


(1.) 的部分：
FB SDK 會在 loading 完成後執行 `window.fbAsyncInit`，所以參考資料來源寫了一個與 React 結合的 Component `FacebookProvider`

(2.) 的部分

經過測試：
![image](https://cloud.githubusercontent.com/assets/1908007/25915080/d7e9218e-35f2-11e7-92b1-2f381e30462a.png)

這裡遇到最大的問題是：

FB 的按讚按鈕不是 React Render 的，所以當我們小教室切換時，React 只會更新 

```
<div
  className="fb-like"
  data-href={formatCanonicalPath(`/labor-rights/${id}`)}
  data-layout="button_count"
  data-action="like"
  data-size="large"
  data-show-faces="false"
  data-share="true"
/>
```

會導致按讚按鈕停留在舊的狀態

用 `componentDidUpdate` 讓 FB XFBML 重新 parse 即可