### PR TITLE
面試經驗表單捲動到最上方未填寫成功的欄位

### DIFF
--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewTime.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewTime.js
@@ -1,10 +1,13 @@
 import React, { PropTypes } from 'react';
 import cn from 'classnames';
+import { Element as ScrollElement } from 'react-scroll';
 
 import Select from 'common/form/Select';
 import InputTitle from '../../common/InputTitle';
 
 import styles from './InterviewTime.module.css';
+
+import { VALID, INVALID, INTERVIEW_TIME } from '../../../../constants/formElements';
 
 const monthMap = Array(12).fill(0).map((_, index) => ({
   label: index + 1,
@@ -16,101 +19,121 @@ const yearMap = Array(12).fill(0).map((_, index) => ({
   value: new Date().getFullYear() - index,
 }));
 
-const InterviewTime = (
-  {
-    interviewTimeYear,
-    interviewTimeMonth,
-    onInterviewTimeYear,
-    onInterviewTimeMonth,
-    interviewTimeYearValidator,
-    interviewTimeMonthValidator,
-    submitted,
+class InterviewTime extends React.Component {
+  constructor(props) {
+    super(props);
+    const isValid = (props.interviewTimeYearValidator(props.interviewTimeYear) &&
+                     props.interviewTimeMonthValidator(props.interviewTimeMonth));
+    props.changeValidationStatus(INTERVIEW_TIME, isValid ? VALID : INVALID);
+    this.state = {
+      isValid,
+    };
   }
-) => {
-  const isWarning = submitted && !(interviewTimeYearValidator(interviewTimeYear)
-    && interviewTimeMonthValidator(interviewTimeMonth));
-  return (
-    <div>
-      <InputTitle
-        text="面試時間"
-        must
-      />
-      <div
-        style={{
-          display: 'flex',
-        }}
-        className={isWarning ? styles.warning : ''}
-      >
+
+  componentWillReceiveProps(nextProps) {
+    const isValid = (this.props.interviewTimeYearValidator(nextProps.interviewTimeYear) &&
+                    this.props.interviewTimeMonthValidator(nextProps.interviewTimeMonth));
+    if (isValid !== this.state.isValid) {
+      this.setState({ isValid });
+      const status = isValid ? VALID : INVALID;
+      this.props.changeValidationStatus(INTERVIEW_TIME, status);
+    }
+  }
+
+  render() {
+    const {
+      interviewTimeYear,
+      interviewTimeMonth,
+      onInterviewTimeYear,
+      onInterviewTimeMonth,
+      submitted,
+    } = this.props;
+    const isWarning = submitted && !this.state.isValid;
+
+    return (
+      <div>
+        <ScrollElement name={INTERVIEW_TIME} />
+        <InputTitle
+          text="面試時間"
+          must
+        />
         <div
           style={{
-            marginRight: '35px',
+            display: 'flex',
           }}
+          className={isWarning ? styles.warning : ''}
         >
           <div
             style={{
-              width: '110px',
-              display: 'inline-block',
-              marginRight: '11px',
+              marginRight: '35px',
             }}
           >
-            <Select
-              options={yearMap}
-              value={interviewTimeYear}
-              onChange={
-                e => onInterviewTimeYear(Number(e.target.value))
-              }
-            />
+            <div
+              style={{
+                width: '110px',
+                display: 'inline-block',
+                marginRight: '11px',
+              }}
+            >
+              <Select
+                options={yearMap}
+                value={interviewTimeYear}
+                onChange={
+                  e => onInterviewTimeYear(Number(e.target.value))
+                }
+              />
+            </div>
+            <p
+              className="pS"
+              style={{
+                display: 'inline-block',
+              }}
+            >
+              年
+          </p>
           </div>
-          <p
-            className="pS"
-            style={{
-              display: 'inline-block',
-            }}
-          >
-            年
-        </p>
-        </div>
-        <div>
-          <div
-            style={{
-              width: '110px',
-              display: 'inline-block',
-              marginRight: '11px',
-            }}
-          >
-            <Select
-              options={monthMap}
-              value={interviewTimeMonth}
-              onChange={
-                e => onInterviewTimeMonth(Number(e.target.value))
-              }
-            />
+          <div>
+            <div
+              style={{
+                width: '110px',
+                display: 'inline-block',
+                marginRight: '11px',
+              }}
+            >
+              <Select
+                options={monthMap}
+                value={interviewTimeMonth}
+                onChange={
+                  e => onInterviewTimeMonth(Number(e.target.value))
+                }
+              />
+            </div>
+            <p
+              className="pS"
+              style={{
+                display: 'inline-block',
+              }}
+            >
+              月
+          </p>
           </div>
-          <p
-            className="pS"
-            style={{
-              display: 'inline-block',
-            }}
-          >
-            月
-        </p>
         </div>
+        {
+          isWarning ?
+            <p
+              className={cn(styles.warning__wording, 'pS')}
+              style={{
+                marginTop: '8px',
+              }}
+            >
+              需填寫面試時間
+              </p>
+            : null
+        }
       </div>
-      {
-        isWarning ?
-          <p
-            className={cn(styles.warning__wording, 'pS')}
-            style={{
-              marginTop: '8px',
-            }}
-          >
-            需填寫面試時間
-            </p>
-          : null
-      }
-    </div>
-  );
-};
+    );
+  }
+}
 
 InterviewTime.propTypes = {
   interviewTimeYear: PropTypes.oneOfType([
@@ -126,6 +149,7 @@ InterviewTime.propTypes = {
   interviewTimeYearValidator: PropTypes.func,
   interviewTimeMonthValidator: PropTypes.func,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 export default InterviewTime;

--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
@@ -40,6 +40,7 @@ class InterviewInfo extends React.PureComponent {
       salaryAmount,
       overallRating,
       submitted,
+      changeValidationStatus,
     } = this.props;
 
     return (
@@ -76,6 +77,7 @@ class InterviewInfo extends React.PureComponent {
               onChange={handleState('region')}
               validator={regionValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -202,6 +204,7 @@ InterviewInfo.propTypes = {
   ]),
   overallRating: PropTypes.number,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 export default InterviewInfo;

--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
@@ -65,6 +65,7 @@ class InterviewInfo extends React.PureComponent {
               onCompanyId={handleState('companyId')}
               validator={companyQueryValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div

--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
@@ -92,6 +92,7 @@ class InterviewInfo extends React.PureComponent {
               onChange={handleState('jobTitle')}
               validator={jobTitleValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div

--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
@@ -128,6 +128,7 @@ class InterviewInfo extends React.PureComponent {
               interviewTimeYearValidator={interviewTimeYearValidator}
               interviewTimeMonthValidator={interviewTimeMonthValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import R from 'ramda';
 import Helmet from 'react-helmet';
-import { animateScroll } from 'react-scroll';
+import { scroller } from 'react-scroll';
 
 import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 
@@ -26,6 +26,7 @@ import {
 } from '../utils';
 
 import helmetData from '../../../constants/helmetData';
+import { INVALID, INTERVIEW_FORM_ORDER } from '../../../constants/formElements';
 
 const createSection = id => subtitle => {
   const section = {
@@ -100,6 +101,8 @@ class InterviewForm extends React.Component {
       ...defaultForm,
       submitted: false,
     };
+
+    this.elementValidationStatus = {};
   }
 
   onSumbit() {
@@ -109,8 +112,35 @@ class InterviewForm extends React.Component {
       return postInterviewExperience(portInterviewFormToRequestFormat(getInterviewForm(this.state)));
     }
     this.handleState('submitted')(true);
-    animateScroll.scrollToTop();
+    const topInvalidElement = this.getTopInvalidElement();
+    console.log(topInvalidElement);
+    if (topInvalidElement !== null) {
+      scroller.scrollTo(topInvalidElement, {
+        duration: 1000,
+        delay: 100,
+        offset: -100,
+        smooth: true,
+      });
+    }
     return null;
+  }
+
+  getTopInvalidElement = () => {
+    const order = INTERVIEW_FORM_ORDER;
+    for (let i = 0; i <= order.length; i += 1) {
+      if (
+        this.elementValidationStatus[order[i]] &&
+        this.elementValidationStatus[order[i]] === INVALID
+      ) {
+        return order[i];
+      }
+    }
+    return null;
+  }
+
+  changeValidationStatus = (elementId, status) => {
+    this.elementValidationStatus[elementId] = status;
+    console.log(this.elementValidationStatus);
   }
 
   handleState(key) {
@@ -161,6 +191,7 @@ class InterviewForm extends React.Component {
     return (
       <div className={styles.container}>
         <Helmet {...helmetData.SHARE_INTERVIEW} />
+
         <h1
           className="headingL"
         >
@@ -191,6 +222,7 @@ class InterviewForm extends React.Component {
           salaryAmount={this.state.salaryAmount}
           overallRating={this.state.overallRating}
           submitted={this.state.submitted}
+          changeValidationStatus={this.changeValidationStatus}
         />
         <InterviewExperience
           handleState={this.handleState}
@@ -205,6 +237,7 @@ class InterviewForm extends React.Component {
           editQa={this.editBlock('interviewQas')}
           interviewSensitiveQuestions={this.state.interviewSensitiveQuestions}
           submitted={this.state.submitted}
+          changeValidationStatus={this.changeValidationStatus}
         />
         <SubmitArea
           onSubmit={this.onSumbit}

--- a/src/components/ShareExperience/common/CompanyQuery.js
+++ b/src/components/ShareExperience/common/CompanyQuery.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Element as ScrollElement } from 'react-scroll';
 
 import AutoCompleteTextInput from 'common/form/AutoCompleteTextInput';
 
@@ -10,6 +11,8 @@ import InputTitle from './InputTitle';
 import {
   getCompaniesSearch,
 } from '../../../apis/companySearchApi';
+
+import { VALID, INVALID, COMPANY } from '../../../constants/formElements';
 
 const getItemValue = item => item.label;
 
@@ -41,9 +44,21 @@ class CompanyQuery extends React.Component {
       return search(e, value);
     };
 
+    const isValid = props.validator(props.companyQuery);
+    props.changeValidationStatus(COMPANY, isValid ? VALID : INVALID);
     this.state = {
       autocompleteItems: [],
+      isValid,
     };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const isValid = this.props.validator(nextProps.companyQuery);
+    if (isValid !== this.state.isValid) {
+      this.setState({ isValid });
+      const status = isValid ? VALID : INVALID;
+      this.props.changeValidationStatus(COMPANY, status);
+    }
   }
 
   handleAutocompleteItems(autocompleteItems) {
@@ -54,9 +69,10 @@ class CompanyQuery extends React.Component {
 
   render() {
     const { autocompleteItems } = this.state;
-    const { companyQuery, onChange, onCompanyId, validator, submitted } = this.props;
+    const { companyQuery, onChange, onCompanyId, submitted } = this.props;
     return (
       <div>
+        <ScrollElement name={COMPANY} />
         <InputTitle
           text="公司/單位 或 統一編號"
           must
@@ -72,7 +88,7 @@ class CompanyQuery extends React.Component {
             onCompanyId(item.value);
             return onChange(value);
           }}
-          isWarning={submitted && !validator(companyQuery)}
+          isWarning={submitted && !this.state.isValid}
           warningWording="需填寫公司/單位"
         />
       </div>
@@ -86,6 +102,7 @@ CompanyQuery.propTypes = {
   onCompanyId: PropTypes.func,
   validator: PropTypes.func,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 CompanyQuery.defaultProps = {

--- a/src/components/ShareExperience/common/JobTitle.js
+++ b/src/components/ShareExperience/common/JobTitle.js
@@ -1,24 +1,51 @@
 import React, { PropTypes } from 'react';
+import { Element as ScrollElement } from 'react-scroll';
 
 import TextInput from 'common/form/TextInput';
 
 import InputTitle from './InputTitle';
 
-const JobTitle = ({ inputTitle, jobTitle, onChange, validator, submitted }) => (
-  <div>
-    <InputTitle
-      text={inputTitle}
-      must
-    />
-    <TextInput
-      placeholder="硬體工程師"
-      value={jobTitle}
-      onChange={e => onChange(e.target.value)}
-      isWarning={submitted && !validator(jobTitle)}
-      warningWording="需填寫職稱"
-    />
-  </div>
-);
+import { VALID, INVALID, JOB_TITLE } from '../../../constants/formElements';
+
+class JobTitle extends React.Component {
+  constructor(props) {
+    super(props);
+    const isValid = props.validator(props.jobTitle);
+    props.changeValidationStatus(JOB_TITLE, isValid ? VALID : INVALID);
+    this.state = {
+      isValid,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const isValid = this.props.validator(nextProps.jobTitle);
+    if (isValid !== this.state.isValid) {
+      this.setState({ isValid });
+      const status = isValid ? VALID : INVALID;
+      this.props.changeValidationStatus(JOB_TITLE, status);
+    }
+  }
+
+  render() {
+    const { inputTitle, jobTitle, onChange, submitted } = this.props;
+    return (
+      <div>
+        <ScrollElement name={JOB_TITLE} />
+        <InputTitle
+          text={inputTitle}
+          must
+        />
+        <TextInput
+          placeholder="硬體工程師"
+          value={jobTitle}
+          onChange={e => onChange(e.target.value)}
+          isWarning={submitted && !this.state.isValid}
+          warningWording="需填寫職稱"
+        />
+      </div>
+    );
+  }
+}
 
 JobTitle.propTypes = {
   inputTitle: PropTypes.string,
@@ -26,6 +53,7 @@ JobTitle.propTypes = {
   onChange: PropTypes.func,
   validator: PropTypes.func,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 JobTitle.defaultProps = {

--- a/src/components/ShareExperience/common/Region.js
+++ b/src/components/ShareExperience/common/Region.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Element as ScrollElement } from 'react-scroll';
 
 import Select from 'common/form/Select';
 import InputTitle from './InputTitle';
@@ -9,49 +10,73 @@ import {
   regionOptions,
 } from './optionMap';
 
-const Region = ({ region, onChange, validator, submitted }) => {
-  const isWarning = submitted && !validator(region);
-  return (
-    <div>
-      <InputTitle
-        text="面試地區"
-        must
-      />
-      <div
-        className={isWarning ? styles.warning : null}
-        style={{
-          width: '320px',
-          position: 'relative',
-        }}
-      >
-        <Select
-          options={regionOptions}
-          value={region}
-          onChange={
-            e => onChange(e.target.value)
-          }
+import { VALID, INVALID, REGION } from '../../../constants/formElements';
+
+class Region extends React.Component {
+  constructor(props) {
+    super(props);
+    const isValid = props.validator(props.region);
+    props.changeValidationStatus(REGION, isValid ? VALID : INVALID);
+    this.state = {
+      isValid,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const isValid = this.props.validator(nextProps.region);
+    if (isValid !== this.state.isValid) {
+      this.setState({ isValid });
+      const status = isValid ? VALID : INVALID;
+      this.props.changeValidationStatus(REGION, status);
+    }
+  }
+
+  render() {
+    const { region, onChange, submitted } = this.props;
+    const isWarning = submitted && !this.state.isValid;
+    return (
+      <div>
+        <ScrollElement name={REGION} />
+        <InputTitle
+          text="面試地區"
+          must
         />
-        {
-          isWarning ?
-            <div
-              style={{
-                position: 'absolute',
-                bottom: '0',
-                transform: 'translateY(150%)',
-              }}
-            >
-              <p
-                className={`pS ${styles.warning__wording}`}
+        <div
+          className={isWarning ? styles.warning : null}
+          style={{
+            width: '320px',
+            position: 'relative',
+          }}
+        >
+          <Select
+            options={regionOptions}
+            value={region}
+            onChange={
+              e => onChange(e.target.value)
+            }
+          />
+          {
+            isWarning ?
+              <div
+                style={{
+                  position: 'absolute',
+                  bottom: '0',
+                  transform: 'translateY(150%)',
+                }}
               >
-                需填寫面試地區
-            </p>
-            </div>
-            : null
-        }
+                <p
+                  className={`pS ${styles.warning__wording}`}
+                >
+                  需填寫面試地區
+              </p>
+              </div>
+              : null
+          }
+        </div>
       </div>
-    </div>
-  );
-};
+    );
+  }
+}
 
 Region.propTypes = {
   region: PropTypes.oneOfType([
@@ -60,7 +85,9 @@ Region.propTypes = {
   ]),
   onChange: PropTypes.func,
   validator: PropTypes.func,
+  // eslint-disable-next-line react/no-unused-prop-types
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 Region.defaultProps = {

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -1,0 +1,8 @@
+
+export const VALID = 'valid';
+export const INVALID = 'invalid';
+export const REGION = 'region';
+
+export const INTERVIEW_FORM_ORDER = [
+  REGION,
+];

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -3,8 +3,10 @@ export const VALID = 'valid';
 export const INVALID = 'invalid';
 export const COMPANY = 'company';
 export const REGION = 'region';
+export const JOB_TITLE = 'job_title';
 
 export const INTERVIEW_FORM_ORDER = [
   COMPANY,
   REGION,
+  JOB_TITLE,
 ];

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -1,8 +1,10 @@
 
 export const VALID = 'valid';
 export const INVALID = 'invalid';
+export const COMPANY = 'company';
 export const REGION = 'region';
 
 export const INTERVIEW_FORM_ORDER = [
+  COMPANY,
   REGION,
 ];

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -4,9 +4,11 @@ export const INVALID = 'invalid';
 export const COMPANY = 'company';
 export const REGION = 'region';
 export const JOB_TITLE = 'job_title';
+export const INTERVIEW_TIME = 'interview_time';
 
 export const INTERVIEW_FORM_ORDER = [
   COMPANY,
   REGION,
   JOB_TITLE,
+  INTERVIEW_TIME,
 ];


### PR DESCRIPTION
### 目的
這個 PR 主要是想改善使用者體驗，當使用有未成功填寫的欄位，可以捲到最上方未成功填寫的 component 上。

### 實作理念
如果要scroll 到最上方未填寫成功的欄位，就必須要有個地方搜集各個欄位填寫的狀況。
最直覺得做法是讓 interviewForm 這個 component 去 maintain 每個需要驗證的欄位的狀態（分為用state / 不用 state 儲存)。（或者是用redux）
而我是選擇將每個需要驗證的欄位的驗證狀態，存在 interviewForm component 裡面的非state變數裡。並且使用 react-scroll ，在欄位偷塞一個scroll element，讓我可以捲到指定的位置。

* 為什麼不用 redux ? 
因為原本的interviewForm 沒有用到，每個欄位的值是maintain在state裡面，就不改架構了。

* 為什麼不用 state ? 
因為這些變數單純是要拿來找到最上方未填寫成功的欄位，跟 render 無關，不須存在 state 裡面。存在裡面要更新 state 比較繁瑣。

### 如何測試
- [ ] 嘗試進去面試經驗分享頁，什麼都不寫按我同意＆送出，應該要捲到公司。
- [ ] 公司填寫一下，再按送出，應該要捲到面試地區。
依此類推。 目前僅完成 公司、面試地區、職稱、面試時間。

先確定這樣的 framework  OK，我再把剩下的完成。

### Screenshots
![syhrccevsx](https://user-images.githubusercontent.com/3805975/28429455-560242c8-6daf-11e7-8759-d21d336a0786.gif)

建議先看第一個 commit   327c3c9 即可



