### PR TITLE
Resolve babel-plugin-react-pure-components causing error

### DIFF
--- a/src/components/common/subscribeValidation.js
+++ b/src/components/common/subscribeValidation.js
@@ -11,7 +11,7 @@ import { VALID, INVALID } from '../../constants/formElements';
  * @param {*} elementName: The element name for scrolling
  */
 export default function subscribeValidation(WrappedComponent, validate, elementName) {
-  return class extends React.Component {
+  return class Subscriber extends React.Component {
     static propTypes = {
       changeValidationStatus: PropTypes.func,
     }


### PR DESCRIPTION
這個問題由 #225 來的，當 NODE_ENV 是 production 的時候，babel-plugin-react-pure-components
嘗試將 class 轉成 pure function

但，有可能是它的 bug，轉換過程，anonymous class 會導致 "Cannot read property 'name' of null"

![image](https://user-images.githubusercontent.com/1908007/28742472-ba4d78dc-7463-11e7-9709-b96c56fddfce.png)

目前是先加上名稱，不確定是否有更好的解法？


* 由於是 hot fix，所以先 merge 讓線上可以運作
* 有更多修正，麻煩再 revert 這個