### PR TITLE
HOC 實作 捲動到最放上方驗證未過元件

### DIFF
--- a/src/components/ShareExperience/InterviewForm/InterviewExperience/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewExperience/index.js
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import ButtonAdd from 'common/button/ButtonAdd';
 import AddButton from 'common/button/AddButton';
 import i from 'common/icons';
+import subscribeValidation from 'common/subscribeValidation';
 
 import styles from '../../ShareExperience.module.css';
 
@@ -20,6 +21,20 @@ import {
   interviewSectionSubtitleOptions,
 } from '../../common/optionMap';
 
+import { TITLE, SECTIONS } from '../../../../constants/formElements';
+
+const TitleWithValidation = subscribeValidation(
+  Title,
+  props => props.validator(props.title),
+  TITLE,
+);
+
+const SectionsWithValidation = subscribeValidation(
+  Sections,
+  props => props.validator(props.sections),
+  SECTIONS,
+);
+
 class InterviewExperience extends Component {
   render() {
     const {
@@ -35,6 +50,7 @@ class InterviewExperience extends Component {
       editQa,
       interviewSensitiveQuestions,
       submitted,
+      changeValidationStatus,
     } = this.props;
     return (
       <div
@@ -51,12 +67,13 @@ class InterviewExperience extends Component {
               marginBottom: '50px',
             }}
           >
-            <Title
+            <TitleWithValidation
               title={title}
               onChange={handleState('title')}
               placeholder="ＯＯ 股份有限公司面試經驗分享"
               validator={titleValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -65,12 +82,13 @@ class InterviewExperience extends Component {
               marginBottom: '80px',
             }}
           >
-            <Sections
+            <SectionsWithValidation
               sections={sections}
               removeSection={removeSection}
               editSection={editSection}
               validator={sectionsValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
             <div
               style={{
@@ -160,6 +178,7 @@ InterviewExperience.propTypes = {
     PropTypes.string,
   ),
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 export default InterviewExperience;

--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/index.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import i from 'common/icons';
+import subscribeValidation from 'common/subscribeValidation';
 
 import styles from '../../ShareExperience.module.css';
 
@@ -24,6 +25,44 @@ import InterviewResult from './InterviewResult';
 import Salary from '../../common/Salary';
 import OverallRating from './OverallRating';
 
+import { COMPANY, REGION, JOB_TITLE, INTERVIEW_TIME, INTERVIEW_RESULT, OVERALL_RATING } from '../../../../constants/formElements';
+
+const CompanyQueryWithValidation = subscribeValidation(
+  CompanyQuery,
+  props => props.validator(props.companyQuery),
+  COMPANY,
+);
+
+const RegionWithValidation = subscribeValidation(
+  Region,
+  props => props.validator(props.region),
+  REGION,
+);
+
+const JobTitleWithValidation = subscribeValidation(
+  JobTitle,
+  props => props.validator(props.jobTitle),
+  JOB_TITLE,
+);
+
+const InterviewTimeWithValidation = subscribeValidation(
+  InterviewTime,
+  props => props.interviewTimeYearValidator(props.interviewTimeYear) && props.interviewTimeMonthValidator(props.interviewTimeMonth),
+  INTERVIEW_TIME,
+);
+
+const InterviewResultWithValidation = subscribeValidation(
+  InterviewResult,
+  props => props.validator(props.interviewResult),
+  INTERVIEW_RESULT,
+);
+
+const OverallRatingWithValidation = subscribeValidation(
+  OverallRating,
+  props => props.validator(props.overallRating),
+  OVERALL_RATING,
+);
+
 class InterviewInfo extends React.PureComponent {
   render() {
     const {
@@ -40,6 +79,7 @@ class InterviewInfo extends React.PureComponent {
       salaryAmount,
       overallRating,
       submitted,
+      changeValidationStatus,
     } = this.props;
 
     return (
@@ -55,7 +95,7 @@ class InterviewInfo extends React.PureComponent {
               marginBottom: '35px',
             }}
           >
-            <CompanyQuery
+            <CompanyQueryWithValidation
               companyQuery={companyQuery}
               onChange={v => {
                 handleState('companyQuery')(v);
@@ -64,6 +104,7 @@ class InterviewInfo extends React.PureComponent {
               onCompanyId={handleState('companyId')}
               validator={companyQueryValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -71,11 +112,12 @@ class InterviewInfo extends React.PureComponent {
               marginBottom: '41px',
             }}
           >
-            <Region
+            <RegionWithValidation
               region={region}
               onChange={handleState('region')}
               validator={regionValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -83,12 +125,13 @@ class InterviewInfo extends React.PureComponent {
               marginBottom: '41px',
             }}
           >
-            <JobTitle
+            <JobTitleWithValidation
               inputTitle="應徵職稱"
               jobTitle={jobTitle}
               onChange={handleState('jobTitle')}
               validator={jobTitleValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -116,7 +159,7 @@ class InterviewInfo extends React.PureComponent {
               marginBottom: '64px',
             }}
           >
-            <InterviewTime
+            <InterviewTimeWithValidation
               interviewTimeYear={interviewTimeYear}
               interviewTimeMonth={interviewTimeMonth}
               onInterviewTimeYear={handleState('interviewTimeYear')}
@@ -124,6 +167,7 @@ class InterviewInfo extends React.PureComponent {
               interviewTimeYearValidator={interviewTimeYearValidator}
               interviewTimeMonthValidator={interviewTimeMonthValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -131,11 +175,12 @@ class InterviewInfo extends React.PureComponent {
               marginBottom: '53px',
             }}
           >
-            <InterviewResult
+            <InterviewResultWithValidation
               interviewResult={interviewResult}
               onChange={handleState('interviewResult')}
               validator={interviewResultValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -151,11 +196,12 @@ class InterviewInfo extends React.PureComponent {
             />
           </div>
           <div>
-            <OverallRating
+            <OverallRatingWithValidation
               overallRating={overallRating}
               onChange={handleState('overallRating')}
               validator={overallRatingValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
         </div>
@@ -202,6 +248,7 @@ InterviewInfo.propTypes = {
   ]),
   overallRating: PropTypes.number,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 export default InterviewInfo;

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import R from 'ramda';
 import Helmet from 'react-helmet';
-import { animateScroll } from 'react-scroll';
+import { scroller } from 'react-scroll';
 
 import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 
@@ -26,6 +26,7 @@ import {
 } from '../utils';
 
 import helmetData from '../../../constants/helmetData';
+import { INVALID, INTERVIEW_FORM_ORDER } from '../../../constants/formElements';
 
 const createSection = id => subtitle => {
   const section = {
@@ -100,6 +101,8 @@ class InterviewForm extends React.Component {
       ...defaultForm,
       submitted: false,
     };
+
+    this.elementValidationStatus = {};
   }
 
   onSumbit() {
@@ -109,8 +112,33 @@ class InterviewForm extends React.Component {
       return postInterviewExperience(portInterviewFormToRequestFormat(getInterviewForm(this.state)));
     }
     this.handleState('submitted')(true);
-    animateScroll.scrollToTop();
+    const topInvalidElement = this.getTopInvalidElement();
+    if (topInvalidElement !== null) {
+      scroller.scrollTo(topInvalidElement, {
+        duration: 1000,
+        delay: 100,
+        offset: -100,
+        smooth: true,
+      });
+    }
     return null;
+  }
+
+  getTopInvalidElement = () => {
+    const order = INTERVIEW_FORM_ORDER;
+    for (let i = 0; i <= order.length; i += 1) {
+      if (
+        this.elementValidationStatus[order[i]] &&
+        this.elementValidationStatus[order[i]] === INVALID
+      ) {
+        return order[i];
+      }
+    }
+    return null;
+  }
+
+  changeValidationStatus = (elementId, status) => {
+    this.elementValidationStatus[elementId] = status;
   }
 
   handleState(key) {
@@ -191,6 +219,7 @@ class InterviewForm extends React.Component {
           salaryAmount={this.state.salaryAmount}
           overallRating={this.state.overallRating}
           submitted={this.state.submitted}
+          changeValidationStatus={this.changeValidationStatus}
         />
         <InterviewExperience
           handleState={this.handleState}
@@ -205,6 +234,7 @@ class InterviewForm extends React.Component {
           editQa={this.editBlock('interviewQas')}
           interviewSensitiveQuestions={this.state.interviewSensitiveQuestions}
           submitted={this.state.submitted}
+          changeValidationStatus={this.changeValidationStatus}
         />
         <SubmitArea
           onSubmit={this.onSumbit}

--- a/src/components/ShareExperience/WorkExperiencesForm/WorkExperience/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/WorkExperience/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import subscribeValidation from 'common/subscribeValidation';
 
 import ButtonAdd from 'common/button/ButtonAdd';
 import styles from './WorkExperience.module.css';
@@ -15,6 +16,20 @@ import {
   sections as sectionsValidator,
 } from '../formCheck';
 
+import { TITLE, SECTIONS } from '../../../../constants/formElements';
+
+const TitleWithValidation = subscribeValidation(
+  Title,
+  props => props.validator(props.title),
+  TITLE,
+);
+
+const SectionsWithValidation = subscribeValidation(
+  Sections,
+  props => props.validator(props.sections),
+  SECTIONS,
+);
+
 class WorkExperience extends React.PureComponent {
   render() {
     const {
@@ -25,6 +40,7 @@ class WorkExperience extends React.PureComponent {
       removeSection,
       editSection,
       submitted,
+      changeValidationStatus,
     } = this.props;
 
     return (
@@ -47,12 +63,13 @@ class WorkExperience extends React.PureComponent {
               marginBottom: '50px',
             }}
           >
-            <Title
+            <TitleWithValidation
               title={title}
               onChange={handleState('title')}
               placeholder="ＯＯ 股份有限公司工作經驗分享"
               validator={titleValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -61,12 +78,13 @@ class WorkExperience extends React.PureComponent {
               marginBottom: '80px',
             }}
           >
-            <Sections
+            <SectionsWithValidation
               sections={sections}
               removeSection={removeSection}
               editSection={editSection}
               validator={sectionsValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
             <div
               style={{
@@ -103,6 +121,7 @@ WorkExperience.propTypes = {
   removeSection: PropTypes.func,
   editSection: PropTypes.func,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 export default WorkExperience;

--- a/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/index.js
@@ -36,6 +36,7 @@ class WorkInfo extends React.PureComponent {
       recommendToOthers,
       weekWorkTime,
       submitted,
+      changeValidationStatus,
     } = this.props;
 
     return (
@@ -79,6 +80,7 @@ class WorkInfo extends React.PureComponent {
               onChange={handleState('region')}
               validator={regionValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -192,6 +194,7 @@ WorkInfo.propTypes = {
   ]),
   recommendToOthers: PropTypes.string,
   submitted: PropTypes.bool,
+  changeValidationStatus: PropTypes.func,
 };
 
 export default WorkInfo;

--- a/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/index.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import subscribeValidation from 'common/subscribeValidation';
 
 import styles from './WorkInfo.module.css';
 
@@ -18,6 +19,14 @@ import {
   region as regionValidator,
   jobTitle as jobTitleValidator,
 } from '../formCheck';
+
+import { REGION } from '../../../../constants/formElements';
+
+const RegionWithValidation = subscribeValidation(
+  Region,
+  props => props.validator(props.region),
+  REGION,
+);
 
 class WorkInfo extends React.PureComponent {
   render() {
@@ -75,7 +84,7 @@ class WorkInfo extends React.PureComponent {
               marginBottom: '41px',
             }}
           >
-            <Region
+            <RegionWithValidation
               region={region}
               onChange={handleState('region')}
               validator={regionValidator}

--- a/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/index.js
@@ -20,12 +20,24 @@ import {
   jobTitle as jobTitleValidator,
 } from '../formCheck';
 
-import { REGION } from '../../../../constants/formElements';
+import { COMPANY, REGION, JOB_TITLE } from '../../../../constants/formElements';
+
+const CompanyQueryWithValidation = subscribeValidation(
+  CompanyQuery,
+  props => props.validator(props.companyQuery),
+  COMPANY,
+);
 
 const RegionWithValidation = subscribeValidation(
   Region,
   props => props.validator(props.region),
   REGION,
+);
+
+const JobTitleWithValidation = subscribeValidation(
+  JobTitle,
+  props => props.validator(props.jobTitle),
+  JOB_TITLE,
 );
 
 class WorkInfo extends React.PureComponent {
@@ -68,7 +80,7 @@ class WorkInfo extends React.PureComponent {
               marginBottom: '35px',
             }}
           >
-            <CompanyQuery
+            <CompanyQueryWithValidation
               companyQuery={companyQuery}
               onChange={v => {
                 handleState('companyQuery')(v);
@@ -77,6 +89,7 @@ class WorkInfo extends React.PureComponent {
               onCompanyId={handleState('companyId')}
               validator={companyQueryValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div
@@ -97,12 +110,13 @@ class WorkInfo extends React.PureComponent {
               marginBottom: '41px',
             }}
           >
-            <JobTitle
+            <JobTitleWithValidation
               inputTitle="職稱"
               jobTitle={jobTitle}
               onChange={handleState('jobTitle')}
               validator={jobTitleValidator}
               submitted={submitted}
+              changeValidationStatus={changeValidationStatus}
             />
           </div>
           <div

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import R from 'ramda';
 import Helmet from 'react-helmet';
-import { animateScroll } from 'react-scroll';
+import { scroller } from 'react-scroll';
 
 import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 
@@ -26,6 +26,7 @@ import {
 import styles from './WorkExperiencesForm.module.css';
 
 import helmetData from '../../../constants/helmetData';
+import { INVALID, WORK_FORM_ORDER } from '../../../constants/formElements';
 
 const createSection = id => subtitle => {
   const section = {
@@ -89,6 +90,8 @@ class WorkExperiencesForm extends React.Component {
       ...defaultForm,
       submitted: false,
     };
+
+    this.elementValidationStatus = {};
   }
 
   onSumbit() {
@@ -98,8 +101,33 @@ class WorkExperiencesForm extends React.Component {
       return postWorkExperience(workExperiencesToBody(this.state));
     }
     this.handleState('submitted')(true);
-    animateScroll.scrollToTop();
+    const topInvalidElement = this.getTopInvalidElement();
+    if (topInvalidElement !== null) {
+      scroller.scrollTo(topInvalidElement, {
+        duration: 1000,
+        delay: 100,
+        offset: -100,
+        smooth: true,
+      });
+    }
     return null;
+  }
+
+  getTopInvalidElement = () => {
+    const order = WORK_FORM_ORDER;
+    for (let i = 0; i <= order.length; i += 1) {
+      if (
+        this.elementValidationStatus[order[i]] &&
+        this.elementValidationStatus[order[i]] === INVALID
+      ) {
+        return order[i];
+      }
+    }
+    return null;
+  }
+
+  changeValidationStatus = (elementId, status) => {
+    this.elementValidationStatus[elementId] = status;
   }
 
   handleState(key) {
@@ -199,6 +227,7 @@ class WorkExperiencesForm extends React.Component {
           weekWorkTime={weekWorkTime}
           recommendToOthers={recommendToOthers}
           submitted={submitted}
+          changeValidationStatus={this.changeValidationStatus}
         />
         <WorkExperience
           handleState={this.handleState}

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -237,6 +237,7 @@ class WorkExperiencesForm extends React.Component {
           removeSection={this.removeBlock('sections')}
           editSection={this.editBlock('sections')}
           submitted={submitted}
+          changeValidationStatus={this.changeValidationStatus}
         />
         <SubmitArea
           onSubmit={this.onSumbit}

--- a/src/components/ShareExperience/common/Region.js
+++ b/src/components/ShareExperience/common/Region.js
@@ -1,5 +1,7 @@
 import React, { PropTypes } from 'react';
 
+import subscribeValidation from 'common/subscribeValidation';
+
 import Select from 'common/form/Select';
 import InputTitle from './InputTitle';
 
@@ -8,6 +10,8 @@ import styles from './Region.module.css';
 import {
   regionOptions,
 } from './optionMap';
+
+import { REGION } from '../../../constants/formElements';
 
 const Region = ({ region, onChange, validator, submitted }) => {
   const isWarning = submitted && !validator(region);
@@ -67,4 +71,11 @@ Region.defaultProps = {
   validator: () => {},
 };
 
-export default Region;
+const RegionWithValidation = subscribeValidation(
+  Region,
+  props => props.validator(props.region),
+  REGION,
+  'changeValidationStatus',
+);
+
+export default RegionWithValidation;

--- a/src/components/ShareExperience/common/Region.js
+++ b/src/components/ShareExperience/common/Region.js
@@ -1,7 +1,5 @@
 import React, { PropTypes } from 'react';
 
-import subscribeValidation from 'common/subscribeValidation';
-
 import Select from 'common/form/Select';
 import InputTitle from './InputTitle';
 
@@ -10,8 +8,6 @@ import styles from './Region.module.css';
 import {
   regionOptions,
 } from './optionMap';
-
-import { REGION } from '../../../constants/formElements';
 
 const Region = ({ region, onChange, validator, submitted }) => {
   const isWarning = submitted && !validator(region);
@@ -71,11 +67,4 @@ Region.defaultProps = {
   validator: () => {},
 };
 
-const RegionWithValidation = subscribeValidation(
-  Region,
-  props => props.validator(props.region),
-  REGION,
-  'changeValidationStatus',
-);
-
-export default RegionWithValidation;
+export default Region;

--- a/src/components/common/subscribeValidation.js
+++ b/src/components/common/subscribeValidation.js
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Element as ScrollElement } from 'react-scroll';
 
 import { VALID, INVALID } from '../../constants/formElements';
@@ -9,18 +9,25 @@ import { VALID, INVALID } from '../../constants/formElements';
  * @param {*} WrappedComponent: The component to be wrapped
  * @param {*} validate: The validation function to validate target value, it should return true / false
  * @param {*} elementName: The element name for scrolling
- * @param {*} onChangeFuncName: The function name in this.props to update validation status
  */
-export default function subscribeValidation(WrappedComponent, validate, elementName, onChangeFuncName) {
+export default function subscribeValidation(WrappedComponent, validate, elementName) {
   return class extends React.Component {
+    static propTypes = {
+      changeValidationStatus: PropTypes.func,
+    }
+    static defaultProps = {
+      changeValidationStatus: undefined,
+    }
     render() {
-      if (this.props[onChangeFuncName]) {
+      if (this.props.changeValidationStatus) {
         const isValid = validate(this.props);
-        this.props[onChangeFuncName](elementName, isValid ? VALID : INVALID);
+        this.props.changeValidationStatus(elementName, isValid ? VALID : INVALID);
+        // eslint-disable-next-line no-unused-vars
+        const { changeValidationStatus, ...restProps } = this.props;
         return (
           <div>
             <ScrollElement name={elementName} />
-            <WrappedComponent {...this.props} />
+            <WrappedComponent {...restProps} />
           </div>
         );
       }

--- a/src/components/common/subscribeValidation.js
+++ b/src/components/common/subscribeValidation.js
@@ -1,0 +1,30 @@
+
+import React from 'react';
+import { Element as ScrollElement } from 'react-scroll';
+
+import { VALID, INVALID } from '../../constants/formElements';
+
+/**
+ *
+ * @param {*} WrappedComponent: The component to be wrapped
+ * @param {*} validate: The validation function to validate target value, it should return true / false
+ * @param {*} elementName: The element name for scrolling
+ * @param {*} onChangeFuncName: The function name in this.props to update validation status
+ */
+export default function subscribeValidation(WrappedComponent, validate, elementName, onChangeFuncName) {
+  return class extends React.Component {
+    render() {
+      if (this.props[onChangeFuncName]) {
+        const isValid = validate(this.props);
+        this.props[onChangeFuncName](elementName, isValid ? VALID : INVALID);
+        return (
+          <div>
+            <ScrollElement name={elementName} />
+            <WrappedComponent {...this.props} />
+          </div>
+        );
+      }
+      return <WrappedComponent {...this.props} />;
+    }
+  };
+}

--- a/src/components/common/subscribeValidation.js
+++ b/src/components/common/subscribeValidation.js
@@ -21,9 +21,8 @@ export default function subscribeValidation(WrappedComponent, validate, elementN
     render() {
       if (this.props.changeValidationStatus) {
         const isValid = validate(this.props);
-        this.props.changeValidationStatus(elementName, isValid ? VALID : INVALID);
-        // eslint-disable-next-line no-unused-vars
         const { changeValidationStatus, ...restProps } = this.props;
+        changeValidationStatus(elementName, isValid ? VALID : INVALID);
         return (
           <div>
             <ScrollElement name={elementName} />

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -1,0 +1,29 @@
+export const VALID = 'valid';
+export const INVALID = 'invalid';
+export const COMPANY = 'company';
+export const REGION = 'region';
+export const JOB_TITLE = 'job_title';
+export const INTERVIEW_TIME = 'interview_time';
+export const INTERVIEW_RESULT = 'interview_result';
+export const OVERALL_RATING = 'overall_rating';
+export const TITLE = 'title';
+export const SECTIONS = 'sections';
+
+export const INTERVIEW_FORM_ORDER = [
+  COMPANY,
+  REGION,
+  JOB_TITLE,
+  INTERVIEW_TIME,
+  INTERVIEW_RESULT,
+  OVERALL_RATING,
+  TITLE,
+  SECTIONS,
+];
+
+export const WORK_FORM_ORDER = [
+  COMPANY,
+  REGION,
+  JOB_TITLE,
+  TITLE,
+  SECTIONS,
+];


### PR DESCRIPTION
昨天跟彥齊討論完，認為捲動到最上方驗證未過的元件這件事，有太多重複的地方，可以嘗試用 HOC來解。

所以這邊寫了一個 prototype。

簡而言之是寫了一個 HOC `subscribeValidation`，必須要傳入以下四個參數：
 * `WrappedComponent`: 要被包住的component
 * `validate`: 如何運用該component 的props 去驗證欄位是否符合格式
 * `elementName`: hidden 的 scrolling element 名稱
 * `onChangeFuncName`: 該 component 的 props裡面，用來更新validation status的函數名稱

不過 server-side-rendering 的時候，會遇到問題。
如果我直接貼網址 `{host}/share/work-experiences` ，前端 server 會出現：
```
(node:51869) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 44): TypeError: Cannot read property 'props' of undefined
```
但從其他頁進去，功能就正常
這是什麼原因？

