### PR TITLE
表單送出與FB 登入整合

### DIFF
--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import R from 'ramda';
 
-import SubmitArea from '../common/SubmitArea';
+import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 
 import styles from './InterviewForm.module.css';
 

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
@@ -25,6 +26,9 @@ class SubmitArea extends React.PureComponent {
     const {
       onSubmit,
       submitable,
+      auth,
+      login,
+      FB,
     } = this.props;
 
     const {
@@ -67,8 +71,11 @@ class SubmitArea extends React.PureComponent {
         <div>
           <ButtonSubmit
             text="送出資料"
-            onClick={onSubmit}
+            onSubmit={onSubmit}
             disabled={!this.state.agree || !submitable}
+            auth={auth}
+            login={login}
+            FB={FB}
           />
         </div>
       </div>
@@ -79,6 +86,9 @@ class SubmitArea extends React.PureComponent {
 SubmitArea.propTypes = {
   onSubmit: PropTypes.func,
   submitable: PropTypes.bool,
+  auth: ImmutablePropTypes.map,
+  login: PropTypes.func.isRequired,
+  FB: PropTypes.object,
 };
 
 export default SubmitArea;

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -14,7 +14,7 @@ class ButtonSubmit extends React.PureComponent {
     this.login = this.login.bind(this);
   }
   login() {
-    this.props.login(this.props.FB)
+    return this.props.login(this.props.FB)
       .catch(error => {
         console.log(error);
       });
@@ -31,16 +31,33 @@ class ButtonSubmit extends React.PureComponent {
         >
           {text}
         </button> :
-        <button
-          className={styles.container}
-          onClick={() =>
-            this.login()
-              .then(onSubmit)
-          }
-          disabled={disabled}
-        >
-          {`以F認證，${text}`}
-        </button>
+        <div>
+          <button
+            className={styles.container}
+            onClick={() =>
+              this.login()
+                .then(onSubmit)
+            }
+            disabled={disabled}
+          >
+            {`以F認證，${text}`}
+          </button>
+          <div
+            style={{
+              textAlign: 'center',
+              marginTop: '21px',
+            }}
+          >
+            <p
+              className="pMbold"
+              style={{
+                color: '#C0C0C0',
+              }}
+            >
+              為什麼需要 Facebook 帳戶驗證？
+            </p>
+          </div>
+        </div>
     );
   }
 }

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -1,22 +1,57 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import styles from './ButtonSubmit.module.css';
 
-const ButtonSubmit = ({ text, onClick, disabled }) => (
-  <button
-    className={styles.container}
-    onClick={onClick}
-    disabled={disabled}
-  >
-    {text}
-  </button>
-);
+const isLogin = auth =>
+  auth.get('status') === 'connected';
+
+class ButtonSubmit extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.login = this.login.bind(this);
+  }
+  login() {
+    this.props.login(this.props.FB)
+      .catch(error => {
+        console.log(error);
+      });
+  }
+
+  render() {
+    const { text, onSubmit, disabled, auth } = this.props;
+    return (
+      isLogin(auth) ?
+        <button
+          className={styles.container}
+          onClick={onSubmit}
+          disabled={disabled}
+        >
+          {text}
+        </button> :
+        <button
+          className={styles.container}
+          onClick={() =>
+            this.login()
+              .then(onSubmit)
+          }
+          disabled={disabled}
+        >
+          {`以F認證，${text}`}
+        </button>
+    );
+  }
+}
 
 ButtonSubmit.propTypes = {
   text: PropTypes.string,
-  onClick: PropTypes.func,
+  onSubmit: PropTypes.func,
   disabled: PropTypes.bool,
+  auth: ImmutablePropTypes.map,
+  login: PropTypes.func.isRequired,
+  FB: PropTypes.object,
 };
 
 export default ButtonSubmit;

--- a/src/containers/ShareExperience/SubmitAreaContainer.js
+++ b/src/containers/ShareExperience/SubmitAreaContainer.js
@@ -1,0 +1,18 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import withFB from 'common/withFB';
+import SubmitArea from '../../components/ShareExperience/common/SubmitArea';
+import { login } from '../../actions/auth';
+
+
+const mapStateToProps = state => ({
+  auth: state.auth,
+});
+
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login }, dispatch);
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(withFB(SubmitArea));


### PR DESCRIPTION
此PR 讓表單送出的行為，經過FB 登入，以順利post。

### 做完的事
* 讓SubmitArea 與登入狀態綁定，若未登入則登入並接著執行onSubmit 的行為