### PR TITLE
在登入成功後重新抓取單頁經驗資料

### DIFF
--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -31,6 +31,7 @@ class ExperienceDetail extends Component {
         backable: React.PropTypes.string,
       }),
     }),
+    authStatus: React.PropTypes.string,
   }
 
   static fetchData({ store, params }) {
@@ -54,6 +55,10 @@ class ExperienceDetail extends Component {
     if (nextProps.params.id !== this.props.params.id) {
       this.props.fetchExperience(nextProps.params.id);
       this.props.fetchReplies(nextProps.params.id);
+    }
+
+    if (nextProps.authStatus !== this.props.authStatus && nextProps.authStatus === 'connected') {
+      this.props.fetchExperience(this.props.params.id);
     }
   }
 

--- a/src/containers/ExperienceDetailPage.js
+++ b/src/containers/ExperienceDetailPage.js
@@ -4,8 +4,13 @@ import { connect } from 'react-redux';
 import ExperienceDetail from '../components/ExperienceDetail';
 import * as ExperienceDetailActions from '../actions/experienceDetail';
 
+import {
+  statusSelector,
+} from '../selectors/authSelector';
+
 const mapStateToProps = state => ({
   experienceDetail: state.experienceDetail,
+  authStatus: statusSelector(state),
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/selectors/authSelector.js
+++ b/src/selectors/authSelector.js
@@ -1,3 +1,3 @@
 export const statusSelector = state => state.auth.get('status');
-export const tokenSelector = state => state.auth.token;
-export const userSelector = state => state.auth.user;
+export const tokenSelector = state => state.auth.get('token');
+export const userSelector = state => state.auth.get('user');

--- a/src/selectors/authSelector.js
+++ b/src/selectors/authSelector.js
@@ -1,0 +1,3 @@
+export const statusSelector = state => state.auth.get('status');
+export const tokenSelector = state => state.auth.token;
+export const userSelector = state => state.auth.user;


### PR DESCRIPTION
1. 增加一個authStatus 的selector
2. 將auth.status 連結至ExperienceDetail
3. 在 `componentWillReceiveProps` 中判斷，若獲得新的authStatus 並且是 `connected` ，則重新呼叫 `this.props.fetchExperience(this.props.params.id)`

我看應該是沒有個別獲取按讚資訊的api ，所以就全撈。

closes: #205 