### PR TITLE
修正表格顯示bug

### DIFF
--- a/src/components/ExperienceSearch/WorkingHourTable.js
+++ b/src/components/ExperienceSearch/WorkingHourTable.js
@@ -137,6 +137,7 @@ class WorkingHourTable extends Component {
       <Table className={styles.companyTable} data={data} primaryKey="created_at">
         <Table.Column
           className={styles.colPosition}
+          title="職稱"
           dataField="job_title"
           dataFormatter={WorkingHourTable.getTitle}
         >
@@ -145,6 +146,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colType}
+          title="職務型態"
           dataField="employment_type"
           dataFormatter={WorkingHourTable.getEmploymentType}
         >
@@ -153,6 +155,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colDayTime}
+          title="表訂 / 實際工時"
           dataField="day_promised_work_time"
           dataFormatter={WorkingHourTable.getWorkingHour}
         >
@@ -161,6 +164,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colWeekTime}
+          title="一週總工時"
           dataField="week_work_time"
           dataFormatter={WorkingHourTable.getWorkingTime}
         >
@@ -169,6 +173,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colFrequency}
+          title="加班頻率"
           dataField="overtime_frequency"
           dataFormatter={WorkingHourTable.getFrequency}
         >
@@ -177,6 +182,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colExperience}
+          title="業界工作經歷"
           dataField="experience_in_year"
           dataFormatter={WorkingHourTable.getYear}
         >
@@ -185,6 +191,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colSalary}
+          title="薪資"
           dataField="salary"
           dataFormatter={WorkingHourTable.getSalary}
           alignRight
@@ -194,6 +201,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colHourly}
+          title="估計時薪"
           dataField="estimated_hourly_wage"
           dataFormatter={WorkingHourTable.getWage}
           alignRight
@@ -209,6 +217,7 @@ class WorkingHourTable extends Component {
 
         <Table.Column
           className={styles.colDataTime}
+          title="參考時間"
           dataField="data_time"
           dataFormatter={WorkingHourTable.getDate}
         >

--- a/src/components/common/table/Table.js
+++ b/src/components/common/table/Table.js
@@ -42,7 +42,7 @@ class Table extends Component {
         record.push(
           <td
             key={idx}
-            data-th={col.props.children}
+            data-th={col.props.title}
             className={cn({ [styles.alignRight]: col.props.alignRight })}
           >
             {value}


### PR DESCRIPTION
#246 

on small device的表格column標題，抓的是Column的children，children原本是純文字，所以運作沒問題

但因為後來有些欄位有製作成說明modal的按鈕的需求，因此就必需要包一個`InfoButton`（若不在這裡包的話，就必需設在`Column`的參數中，但這就影響`Column`的通用性了）

想不到比較好的解法，只好在`Column`再加一個參數，多寫一次要顯示的文字