### PR TITLE
修正單篇經驗頁面返回不會正確回到列表的問題

### DIFF
--- a/src/components/ExperienceDetail/BackToList.js
+++ b/src/components/ExperienceDetail/BackToList.js
@@ -1,13 +1,25 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { browserHistory } from 'react-router';
 import i from 'common/icons';
 import { P } from 'common/base';
 import styles from './BackToList.module.css';
 
-const BackToList = () => (
-  <button onClick={() => browserHistory.goBack()} className={styles.backBtn}>
+const backOrPush = backable => {
+  if (backable) {
+    return browserHistory.goBack();
+  }
+
+  return browserHistory.push('/experiences/search');
+};
+
+const BackToList = ({ backable }) => (
+  <button onClick={() => backOrPush(backable)} className={styles.backBtn}>
     <i.ArrowGo /><P size="m" bold>返回列表</P>
   </button>
 );
+
+BackToList.propTypes = {
+  backable: PropTypes.bool,
+};
 
 export default BackToList;

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -104,9 +104,7 @@ class ExperienceDetail extends Component {
       experienceDetail, setTos, setComment, likeExperience, likeReply,
     } = this.props;
 
-    const {
-      backable,
-    } = this.props.location.query;
+    const backable = this.props.location.query.backable || 'false';
     const data = experienceDetail.toJS();
     const experience = data.experience;
     return (
@@ -138,7 +136,7 @@ class ExperienceDetail extends Component {
             <ReactionZone experience={experience} likeExperience={likeExperience} />
 
             <BackToList
-              backable={Boolean(Number(backable))}
+              backable={JSON.parse(backable)}
             />
           </Wrapper>
         </Section>

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -26,6 +26,11 @@ class ExperienceDetail extends Component {
     setComment: React.PropTypes.func.isRequired,
     submitComment: React.PropTypes.func.isRequired,
     params: React.PropTypes.object.isRequired,
+    location: React.PropTypes.shape({
+      query: React.PropTypes.shape({
+        backable: React.PropTypes.string,
+      }),
+    }),
   }
 
   static fetchData({ store, params }) {
@@ -98,6 +103,10 @@ class ExperienceDetail extends Component {
     const {
       experienceDetail, setTos, setComment, likeExperience, likeReply,
     } = this.props;
+
+    const {
+      backable,
+    } = this.props.location.query;
     const data = experienceDetail.toJS();
     const experience = data.experience;
     return (
@@ -128,7 +137,9 @@ class ExperienceDetail extends Component {
             { /* 按讚，分享，檢舉區塊  */}
             <ReactionZone experience={experience} likeExperience={likeExperience} />
 
-            <BackToList />
+            <BackToList
+              backable={Boolean(Number(backable))}
+            />
           </Wrapper>
         </Section>
         <Section>

--- a/src/components/ExperienceSearch/ExperienceBlock.js
+++ b/src/components/ExperienceSearch/ExperienceBlock.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import cn from 'classnames';
+import qs from 'qs';
 
 import { Heading, P } from 'common/base';
 import i from 'common/icons';
@@ -50,7 +51,7 @@ const ExperienceBlock = ({ data, size }) => {
   console.log(data, 'data tin');
 
   return (
-    <Link to={`/experiences/${data._id}`} className={cn(styles.container, styles[size])}>
+    <Link to={`/experiences/${data._id}?${qs.stringify({ backable: 1 })}`} className={cn(styles.container, styles[size])}>
       <section className={styles.contentWrapper}>
         <P size="s">
           {`${expType}${splitter}${year} 年 ${month} 月`}

--- a/src/components/ExperienceSearch/ExperienceBlock.js
+++ b/src/components/ExperienceSearch/ExperienceBlock.js
@@ -22,7 +22,7 @@ Label.propTypes = {
   className: PropTypes.string,
 };
 
-const ExperienceBlock = ({ data, size }) => {
+const ExperienceBlock = ({ data, size, backable }) => {
   const expType = data.type === 'interview' ? '面試' : '工作';
   const date = new Date(Date.parse(data.created_at));
   const year = date.getFullYear();
@@ -51,7 +51,7 @@ const ExperienceBlock = ({ data, size }) => {
   console.log(data, 'data tin');
 
   return (
-    <Link to={`/experiences/${data._id}?${qs.stringify({ backable: 1 })}`} className={cn(styles.container, styles[size])}>
+    <Link to={`/experiences/${data._id}?${qs.stringify({ backable })}`} className={cn(styles.container, styles[size])}>
       <section className={styles.contentWrapper}>
         <P size="s">
           {`${expType}${splitter}${year} 年 ${month} 月`}
@@ -86,9 +86,11 @@ const ExperienceBlock = ({ data, size }) => {
 ExperienceBlock.propTypes = {
   data: PropTypes.object.isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
+  backable: PropTypes.bool,
 };
 ExperienceBlock.defaultProps = {
   size: 'm',
+  backable: false,
 };
 
 export default ExperienceBlock;

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -146,6 +146,7 @@ class ExperienceSearch extends Component {
                       <ExperienceBlock
                         key={o._id} to={`/experiences/${o._id}`}
                         data={o} size="l"
+                        backable
                       />
                     )
                   ))


### PR DESCRIPTION
利用query string 帶入 `backable` 來判斷是否要 `goBack()` 還是 `push('/experience/search')`

實作是在 `ExperienceBlock` Link.to 來夾帶backable = 1

不過因為LandingPage 也是用這個元件來放連結，所以從LandingPage 進入單篇經驗，也會觸發 `goBack()` 造成預期應該返回列表，但其實是跳到LandingPage 的情況。

closes: #224 