### PR TITLE
Refactor helmet

### DIFF
--- a/src/components/About/index.js
+++ b/src/components/About/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
+import helmetData from '../../constants/helmetData';
 
 const About = () => (
   <Section Tag="main" pageTop paddingBottom>
+    <Helmet {...helmetData.ABOUT} />
     <Wrapper size="l">
       About
     </Wrapper>

--- a/src/components/Contact/index.js
+++ b/src/components/Contact/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
+import helmetData from '../../constants/helmetData';
 
 const Contact = () => (
   <Section Tag="main" pageTop paddingBottom>
+    <Helmet {...helmetData.CONTACT} />
     <Wrapper size="l">
       Contact
     </Wrapper>

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -12,6 +12,7 @@ import status from '../../constants/status';
 import {
   fetchExperience,
 } from '../../actions/experienceDetail';
+import { formatCanonicalPath } from '../../utils/helmetHelper';
 
 class ExperienceDetail extends Component {
   static propTypes = {
@@ -56,6 +57,42 @@ class ExperienceDetail extends Component {
     this.props.submitComment(data.experience._id);
   }
 
+  renderHelmet = () => {
+    if (this.props.experienceDetail) {
+      const experience = this.props.experienceDetail.toJS().experience;
+      console.log(experience);
+      if ('_id' in experience) {
+        const id = experience._id;
+        const company = experience.company.name;
+        const jobTitle = experience.job_title;
+        const type = experience.type;
+        const sections = experience.sections;
+        const mapping = {
+          interview: '面試經驗分享',
+          work: '工作經驗分享',
+        };
+        const title = `${company} ${jobTitle} ${mapping[type]}`;
+        const description = `${sections[0].subtitle} ${sections[0].content}`;
+        return (
+          <Helmet
+            title={title}
+            meta={[
+              { name: 'description', content: description },
+              { property: 'og:title', content: title },
+              { property: 'og:url', content: formatCanonicalPath(`/experiences/${id}`) },
+              { property: 'og:description', content: description },
+            ]}
+            link={[
+              { rel: 'canonical', href: formatCanonicalPath(`/experiences/${id}`) },
+            ]}
+          />
+        );
+      }
+      return null;
+    }
+    return null;
+  }
+
   render() {
     const {
       experienceDetail, setTos, setComment, likeExperience, likeReply,
@@ -64,9 +101,7 @@ class ExperienceDetail extends Component {
     const experience = data.experience;
     return (
       <main className="wrapperL">
-        <Helmet
-          title="面試‧工作經驗"
-        />
+        {this.renderHelmet()}
         <div className={styles.heading}>
           <h2 className={`${styles.badge} pM`}>
             {experience.type === 'work' ? '工作' : '面試'}

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -12,6 +12,7 @@ import Searchbar from './Searchbar';
 import ExperienceBlock from './ExperienceBlock';
 import WorkingHourBlock from './WorkingHourBlock';
 import { fetchExperiences } from '../../actions/experienceSearch';
+import helmetData from '../../constants/helmetData';
 
 class ExperienceSearch extends Component {
   static fetchData({ store: { dispatch } }) {
@@ -72,7 +73,7 @@ class ExperienceSearch extends Component {
 
     return (
       <Section Tag="main" pageTop paddingBottom>
-        <Helmet title="面試 ‧ 工作經驗" />
+        <Helmet {...helmetData.EXPERIENCE_SEARCH} />
         <Wrapper size="l">
           <div className={styles.container}>
             <aside className={styles.aside}>

--- a/src/components/Faq/index.js
+++ b/src/components/Faq/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
+import helmetData from '../../constants/helmetData';
 
 const Faq = () => (
   <Section Tag="main" pageTop paddingBottom>
+    <Helmet {...helmetData.FAQ} />
     <Wrapper size="l">
       Faq
     </Wrapper>

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -2,11 +2,6 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Loader from 'common/Loader';
-import {
-  siteName,
-  formatTitle,
-  formatCanonicalPath,
-} from 'utils/helmetHelper';
 import Columns from 'common/Columns';
 import { Section, Wrapper, Heading } from 'common/base';
 import {
@@ -15,6 +10,7 @@ import {
 import status from '../../constants/status';
 import LaborRightsEntry from './LaborRightsEntry';
 import About from './About';
+import helmetData from '../../constants/helmetData';
 
 class LaborRightsMenu extends React.Component {
   static fetchData({ store }) {
@@ -27,26 +23,10 @@ class LaborRightsMenu extends React.Component {
 
   render() {
     const title = '勞動知識小教室';
-    const description = `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。`;
     return (
       <Section Tag="main" pageTop>
         <Wrapper size="l" Tag="main">
-          <Helmet
-            title={formatTitle(title)}
-            meta={[
-              { name: 'description', content: description },
-              { property: 'og:url', content: formatCanonicalPath('/labor-rights') },
-              { property: 'og:type', content: 'website' },
-              { property: 'og:locale', content: 'zh_TW' },
-              { property: 'og:description', content: description },
-              { property: 'og:title', content: formatTitle(title) },
-              { property: 'og:site_name', content: siteName },
-              { property: 'og:image', content: 'https://s3-ap-northeast-1.amazonaws.com/goodjob.life/www/og-image-labor-rights.jpg' },
-            ]}
-            link={[
-              { rel: 'canonical', href: formatCanonicalPath('/labor-rights') },
-            ]}
-          />
+          <Helmet {...helmetData.LABOR_RIGHTS_MENU} />
           {this.props.status === status.FETCHING && <Loader />}
           {
             this.props.status === status.ERROR && this.props.error &&

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -57,7 +57,6 @@ class LaborRightsSingle extends React.Component {
           meta={[
             { name: 'description', content: seoDescription },
             { property: 'og:url', content: formatCanonicalPath(`/labor-rights/${id}`) },
-            { property: 'og:type', content: 'website' },
             { property: 'og:title', content: formatTitle(seoTitle) },
             { property: 'og:description', content: seoDescription },
             { property: 'og:image', content: formatUrl(coverUrl) },

--- a/src/components/LandingPage/index.js
+++ b/src/components/LandingPage/index.js
@@ -11,6 +11,7 @@ import { fetchExperiences } from '../../actions/experienceSearch';
 import { fetchMetaListIfNeeded } from '../../actions/laborRightsMenu';
 import LaborRightsEntry from '../LaborRightsMenu/LaborRightsEntry';
 import HomeBanner from './HomeBanner';
+import helmetData from '../../constants/helmetData';
 
 class LandingPage extends Component {
   static fetchData({ store: { dispatch } }) {
@@ -31,6 +32,16 @@ class LandingPage extends Component {
       this.props.fetchMetaListIfNeeded(),
     ]);
   }
+
+  renderHelmet = () => {
+    const data = helmetData.LANDING_PAGE;
+    return (
+      <Helmet
+        title={data.title}
+        meta={data.meta}
+      />
+    );
+  }
   render() {
     const expDatas = this.props.experienceSearch.toJS().experiences || [];
     expDatas.sort((a, b) => {
@@ -44,9 +55,7 @@ class LandingPage extends Component {
     });
     return (
       <main>
-        <Helmet
-          title="首頁"
-        />
+        {this.renderHelmet()}
         <HomeBanner />
         <Section padding>
           <Wrapper size="l">

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -1,13 +1,15 @@
 import React, { PropTypes } from 'react';
+import Helmet from 'react-helmet';
 
 import styles from './App.module.css';
 import Header from '../../containers/Layout/Header';
 import Footer from './Footer';
-
+import helmetData from '../../constants/helmetData';
 
 const App = ({ children }) => (
   <div className={styles.App}>
     <Header />
+    <Helmet {...helmetData.DEFAULT} />
     <div className={styles.content}>
       {children}
     </div>

--- a/src/components/Privacy/index.js
+++ b/src/components/Privacy/index.js
@@ -3,12 +3,11 @@ import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
 import PageBanner from 'common/PageBanner';
 import editorStyles from 'common/Editor.module.css';
+import helmetData from '../../constants/helmetData';
 
 const Privacy = () => (
   <main>
-    <Helmet
-      title="隱私權政策"
-    />
+    <Helmet {...helmetData.PRIVACY_POLICY} />
     <PageBanner heading="隱私權政策" />
     <Section padding>
       <Wrapper size="l" className={editorStyles.editor}>

--- a/src/components/Recruit/index.js
+++ b/src/components/Recruit/index.js
@@ -1,8 +1,11 @@
 import React from 'react';
+import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
+import helmetData from '../../constants/helmetData';
 
 const Recruit = () => (
   <Section Tag="main" pageTop paddingBottom>
+    <Helmet {...helmetData.RECRUIT} />
     <Wrapper size="l">
       Recruit
     </Wrapper>

--- a/src/components/ShareExperience/Entry.js
+++ b/src/components/ShareExperience/Entry.js
@@ -1,12 +1,15 @@
 import React from 'react';
 import { browserHistory } from 'react-router';
+import Helmet from 'react-helmet';
 import { Wrapper } from 'common/base';
 import ShareExpSection from 'common/ShareExpSection';
 import i from 'common/icons';
 import styles from './Entry.module.css';
+import helmetData from '../../constants/helmetData';
 
 const Entry = () => (
   <div>
+    <Helmet {...helmetData.SHARE} />
     <Wrapper size="l" className={styles.wrapper}>
       <button onClick={() => browserHistory.goBack()} className={styles.closeBtn}><i.X /></button>
     </Wrapper>

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import R from 'ramda';
+import Helmet from 'react-helmet';
 
 import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 
@@ -22,6 +23,8 @@ import {
   portInterviewFormToRequestFormat,
   idGenerator,
 } from '../utils';
+
+import helmetData from '../../../constants/helmetData';
 
 const createSection = id => subtitle => {
   const section = {
@@ -143,6 +146,7 @@ class InterviewForm extends React.Component {
   render() {
     return (
       <div className={styles.container}>
+        <Helmet {...helmetData.SHARE_INTERVIEW} />
         <h1
           className="headingL"
         >

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import R from 'ramda';
+import Helmet from 'react-helmet';
 
 import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 
@@ -22,6 +23,8 @@ import {
 } from './formCheck';
 
 import styles from './WorkExperiencesForm.module.css';
+
+import helmetData from '../../../constants/helmetData';
 
 const createSection = id => subtitle => {
   const section = {
@@ -149,6 +152,7 @@ class WorkExperiencesForm extends React.Component {
 
     return (
       <div className={styles.container}>
+        <Helmet {...helmetData.SHARE_WORK} />
         <h1
           className="headingL"
         >

--- a/src/components/Terms/index.js
+++ b/src/components/Terms/index.js
@@ -3,12 +3,11 @@ import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
 import PageBanner from 'common/PageBanner';
 import editorStyles from 'common/Editor.module.css';
+import helmetData from '../../constants/helmetData';
 
 const Terms = () => (
   <main>
-    <Helmet
-      title="使用者條款"
-    />
+    <Helmet {...helmetData.USER_TERMS} />
     <PageBanner heading="使用者條款" />
     <Section padding>
       <Wrapper size="l" className={editorStyles.editor}>

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -111,7 +111,7 @@ const helmetData = {
     title: '勞動知識小教室',
     meta: [
       { name: 'description', content: `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。` },
-      { property: 'og:title', content: '搜尋面試及工作經驗' },
+      { property: 'og:title', content: '勞動知識小教室' },
       { property: 'og:url', content: formatCanonicalPath('/labor-rights') },
       { property: 'og:image', content: `${imgHost}/www/og/labor-rights.jpg` },
       { property: 'og:description', content: `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。` },

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -1,0 +1,206 @@
+
+
+import { formatCanonicalPath } from '../utils/helmetHelper';
+/*
+  This file will organize most of CONSTANT head information.
+  For those DYNAMIC head information, will be generated in each component
+*/
+
+/*
+The followings are some useful html head elements:
+  <title>
+  <meta name='description' content='Free Web tutorials'>
+  <meta name='keywords' content='HTML, CSS, XML, JavaScript'>
+  <meta name='author' content='John Doe'>
+* reference: https://www.w3schools.com/html/html_head.asp
+
+The followings are some useful elements from Open Graph Protocol:
+  og:title - The title of your object as it should appear within the graph, e.g., 'The Rock'.
+  og:type - The type of your object, e.g., 'video.movie'. Depending on the type you specify, other properties may also be required.
+  og:image - An image URL which should represent your object within the graph.
+  og:url - The canonical URL of your object that will be used as its permanent ID in the graph, e.g., 'http://www.imdb.com/title/tt0117500/'.
+  og:description - A one to two sentence description of your object.
+  og:locale - The locale these tags are marked up in. Of the format language_TERRITORY. Default is en_US.
+  og:site_name - If your object is part of a larger web site, the name which should be displayed for the overall site. e.g., 'IMDb'.
+* reference: http://ogp.me/
+
+*/
+
+const siteName = 'goodjob 透明資訊求職平台';
+const imgHost = 'https://s3-ap-northeast-1.amazonaws.com/goodjob.life';
+const helmetData = {
+  DEFAULT: {
+    title: siteName,
+    titleTemplate: `%s | ${siteName}`,
+    meta: [
+      { name: 'description', content: '分享你的工時、薪資、面試經驗以及工作經驗，讓我們一起改善求職市場不透明的問題。' },
+      { name: 'keywords', content: '工作時間, 薪資, 面試經驗, 工作經驗, 工作評論' },
+      { property: 'og:title', content: siteName },
+      { property: 'og:url', content: formatCanonicalPath('/') },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:image', content: `${imgHost}/www/og/default.jpg` },
+      { property: 'og:description', content: '分享你的工時、薪資、面試經驗以及工作經驗，讓我們一起改善求職市場不透明的問題。' },
+      { property: 'og:locale', content: 'zh_TW' },
+      { property: 'og:site_name', content: siteName },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/') },
+    ],
+  },
+  LANDING_PAGE: {
+    title: '首頁',
+    meta: [
+    ],
+  },
+  SHARE: {
+    title: '分享資訊',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '' },
+      { property: 'og:url', content: formatCanonicalPath('/share') },
+      { property: 'og:image', content: `${imgHost}/www/og/share.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/share') },
+    ],
+  },
+  SHARE_INTERVIEW: {
+    title: '面試經驗分享',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '面試經驗分享' },
+      { property: 'og:url', content: formatCanonicalPath('/share/interview') },
+      { property: 'og:image', content: `${imgHost}/www/og/share-interview.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/share/interview') },
+    ],
+  },
+  SHARE_WORK: {
+    title: '工作經驗分享',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '工作經驗分享' },
+      { property: 'og:url', content: formatCanonicalPath('/share/work-experience') },
+      { property: 'og:image', content: `${imgHost}/www/og/share-work.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/share/work-experience') },
+    ],
+  },
+  EXPERIENCE_SEARCH: {
+    title: '搜尋面試及工作經驗',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '搜尋面試及工作經驗' },
+      { property: 'og:url', content: formatCanonicalPath('/experiences/search') },
+      { property: 'og:image', content: `${imgHost}/www/og/experience-search.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/experiences/search') },
+    ],
+  },
+  EXPERIENCE_DETAIL: {
+    // information is dynamic
+  },
+  LABOR_RIGHTS_MENU: {
+    title: '勞動知識小教室',
+    meta: [
+      { name: 'description', content: `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。` },
+      { property: 'og:title', content: '搜尋面試及工作經驗' },
+      { property: 'og:url', content: formatCanonicalPath('/labor-rights') },
+      { property: 'og:image', content: `${imgHost}/www/og/labor-rights.jpg` },
+      { property: 'og:description', content: `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。` },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/labor-rights') },
+    ],
+  },
+  LABOR_RIGHTS_SINGLE: {
+    // information is dynamic
+  },
+  CONTACT: {
+    title: '聯絡我們',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '聯絡我們' },
+      { property: 'og:url', content: formatCanonicalPath('/contact') },
+      { property: 'og:image', content: `${imgHost}/www/og/contact.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/contact') },
+    ],
+  },
+  ABOUT: {
+    title: '關於我們',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '關於我們' },
+      { property: 'og:url', content: formatCanonicalPath('/about') },
+      { property: 'og:image', content: `${imgHost}/www/og/about.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/about') },
+    ],
+  },
+  PRIVACY_POLICY: {
+    title: '隱私權政策',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '隱私權政策' },
+      { property: 'og:url', content: formatCanonicalPath('/privacy-policy') },
+      { property: 'og:image', content: `${imgHost}/www/og/privacy-policy.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/privacy-policy') },
+    ],
+  },
+  USER_TERMS: {
+    title: '使用者條款',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '使用者條款' },
+      { property: 'og:url', content: formatCanonicalPath('/user-term') },
+      { property: 'og:image', content: `${imgHost}/www/og/user-term.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/user-term') },
+    ],
+  },
+  FAQ: {
+    title: '常見問答',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '常見問答' },
+      { property: 'og:url', content: formatCanonicalPath('/faq') },
+      { property: 'og:image', content: `${imgHost}/www/og/faq.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/faq') },
+    ],
+  },
+  RECRUIT: {
+    title: '加入我們',
+    meta: [
+      { name: 'description', content: '' },
+      { property: 'og:title', content: '加入我們' },
+      { property: 'og:url', content: formatCanonicalPath('/recruit') },
+      { property: 'og:image', content: `${imgHost}/www/og/recruit.jpg` },
+      { property: 'og:description', content: '' },
+    ],
+    link: [
+      { rel: 'canonical', href: formatCanonicalPath('/recruit') },
+    ],
+  },
+};
+
+export default helmetData;


### PR DESCRIPTION
partly solve #4 

1. 新增 `helmetData.js` 這個constant file，管理所有`靜態`的 head information。比較不會資訊四散各地，不好維護。
2. 針對 head information 需要`動態`改變的頁面：`/labor-rights/:id` `/experiences/:id` 。 則是直接在component 內部讀取資料，產生helmet所需的資訊。
3. 目前 helmetData 裡面的資訊只是初版，待行銷組完全確定後，會再另送ＰＲ修正。請主要看結構有沒有問題、實際測試是否有真的產生 head informat。
4. 測試的方法是打開原始碼去看，是否真的產生對應的資訊。不要用inspect element 的方式，因為那可能是前端後來才render出來的。
