### PR TITLE
修正面試QA 答案不可空白問題

### DIFF
--- a/src/components/ShareExperience/InterviewForm/formCheck.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.js
@@ -97,9 +97,12 @@ const interviewQaQuestion = R.compose(
 );
 
 const interviewQaAnswer = R.compose(
-  R.allPass([
-    lteLength(5000),
-    gtLength(0),
+  R.anyPass([
+    R.allPass([
+      lteLength(5000),
+      gtLength(0),
+    ]),
+    n => (n === undefined) || (n === null) || (n === ''),
   ]),
   R.prop('answer')
 );

--- a/src/components/ShareExperience/InterviewForm/formCheck.test.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.test.js
@@ -223,7 +223,7 @@ describe('singleQa and qas tests', () => {
 
   test('singleInterviewQa content tests', () => {
     expect(singleInterviewQa(sectionTooLongAnswer)).toBe(false);
-    expect(singleInterviewQa(sectionEmptyAnswer)).toBe(false);
+    expect(singleInterviewQa(sectionEmptyAnswer)).toBe(true);
   });
 
   test('interviewQas pass', () => {
@@ -235,7 +235,6 @@ describe('singleQa and qas tests', () => {
     expect(interviewQas([normalQa, sectionTooLongQuestion])).toBe(false);
     expect(interviewQas([normalQa, sectionEmptyQuestion])).toBe(false);
     expect(interviewQas([normalQa, sectionTooLongAnswer])).toBe(false);
-    expect(interviewQas([normalQa, sectionEmptyAnswer])).toBe(false);
   });
 });
 

--- a/src/components/ShareExperience/utils.js
+++ b/src/components/ShareExperience/utils.js
@@ -65,12 +65,6 @@ const filterEmptyInterviewQas = R.filter(
       R.defaultTo(''),
       R.prop('question')
     ),
-    R.compose(
-      n => n !== 0,
-      s => s.length,
-      R.defaultTo(''),
-      R.prop('answer')
-    ),
   ])
 );
 


### PR DESCRIPTION
修改form checking function
並且在form to api body 中間修改為，不排除答案為空的qa object

#170 