### PR TITLE
兩個填寫頁的送出回饋，以及元件Style

### DIFF
--- a/src/components/ShareExperience/common/FacebookFail.js
+++ b/src/components/ShareExperience/common/FacebookFail.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Warning from 'common/icons/Warning';
+import Button from 'common/button/Button';
+
+const FacebookFail = ({ buttonClick }) => (
+  <div
+    style={{
+      padding: '55px',
+      width: '470px',
+    }}
+  >
+    <Warning
+      style={{
+        fill: '#FCD406',
+        height: '82px',
+        width: '82px',
+        marginBottom: '32px',
+      }}
+    />
+    <h2
+      style={{
+        fontSize: '2rem',
+        marginBottom: '19px',
+      }}
+    >
+      Facebook 登入失敗
+    </h2>
+    <p
+      style={{
+        marginBottom: '30px',
+      }}
+    >
+      為了避免使用者大量輸入假資訊，我們會以您的 Facebook 帳戶做驗證。但別擔心！您的帳戶資訊不會以任何形式被揭露、顯示。
+    </p>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <Button
+        btnStyle="black"
+        circleSize="md"
+        onClick={buttonClick}
+      >
+        以 f 認證，送出資料
+      </Button>
+    </div>
+  </div>
+);
+
+FacebookFail.propTypes = {
+  buttonClick: PropTypes.func,
+};
+
+export default FacebookFail;

--- a/src/components/ShareExperience/common/FailFeedback.js
+++ b/src/components/ShareExperience/common/FailFeedback.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Warning from 'common/icons/Warning';
+import Button from 'common/button/Button';
+
+const FailFeedback = ({ buttonClick }) => (
+  <div
+    style={{
+      padding: '55px',
+      width: '470px',
+    }}
+  >
+    <Warning
+      style={{
+        fill: '#FCD406',
+        height: '82px',
+        width: '82px',
+        marginBottom: '32px',
+      }}
+    />
+    <h2
+      style={{
+        fontSize: '2rem',
+        marginBottom: '19px',
+      }}
+    >
+      Oops 有些錯誤發生
+    </h2>
+    <p
+      style={{
+        marginBottom: '30px',
+      }}
+    >
+      請查看你的網路連線再試一次，如果你還沒填寫完，請先別關閉瀏覽器！
+    </p>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <Button
+        btnStyle="black"
+        circleSize="md"
+        onClick={buttonClick}
+      >
+        好，我知道了
+      </Button>
+    </div>
+  </div>
+);
+
+FailFeedback.propTypes = {
+  buttonClick: PropTypes.func,
+};
+
+export default FailFeedback;

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -4,21 +4,32 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
+import Modal from 'common/Modal';
+
+import SuccessFeedback from './SuccessFeedback';
 
 class SubmitArea extends React.PureComponent {
   constructor(props) {
     super(props);
 
     this.handleAgree = this.handleAgree.bind(this);
+    this.handleIsOpen = this.handleIsOpen.bind(this);
 
     this.state = {
       agree: false,
+      isOpen: true,
     };
   }
 
   handleAgree(agree) {
     this.setState(() => ({
       agree,
+    }));
+  }
+
+  handleIsOpen(isOpen) {
+    this.setState(() => ({
+      isOpen,
     }));
   }
 
@@ -33,6 +44,7 @@ class SubmitArea extends React.PureComponent {
 
     const {
       agree,
+      isOpen,
     } = this.state;
 
     return (
@@ -77,6 +89,12 @@ class SubmitArea extends React.PureComponent {
             FB={FB}
           />
         </div>
+        <Modal
+          isOpen={isOpen}
+          close={() => this.handleIsOpen(!isOpen)}
+        >
+          <SuccessFeedback />
+        </Modal>
       </div>
     );
   }

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -9,6 +9,7 @@ import Modal from 'common/Modal';
 
 import SuccessFeedback from './SuccessFeedback';
 import FailFeedback from './FailFeedback';
+import FacebookFail from './FacebookFail';
 
 const getSuccessFeedback = id => (
   <SuccessFeedback
@@ -24,6 +25,12 @@ const getFailFeedback = buttonClick => (
   />
 );
 
+const getFacebookFail = buttonClick => (
+  <FacebookFail
+    buttonClick={buttonClick}
+  />
+);
+
 class SubmitArea extends React.PureComponent {
   constructor(props) {
     super(props);
@@ -32,6 +39,8 @@ class SubmitArea extends React.PureComponent {
     this.handleIsOpen = this.handleIsOpen.bind(this);
     this.handleFeedback = this.handleFeedback.bind(this);
     this.onSubmit = this.onSubmit.bind(this);
+    this.login = this.login.bind(this);
+    this.onFacebookFail = this.onFacebookFail.bind(this);
 
     this.state = {
       agree: false,
@@ -39,6 +48,7 @@ class SubmitArea extends React.PureComponent {
       feedback: null,
     };
   }
+
 
   onSubmit() {
     return this.props.onSubmit()
@@ -55,6 +65,22 @@ class SubmitArea extends React.PureComponent {
       });
   }
 
+  onFacebookFail() {
+    this.handleIsOpen(true);
+    return this.handleFeedback(getFacebookFail(this.login));
+  }
+
+  login() {
+    return this.props.login(this.props.FB)
+      .then(status => {
+        if (status === 'connected') {
+          return this.onSubmit();
+        }
+
+        throw Error('can not login');
+      })
+      .catch(this.onFacebookFail);
+  }
   handleAgree(agree) {
     this.setState(() => ({
       agree,
@@ -77,8 +103,6 @@ class SubmitArea extends React.PureComponent {
     const {
       submitable,
       auth,
-      login,
-      FB,
     } = this.props;
 
     const {
@@ -125,9 +149,7 @@ class SubmitArea extends React.PureComponent {
             onSubmit={this.onSubmit}
             disabled={!this.state.agree || !submitable}
             auth={auth}
-            login={login}
-            loginFallback={() => { console.log('登入失敗啦！！！'); }}
-            FB={FB}
+            login={this.login}
           />
         </div>
         <Modal

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { browserHistory } from 'react-router';
 
 import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
@@ -8,22 +9,38 @@ import Modal from 'common/Modal';
 
 import SuccessFeedback from './SuccessFeedback';
 
+const getSuccessFeedback = id => (
+  <SuccessFeedback
+    buttonClick={() => (
+      browserHistory.push(`/experiences/${id}`)
+    )}
+  />
+);
+
 class SubmitArea extends React.PureComponent {
   constructor(props) {
     super(props);
 
     this.handleAgree = this.handleAgree.bind(this);
     this.handleIsOpen = this.handleIsOpen.bind(this);
+    this.handleFeedback = this.handleFeedback.bind(this);
 
     this.state = {
       agree: false,
-      isOpen: true,
+      isOpen: false,
+      feedback: null,
     };
   }
 
   handleAgree(agree) {
     this.setState(() => ({
       agree,
+    }));
+  }
+
+  handleFeedback(feedback) {
+    this.setState(() => ({
+      feedback,
     }));
   }
 
@@ -45,6 +62,7 @@ class SubmitArea extends React.PureComponent {
     const {
       agree,
       isOpen,
+      feedback,
     } = this.state;
 
     return (
@@ -82,7 +100,18 @@ class SubmitArea extends React.PureComponent {
         <div>
           <ButtonSubmit
             text="送出資料"
-            onSubmit={onSubmit}
+            onSubmit={() => (
+              onSubmit()
+                .then(r => r.experience._id)
+                .then(id => {
+                  this.handleIsOpen(true);
+                  return this.handleFeedback(getSuccessFeedback(id));
+                })
+                .catch(() => {
+                  this.handleIsOpen(true);
+                  return this.handleFeedback(getSuccessFeedback('fail'));
+                })
+            )}
             disabled={!this.state.agree || !submitable}
             auth={auth}
             login={login}
@@ -93,7 +122,7 @@ class SubmitArea extends React.PureComponent {
           isOpen={isOpen}
           close={() => this.handleIsOpen(!isOpen)}
         >
-          <SuccessFeedback />
+          {feedback}
         </Modal>
       </div>
     );

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -40,7 +40,6 @@ class SubmitArea extends React.PureComponent {
         style={{
           display: 'flex',
           flexDirection: 'column',
-          alignItems: 'center',
           marginTop: '57px',
         }}
       >

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -133,6 +133,7 @@ class SubmitArea extends React.PureComponent {
         <Modal
           isOpen={isOpen}
           close={() => this.handleIsOpen(!isOpen)}
+          hasClose={false}
         >
           {feedback}
         </Modal>

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -8,12 +8,19 @@ import Checkbox from 'common/form/Checkbox';
 import Modal from 'common/Modal';
 
 import SuccessFeedback from './SuccessFeedback';
+import FailFeedback from './FailFeedback';
 
 const getSuccessFeedback = id => (
   <SuccessFeedback
     buttonClick={() => (
       browserHistory.push(`/experiences/${id}`)
     )}
+  />
+);
+
+const getFailFeedback = buttonClick => (
+  <FailFeedback
+    buttonClick={buttonClick}
   />
 );
 
@@ -24,12 +31,28 @@ class SubmitArea extends React.PureComponent {
     this.handleAgree = this.handleAgree.bind(this);
     this.handleIsOpen = this.handleIsOpen.bind(this);
     this.handleFeedback = this.handleFeedback.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
 
     this.state = {
       agree: false,
       isOpen: false,
       feedback: null,
     };
+  }
+
+  onSubmit() {
+    return this.props.onSubmit()
+      .then(r => r.experience._id)
+      .then(id => {
+        this.handleIsOpen(true);
+        return this.handleFeedback(getSuccessFeedback(id));
+      })
+      .catch(() => {
+        this.handleIsOpen(true);
+        return this.handleFeedback(getFailFeedback(
+          () => this.handleIsOpen(false)
+        ));
+      });
   }
 
   handleAgree(agree) {
@@ -52,7 +75,6 @@ class SubmitArea extends React.PureComponent {
 
   render() {
     const {
-      onSubmit,
       submitable,
       auth,
       login,
@@ -100,21 +122,11 @@ class SubmitArea extends React.PureComponent {
         <div>
           <ButtonSubmit
             text="送出資料"
-            onSubmit={() => (
-              onSubmit()
-                .then(r => r.experience._id)
-                .then(id => {
-                  this.handleIsOpen(true);
-                  return this.handleFeedback(getSuccessFeedback(id));
-                })
-                .catch(() => {
-                  this.handleIsOpen(true);
-                  return this.handleFeedback(getSuccessFeedback('fail'));
-                })
-            )}
+            onSubmit={this.onSubmit}
             disabled={!this.state.agree || !submitable}
             auth={auth}
             login={login}
+            loginFallback={() => { console.log('登入失敗啦！！！'); }}
             FB={FB}
           />
         </div>

--- a/src/components/ShareExperience/common/SuccessFeedback.js
+++ b/src/components/ShareExperience/common/SuccessFeedback.js
@@ -1,0 +1,34 @@
+import React from 'react';
+// import PropTypes from 'prop-types';
+
+import Checked from 'common/icons/Checked';
+// import Button from 'common/button/Button';
+
+const SuccessFeedback = () => (
+  <div
+    style={{
+      padding: '55px',
+      width: '470px',
+    }}
+  >
+    <Checked
+      style={{
+        fill: '#FCD406',
+        height: '82px',
+        width: '82px',
+        marginBottom: '32px',
+      }}
+    />
+    <h2
+      style={{
+        fontSize: '2rem',
+      }}
+    >
+      上傳成功
+    </h2>
+  </div>
+);
+
+SuccessFeedback.propTypes = {};
+
+export default SuccessFeedback;

--- a/src/components/ShareExperience/common/SuccessFeedback.js
+++ b/src/components/ShareExperience/common/SuccessFeedback.js
@@ -1,10 +1,10 @@
 import React from 'react';
-// import PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 import Checked from 'common/icons/Checked';
-// import Button from 'common/button/Button';
+import Button from 'common/button/Button';
 
-const SuccessFeedback = () => (
+const SuccessFeedback = ({ buttonClick }) => (
   <div
     style={{
       padding: '55px',
@@ -22,13 +22,30 @@ const SuccessFeedback = () => (
     <h2
       style={{
         fontSize: '2rem',
+        marginBottom: '47px',
       }}
     >
       上傳成功
     </h2>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <Button
+        btnStyle="black"
+        circleSize="md"
+        onClick={buttonClick}
+      >
+        查看本篇
+      </Button>
+    </div>
   </div>
 );
 
-SuccessFeedback.propTypes = {};
+SuccessFeedback.propTypes = {
+  buttonClick: PropTypes.func,
+};
 
 export default SuccessFeedback;

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -6,7 +6,7 @@ import Cross from '../images/x.svg';
 
 import styles from './Modal.module.css';
 
-const Modal = ({ children, isOpen, close }) => (
+const Modal = ({ children, isOpen, hasClose, close }) => (
   <div
     className={
       cn(styles.modal, { [styles.isOpen]: isOpen })
@@ -14,12 +14,15 @@ const Modal = ({ children, isOpen, close }) => (
   >
     <div className={styles.inner}>
       <div className={styles.content}>
-        <div className={styles.close}>
-          <Cross
-            className={styles.close__icon}
-            onClick={close}
-          />
-        </div>
+        {
+          hasClose ?
+            <div className={styles.close}>
+              <Cross
+                className={styles.close__icon}
+                onClick={close}
+              />
+            </div> : null
+        }
         {children}
       </div>
     </div>
@@ -29,7 +32,12 @@ const Modal = ({ children, isOpen, close }) => (
 Modal.propTypes = {
   children: PropTypes.node,
   isOpen: PropTypes.bool,
+  hasClose: PropTypes.bool,
   close: PropTypes.func,
+};
+
+Modal.defaultProps = {
+  hasClose: true,
 };
 
 export default Modal;

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -23,41 +23,50 @@ class ButtonSubmit extends React.PureComponent {
   render() {
     const { text, onSubmit, disabled, auth } = this.props;
     return (
-      isLogin(auth) ?
-        <button
-          className={styles.container}
-          onClick={onSubmit}
-          disabled={disabled}
-        >
-          {text}
-        </button> :
-        <div>
-          <button
-            className={styles.container}
-            onClick={() =>
-              this.login()
-                .then(onSubmit)
-            }
-            disabled={disabled}
-          >
-            {`以F認證，${text}`}
-          </button>
-          <div
-            style={{
-              textAlign: 'center',
-              marginTop: '21px',
-            }}
-          >
-            <p
-              className="pMbold"
-              style={{
-                color: '#C0C0C0',
-              }}
+      <div
+        style={{
+          // display: 'flex',
+          textAlign: 'center',
+        }}
+      >
+        {
+          isLogin(auth) ?
+            <button
+              className={styles.container}
+              onClick={onSubmit}
+              disabled={disabled}
             >
-              為什麼需要 Facebook 帳戶驗證？
-            </p>
-          </div>
-        </div>
+              {text}
+            </button> :
+            <div>
+              <button
+                className={styles.container}
+                onClick={() =>
+                  this.login()
+                    .then(onSubmit)
+                }
+                disabled={disabled}
+              >
+                <pre>{`以  f  認證，${text}`}</pre>
+              </button>
+              <div
+                style={{
+                  textAlign: 'center',
+                  marginTop: '21px',
+                }}
+              >
+                <p
+                  className="pMbold"
+                  style={{
+                    color: '#C0C0C0',
+                  }}
+                >
+                  為什麼需要 Facebook 帳戶驗證？
+              </p>
+              </div>
+            </div>
+        }
+      </div>
     );
   }
 }

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -8,19 +8,8 @@ const isLogin = auth =>
   auth.get('status') === 'connected';
 
 class ButtonSubmit extends React.PureComponent {
-  constructor(props) {
-    super(props);
-
-    this.login = this.login.bind(this);
-  }
-  login() {
-    return this.props.login(this.props.FB)
-      .then(this.props.onSubmit)
-      .catch(this.props.loginFallback);
-  }
-
   render() {
-    const { text, onSubmit, disabled, auth } = this.props;
+    const { text, onSubmit, disabled, auth, login } = this.props;
     return (
       <div
         style={{
@@ -39,9 +28,7 @@ class ButtonSubmit extends React.PureComponent {
             <div>
               <button
                 className={styles.container}
-                onClick={() =>
-                  this.login()
-                }
+                onClick={login}
                 disabled={disabled}
               >
                 <pre>{`以  f  認證，${text}`}</pre>
@@ -74,8 +61,6 @@ ButtonSubmit.propTypes = {
   disabled: PropTypes.bool,
   auth: ImmutablePropTypes.map,
   login: PropTypes.func.isRequired,
-  loginFallback: PropTypes.func,
-  FB: PropTypes.object,
 };
 
 export default ButtonSubmit;

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -15,9 +15,8 @@ class ButtonSubmit extends React.PureComponent {
   }
   login() {
     return this.props.login(this.props.FB)
-      .catch(error => {
-        console.log(error);
-      });
+      .then(this.props.onSubmit)
+      .catch(this.props.loginFallback);
   }
 
   render() {
@@ -25,7 +24,6 @@ class ButtonSubmit extends React.PureComponent {
     return (
       <div
         style={{
-          // display: 'flex',
           textAlign: 'center',
         }}
       >
@@ -43,7 +41,6 @@ class ButtonSubmit extends React.PureComponent {
                 className={styles.container}
                 onClick={() =>
                   this.login()
-                    .then(onSubmit)
                 }
                 disabled={disabled}
               >
@@ -77,6 +74,7 @@ ButtonSubmit.propTypes = {
   disabled: PropTypes.bool,
   auth: ImmutablePropTypes.map,
   login: PropTypes.func.isRequired,
+  loginFallback: PropTypes.func,
   FB: PropTypes.object,
 };
 

--- a/src/components/common/button/ButtonSubmit.module.css
+++ b/src/components/common/button/ButtonSubmit.module.css
@@ -4,7 +4,10 @@
 .container {
   background: #000000;
   color: #FFFFFF;
-  padding: 14px 68px;
+  padding: 14px 0;
+  // height: 50px;
+  width: 200px;
+  text-align: center;
 
   &:hover {
     background: main-yellow;


### PR DESCRIPTION
這個PR 主要在補上填寫頁面的送出回饋

## 做了什麼
* 送出成功、失敗的回饋UI
* 成功後的按鈕讓他直接跳轉到該篇的頁面
* 失敗則讓他關閉Modal
* Modal 加上`hasClose` 的選項讓使用者可以選擇該Modal 是否要包含 **關閉按鈕 X**

## 沒做什麼
* 我還沒辦法模擬出FB 登入的失敗，所以登入失敗單獨的回饋則沒有接上，我用斷網來測，是會回到上述通用的「失敗」

#147 