### PR TITLE
面試結果檢驗規則錯誤

### DIFF
--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewResult.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewResult.js
@@ -4,8 +4,6 @@ import cn from 'classnames';
 import ButtonGroup from 'common/button/ButtonGroup';
 import TextInput from 'common/form/TextInput';
 
-import * as formCheck from '../formCheck';
-
 import InputTitle from '../../common/InputTitle';
 import {
   interviewResultMap,
@@ -58,8 +56,6 @@ const InterviewResult = ({ interviewResult, onChange, validator, submitted }) =>
                 value={interviewResult}
                 placeholder="輸入面試結果..."
                 onChange={e => onChange(e.target.value)}
-                isWarning={!formCheck.interviewResult(interviewResult)}
-                warningWording="請輸入10個字以內"
               />
             </section> :
             null

--- a/src/components/ShareExperience/InterviewForm/formCheck.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.js
@@ -3,7 +3,6 @@ import R from 'ramda';
 import {
   notStrEmpty,
   notNullOrUndefined,
-  gteLength,
   lteLength,
   gtLength,
 } from 'utils/dataCheckUtil';
@@ -42,7 +41,7 @@ export const interviewTimeMonth = R.allPass([
 
 export const interviewResult = t =>
   notNullOrUndefined(t) && R.allPass([
-    gteLength(0),
+    gtLength(0),
     lteLength(10),
   ])(t);
 

--- a/src/components/ShareExperience/InterviewForm/formCheck.test.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.test.js
@@ -90,13 +90,13 @@ describe('interviewTimeMonth test', () => {
 });
 
 describe('interviewResult test', () => {
-  test('string length in [0, 10] should pass', () => {
-    expect(interviewResult('')).toBe(true);
+  test('string length in (0, 10] should pass', () => {
     expect(interviewResult('abcdeabcde')).toBe(true);
     expect(interviewResult('abc')).toBe(true);
   });
 
-  test('string length not in [0, 10] should not pass', () => {
+  test('string length not in (0, 10] should not pass', () => {
+    expect(interviewResult('')).toBe(false);
     expect(interviewResult('abcdeabcdea')).toBe(false);
   });
 });


### PR DESCRIPTION
目前面試結果的檢驗規則是 (0, 10]
這個PR 修改了之前錯誤理解的form checking function ，以及對應的測試

#188 