### PR TITLE
fixed the style error of experience block (#192)

### DIFF
--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -143,7 +143,10 @@ class ExperienceSearch extends Component {
                 {
                   (data.experiences || []).map(o => (
                     data[o.type] && (
-                      <ExperienceBlock key={o._id} to={`/experiences/${o._id}`} data={o} />
+                      <ExperienceBlock
+                        key={o._id} to={`/experiences/${o._id}`}
+                        data={o} size="l"
+                      />
                     )
                   ))
                 }


### PR DESCRIPTION
我本來是試著調整 CSS，但後來仔細看了一下，發現「每一篇經驗 (元件: ExperienceBlock)」的樣式還有分 m 跟 l 兩種，所以猜想 m 是給首頁用的，所以我在經驗搜尋頁這裡，把「每一篇經驗」套用 l 這個樣式，試了一下 chrome 跟 ff 都不會有 overlap 的問題了 ... 但這部份可能還要麻煩 @wutingy 幫忙確認一下是不是這個樣子。