### PR TITLE
加上送出區塊必須的連結、提示

### DIFF
--- a/src/components/ExperienceDetail/MessageBoard.js
+++ b/src/components/ExperienceDetail/MessageBoard.js
@@ -29,7 +29,17 @@ const MessageBoard = ({
               color: '#3B3B3B',
             }}
           >
-            我分享的是真實資訊，並且遵守中華民國法律以及
+            我分享的是真實資訊，並且遵守本站
+            <Link
+              to="/guidelines"
+              target="_blank"
+              style={{
+                color: '#02309E',
+              }}
+            >
+              發文留言規定
+            </Link>
+            、
             <Link
               to="/user-terms"
               target="_blank"
@@ -37,9 +47,9 @@ const MessageBoard = ({
                 color: '#02309E',
               }}
             >
-              本站使用者條款
+              使用者條款
             </Link>
-            。
+            以及中華民國法律。
           </p>
         }
         onChange={setTos} checked={tos}

--- a/src/components/ExperienceDetail/MessageBoard.js
+++ b/src/components/ExperienceDetail/MessageBoard.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
 
 import Button from 'common/button/Button';
 import Checkbox from 'common/form/Checkbox';
@@ -22,8 +23,30 @@ const MessageBoard = ({
     <div className={`formLabel ${styles.termsOfService}`}>
       <Checkbox
         id="termsOfService" value="agree"
-        label="我分享的是真實資訊，並且遵守中華民國法律以及本站使用者條款。"
+        label={
+          <p
+            style={{
+              color: '#3B3B3B',
+            }}
+          >
+            我分享的是真實資訊，並且遵守中華民國法律以及
+            <Link
+              to="/user-terms"
+              target="_blank"
+              style={{
+                color: '#02309E',
+              }}
+            >
+              本站使用者條款
+            </Link>
+            。
+          </p>
+        }
         onChange={setTos} checked={tos}
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+        }}
       />
       <Button
         btnStyle="submit"

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { browserHistory } from 'react-router';
+import { browserHistory, Link } from 'react-router';
 
 import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
@@ -150,7 +150,17 @@ class SubmitArea extends React.PureComponent {
               color: '#3B3B3B',
             }}
           >
-            我分享的是真實資訊，並且遵守中華民國法律以及本站使用者條款。
+            我分享的是真實資訊，並且遵守中華民國法律以及
+              <Link
+                to="/user-terms"
+                target="_blank"
+                style={{
+                  color: '#02309E',
+                }}
+              >
+                本站使用者條款
+              </Link>
+              。
           </p>
         </label>
         <div>

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -150,17 +150,27 @@ class SubmitArea extends React.PureComponent {
               color: '#3B3B3B',
             }}
           >
-            我分享的是真實資訊，並且遵守中華民國法律以及
-              <Link
-                to="/user-terms"
-                target="_blank"
-                style={{
-                  color: '#02309E',
-                }}
-              >
-                本站使用者條款
-              </Link>
-              。
+            我分享的是真實資訊，並且遵守本站
+            <Link
+              to="/guidelines"
+              target="_blank"
+              style={{
+                color: '#02309E',
+              }}
+            >
+              發文留言規定
+            </Link>
+            、
+            <Link
+              to="/user-terms"
+              target="_blank"
+              style={{
+                color: '#02309E',
+              }}
+            >
+              使用者條款
+            </Link>
+            以及中華民國法律。
           </p>
         </label>
         <div>

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -1,17 +1,49 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import cn from 'classnames';
+import Modal from 'common/Modal';
 
 import authStatus from '../../../constants/authStatus';
+
+import WhyFacebookAuth from './WhyFacebookAuth';
 
 import styles from './ButtonSubmit.module.css';
 
 const isLogin = auth =>
   auth.get('status') === authStatus.CONNECTED;
 
+const getWhyFacebookAuth = onClick => (
+  <WhyFacebookAuth
+    buttonClick={onClick}
+  />
+);
+
 class ButtonSubmit extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isOpen: false,
+      feedback: null,
+    };
+  }
+
+  handleIsOpen = isOpen => (
+    this.setState({
+      isOpen,
+    })
+  )
+
+  handleFeedback = feedback => (
+    this.setState({
+      feedback,
+    })
+  )
+
   render() {
     const { text, onSubmit, disabled, auth, login } = this.props;
+    const { isOpen, feedback } = this.state;
     return (
       <div
         style={{
@@ -27,7 +59,13 @@ class ButtonSubmit extends React.PureComponent {
             >
               {text}
             </button> :
-            <div>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+              }}
+            >
               <button
                 className={styles.container}
                 onClick={login}
@@ -37,21 +75,31 @@ class ButtonSubmit extends React.PureComponent {
               </button>
               <div
                 style={{
-                  textAlign: 'center',
                   marginTop: '21px',
+                  cursor: 'pointer',
+                }}
+                onClick={() => {
+                  this.handleIsOpen(true);
+                  return this.handleFeedback(getWhyFacebookAuth(
+                    () => this.handleIsOpen(false)
+                  ));
                 }}
               >
                 <p
-                  className="pMbold"
-                  style={{
-                    color: '#C0C0C0',
-                  }}
+                  className={cn('pMbold', styles.whyFB)}
                 >
                   為什麼需要 Facebook 帳戶驗證？
               </p>
               </div>
             </div>
         }
+        <Modal
+          isOpen={isOpen}
+          close={() => this.handleIsOpen(!isOpen)}
+          hasClose={false}
+        >
+          {feedback}
+        </Modal>
       </div>
     );
   }

--- a/src/components/common/button/ButtonSubmit.module.css
+++ b/src/components/common/button/ButtonSubmit.module.css
@@ -1,4 +1,4 @@
-@value main-yellow, main-gray from "common/variables.module.css";
+@value main-yellow, main-gray, gray-dark from "common/variables.module.css";
 
 
 .container {
@@ -16,5 +16,14 @@
   &:disabled {
     background: main-gray;
     cursor: not-allowed;
+  }
+}
+
+.whyFB {
+  color: #C0C0C0;
+  transition: color 0.2s linear;
+
+  &:hover {
+    color: gray-dark;
   }
 }

--- a/src/components/common/button/WhyFacebookAuth.js
+++ b/src/components/common/button/WhyFacebookAuth.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Question from 'common/icons/Question';
+import Button from 'common/button/Button';
+
+const WhyFacebookAuth = ({ buttonClick }) => (
+  <div
+    style={{
+      padding: '55px',
+      width: '470px',
+    }}
+  >
+    <Question
+      style={{
+        fill: '#FCD406',
+        height: '82px',
+        width: '82px',
+        marginBottom: '32px',
+      }}
+    />
+    <h2
+      style={{
+        fontSize: '2rem',
+        marginBottom: '19px',
+      }}
+    >
+      為何需要 FB 帳戶驗證？
+    </h2>
+    <p
+      style={{
+        marginBottom: '30px',
+      }}
+    >
+      為了避免使用者大量輸入假資訊，我們會以您的 Facebook 帳戶做驗證。但別擔心！您的帳戶資訊不會以任何形式被揭露、顯示。
+    </p>
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+      }}
+    >
+      <Button
+        btnStyle="black"
+        circleSize="md"
+        onClick={buttonClick}
+      >
+        好，我知道了
+      </Button>
+    </div>
+  </div>
+);
+
+WhyFacebookAuth.propTypes = {
+  buttonClick: PropTypes.func,
+};
+
+export default WhyFacebookAuth;

--- a/src/components/common/form/Checkbox.js
+++ b/src/components/common/form/Checkbox.js
@@ -4,11 +4,11 @@ import cn from 'classnames';
 import styles from './Checkbox.module.css';
 
 const Checkbox = ({
-  id, name, label, value, checked, disabled, margin, onChange,
+  id, name, label, value, checked, disabled, margin, onChange, style,
 }) => (
   <div
     className={cn(styles.formGroup, { [styles.disabled]: disabled })}
-    style={{ margin }}
+    style={{ margin, ...style }}
   >
     <input
       type="checkbox" id={id || `checkbox-${value}`}
@@ -29,12 +29,16 @@ Checkbox.defaultProps = {
 Checkbox.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.node,
+  ]).isRequired,
   value: PropTypes.string.isRequired,
   checked: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,
   margin: PropTypes.string,
   onChange: PropTypes.func.isRequired,
+  style: PropTypes.object,
 };
 
 export default Checkbox;


### PR DESCRIPTION
closes: #237 
closes: #240 

## 做完的
* 加上單篇經驗頁面、填寫頁中的送出區域的**使用者條款**、**發文留言規定**連結
* 增加**為什麼需要 Facebook 帳戶驗證？** 的modal
* 在 `Checkbox` 加上style （因為置中跑版）

## 沒做完的
* 單篇經驗頁那裡，之前按鈕底下就沒有 **為什麼需要 Facebook 帳戶驗證？** ，所以就沒特別加上，連帶modal 也沒有