### PR TITLE
完成 helmet

### DIFF
--- a/src/components/About/index.js
+++ b/src/components/About/index.js
@@ -5,7 +5,7 @@ import { Section, Wrapper, Heading, P } from 'common/base';
 import CallToAction from 'common/CallToAction';
 import { Facebook, Email, Github } from 'common/icons';
 import editorStyles from 'common/Editor.module.css';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 import styles from './About.module.css';
 import Timeline from './Timeline';
 
@@ -53,7 +53,7 @@ const data2017 = [
 
 const About = () => (
   <Section Tag="main" pageTop>
-    <Helmet {...helmetData.ABOUT} />
+    <Helmet {...HELMET_DATA.ABOUT} />
     <Section paddingBottom>
       <Wrapper size="m">
         <Heading size="m" marginBottomS>緣起：求職資訊不透明</Heading>

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -13,7 +13,8 @@ import status from '../../constants/status';
 import {
   fetchExperience,
 } from '../../actions/experienceDetail';
-import { formatCanonicalPath } from '../../utils/helmetHelper';
+import { formatTitle, formatCanonicalPath } from '../../utils/helmetHelper';
+import { SITE_NAME } from '../../constants/helmetData';
 
 import authStatus from '../../constants/authStatus';
 
@@ -91,7 +92,7 @@ class ExperienceDetail extends Component {
             title={title}
             meta={[
               { name: 'description', content: description },
-              { property: 'og:title', content: title },
+              { property: 'og:title', content: formatTitle(title, SITE_NAME) },
               { property: 'og:url', content: formatCanonicalPath(`/experiences/${id}`) },
               { property: 'og:description', content: description },
             ]}

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -73,19 +73,19 @@ class ExperienceDetail extends Component {
   renderHelmet = () => {
     if (this.props.experienceDetail) {
       const experience = this.props.experienceDetail.toJS().experience;
-      console.log(experience);
       if ('_id' in experience) {
         const id = experience._id;
+        const title = experience.title;
         const company = experience.company.name;
         const jobTitle = experience.job_title;
         const type = experience.type;
-        const sections = experience.sections;
+        const subtitle = experience.sections[0].subtitle.replace(/(\r\n|\n|\r)/gm, ' ');
+        const content = experience.sections[0].content.replace(/(\r\n|\n|\r)/gm, ' ');
         const mapping = {
           interview: '面試經驗分享',
           work: '工作經驗分享',
         };
-        const title = `${company} ${jobTitle} ${mapping[type]}`;
-        const description = `${sections[0].subtitle} ${sections[0].content}`;
+        const description = `${company} ${jobTitle} 的${mapping[type]}。 ${subtitle}：${content}`;
         return (
           <Helmet
             title={title}

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -14,6 +14,8 @@ import WorkingHourBlock from './WorkingHourBlock';
 import { fetchExperiences } from '../../actions/experienceSearch';
 import helmetData from '../../constants/helmetData';
 
+import getScale from '../../utils/numberUtils';
+
 class ExperienceSearch extends Component {
   static fetchData({ store: { dispatch } }) {
     return dispatch(fetchExperiences('sort', '', 0));
@@ -63,6 +65,17 @@ class ExperienceSearch extends Component {
     this.props.fetchExperiences('sort', e.target.value, 0);
   }
 
+  renderHelmet = () => {
+    const scale = getScale(this.props.experienceSearch.get('experienceCount'));
+    const description = `馬上查詢超過 ${scale} 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！`;
+    const data = helmetData.EXPERIENCE_SEARCH;
+    data.meta.push(
+      { name: 'description', content: description },
+      { property: 'og:description', content: description },
+    );
+    return <Helmet {...data} />;
+  }
+
   render() {
     const {
       /* setSort, */ setSearchType, /* setIndustry, */ fetchKeywords, setKeyword,
@@ -73,7 +86,7 @@ class ExperienceSearch extends Component {
 
     return (
       <Section Tag="main" pageTop paddingBottom>
-        <Helmet {...helmetData.EXPERIENCE_SEARCH} />
+        {this.renderHelmet()}
         <Wrapper size="l">
           <div className={styles.container}>
             <aside className={styles.aside}>

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -12,7 +12,7 @@ import Searchbar from './Searchbar';
 import ExperienceBlock from './ExperienceBlock';
 import WorkingHourBlock from './WorkingHourBlock';
 import { fetchExperiences } from '../../actions/experienceSearch';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 import getScale from '../../utils/numberUtils';
 
@@ -68,7 +68,7 @@ class ExperienceSearch extends Component {
   renderHelmet = () => {
     const scale = getScale(this.props.experienceSearch.get('experienceCount'));
     const description = `馬上查詢超過 ${scale} 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！`;
-    const data = helmetData.EXPERIENCE_SEARCH;
+    const data = HELMET_DATA.EXPERIENCE_SEARCH;
     data.meta.push(
       { name: 'description', content: description },
       { property: 'og:description', content: description },

--- a/src/components/Faq/index.js
+++ b/src/components/Faq/index.js
@@ -4,11 +4,11 @@ import { Section, Wrapper } from 'common/base';
 import PageBanner from 'common/PageBanner';
 import editorStyles from 'common/Editor.module.css';
 import styles from './Faq.module.css';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 const Faq = () => (
   <main>
-    <Helmet {...helmetData.FAQ} />
+    <Helmet {...HELMET_DATA.FAQ} />
     <PageBanner heading="常見問答" />
     <Section padding>
       <Wrapper size="m" className={editorStyles.editor}>

--- a/src/components/Guidelines/index.js
+++ b/src/components/Guidelines/index.js
@@ -3,11 +3,11 @@ import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
 import PageBanner from 'common/PageBanner';
 import editorStyles from 'common/Editor.module.css';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 const GuideLines = () => (
   <main>
-    <Helmet {...helmetData.GUIDELINES} />
+    <Helmet {...HELMET_DATA.GUIDELINES} />
     <PageBanner heading="發文留言規則" />
     <Section padding>
       <Wrapper size="m" className={editorStyles.editor}>

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -10,7 +10,7 @@ import {
 import status from '../../constants/status';
 import LaborRightsEntry from './LaborRightsEntry';
 import About from './About';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 class LaborRightsMenu extends React.Component {
   static fetchData({ store }) {
@@ -26,7 +26,7 @@ class LaborRightsMenu extends React.Component {
     return (
       <Section Tag="main" pageTop>
         <Wrapper size="l" Tag="main">
-          <Helmet {...helmetData.LABOR_RIGHTS_MENU} />
+          <Helmet {...HELMET_DATA.LABOR_RIGHTS_MENU} />
           {this.props.status === status.FETCHING && <Loader />}
           {
             this.props.status === status.ERROR && this.props.error &&

--- a/src/components/LandingPage/index.js
+++ b/src/components/LandingPage/index.js
@@ -12,7 +12,7 @@ import { fetchMetaListIfNeeded } from '../../actions/laborRightsMenu';
 import LaborRightsEntry from '../LaborRightsMenu/LaborRightsEntry';
 import Banner from './Banner';
 import Dashboard from './Dashboard';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 class LandingPage extends Component {
   static fetchData({ store: { dispatch } }) {
@@ -38,7 +38,7 @@ class LandingPage extends Component {
     const expData = this.props.experienceSearch.toJS().experiences || [];
     return (
       <main>
-        <Helmet {...helmetData.LANDING_PAGE} />
+        <Helmet {...HELMET_DATA.LANDING_PAGE} />
         <Banner />
         <Dashboard />
         <Section padding>

--- a/src/components/LandingPage/index.js
+++ b/src/components/LandingPage/index.js
@@ -34,20 +34,11 @@ class LandingPage extends Component {
     ]);
   }
 
-  renderHelmet = () => {
-    const data = helmetData.LANDING_PAGE;
-    return (
-      <Helmet
-        title={data.title}
-        meta={data.meta}
-      />
-    );
-  }
   render() {
     const expData = this.props.experienceSearch.toJS().experiences || [];
     return (
       <main>
-        {this.renderHelmet()}
+        <Helmet {...helmetData.LANDING_PAGE} />
         <Banner />
         <Dashboard />
         <Section padding>

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -4,12 +4,12 @@ import Helmet from 'react-helmet';
 import styles from './App.module.css';
 import Header from '../../containers/Layout/Header';
 import Footer from './Footer';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 const App = ({ children }) => (
   <div className={styles.App}>
     <Header />
-    <Helmet {...helmetData.DEFAULT} />
+    <Helmet {...HELMET_DATA.DEFAULT} />
     <div className={styles.content}>
       {children}
     </div>

--- a/src/components/Privacy/index.js
+++ b/src/components/Privacy/index.js
@@ -3,11 +3,11 @@ import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
 import PageBanner from 'common/PageBanner';
 import editorStyles from 'common/Editor.module.css';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 const Privacy = () => (
   <main>
-    <Helmet {...helmetData.PRIVACY_POLICY} />
+    <Helmet {...HELMET_DATA.PRIVACY_POLICY} />
     <PageBanner heading="隱私權政策" />
     <Section padding>
       <Wrapper size="m" className={editorStyles.editor}>

--- a/src/components/ShareExperience/Entry.js
+++ b/src/components/ShareExperience/Entry.js
@@ -5,11 +5,11 @@ import { Wrapper } from 'common/base';
 import ShareExpSection from 'common/ShareExpSection';
 import i from 'common/icons';
 import styles from './Entry.module.css';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 const Entry = () => (
   <div>
-    <Helmet {...helmetData.SHARE} />
+    <Helmet {...HELMET_DATA.SHARE} />
     <Wrapper size="l" className={styles.wrapper}>
       <button onClick={() => browserHistory.goBack()} className={styles.closeBtn}><i.X /></button>
     </Wrapper>

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -25,7 +25,7 @@ import {
   idGenerator,
 } from '../utils';
 
-import helmetData from '../../../constants/helmetData';
+import { HELMET_DATA } from '../../../constants/helmetData';
 import { INVALID, INTERVIEW_FORM_ORDER } from '../../../constants/formElements';
 
 const createSection = id => (subtitle, placeholder = '', titlePlaceholder = '請輸入標題，例：面試方式') => {
@@ -192,7 +192,7 @@ class InterviewForm extends React.Component {
   render() {
     return (
       <div className={styles.container}>
-        <Helmet {...helmetData.SHARE_INTERVIEW} />
+        <Helmet {...HELMET_DATA.SHARE_INTERVIEW} />
         <h1
           className="headingL"
           style={{

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -25,7 +25,7 @@ import {
 
 import styles from './WorkExperiencesForm.module.css';
 
-import helmetData from '../../../constants/helmetData';
+import { HELMET_DATA } from '../../../constants/helmetData';
 import { INVALID, WORK_FORM_ORDER } from '../../../constants/formElements';
 
 const createSection = id => (subtitle, placeholder = '', titlePlaceholder = '請輸入標題，例：實際工作內容') => {
@@ -199,7 +199,7 @@ class WorkExperiencesForm extends React.Component {
 
     return (
       <div className={styles.container}>
-        <Helmet {...helmetData.SHARE_WORK} />
+        <Helmet {...HELMET_DATA.SHARE_WORK} />
         <h1
           className="headingL"
           style={{

--- a/src/components/Terms/index.js
+++ b/src/components/Terms/index.js
@@ -3,11 +3,11 @@ import Helmet from 'react-helmet';
 import { Section, Wrapper } from 'common/base';
 import PageBanner from 'common/PageBanner';
 import editorStyles from 'common/Editor.module.css';
-import helmetData from '../../constants/helmetData';
+import { HELMET_DATA } from '../../constants/helmetData';
 
 const Terms = () => (
   <main>
-    <Helmet {...helmetData.USER_TERMS} />
+    <Helmet {...HELMET_DATA.USER_TERMS} />
     <PageBanner heading="使用者條款" />
     <Section padding>
       <Wrapper size="m" className={editorStyles.editor}>

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -1,6 +1,6 @@
 
 
-import { formatCanonicalPath } from '../utils/helmetHelper';
+import { formatTitle, formatCanonicalPath } from '../utils/helmetHelper';
 /*
   This file will organize most of CONSTANT head information.
   For those DYNAMIC head information, will be generated in each component
@@ -26,22 +26,22 @@ The followings are some useful elements from Open Graph Protocol:
 
 */
 
-const siteName = 'GoodJob 好工作評論網';
 const imgHost = 'https://s3-ap-northeast-1.amazonaws.com/goodjob.life';
-const helmetData = {
+export const SITE_NAME = 'GoodJob 好工作評論網';
+export const HELMET_DATA = {
   DEFAULT: {
-    defaultTitle: siteName,
-    titleTemplate: `%s | ${siteName}`,
+    defaultTitle: SITE_NAME,
+    titleTemplate: `%s | ${SITE_NAME}`,
     meta: [
       { name: 'description', content: '你是否曾覺得職場資訊不夠透明？分享你的職場或面試經驗，讓我們一起改變現狀、定義理想的工作！' },
       { name: 'keywords', content: '工作時間, 薪資, 面試經驗, 工作經驗, 工作評論' },
-      { property: 'og:title', content: siteName },
+      { property: 'og:title', content: SITE_NAME },
       { property: 'og:url', content: formatCanonicalPath('/') },
       { property: 'og:type', content: 'website' },
       { property: 'og:image', content: `${imgHost}/www/og/default.jpg` },
       { property: 'og:description', content: '你是否曾覺得職場資訊不夠透明？分享你的職場或面試經驗，讓我們一起改變現狀、定義理想的工作！' },
       { property: 'og:locale', content: 'zh_TW' },
-      { property: 'og:site_name', content: siteName },
+      { property: 'og:site_name', content: SITE_NAME },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/') },
@@ -53,7 +53,7 @@ const helmetData = {
   SHARE: {
     title: '分享你的職場資訊',
     meta: [
-      { property: 'og:title', content: '分享你的職場資訊' },
+      { property: 'og:title', content: formatTitle('分享你的職場資訊', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/share') },
       { property: 'og:image', content: `${imgHost}/www/og/share.jpg` },
     ],
@@ -64,7 +64,7 @@ const helmetData = {
   SHARE_INTERVIEW: {
     title: '面試經驗分享',
     meta: [
-      { property: 'og:title', content: '面試經驗分享' },
+      { property: 'og:title', content: formatTitle('面試經驗分享', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/share/interview') },
       { property: 'og:image', content: `${imgHost}/www/og/share-interview.jpg` },
     ],
@@ -75,7 +75,7 @@ const helmetData = {
   SHARE_WORK: {
     title: '工作經驗分享',
     meta: [
-      { property: 'og:title', content: '工作經驗分享' },
+      { property: 'og:title', content: formatTitle('工作經驗分享', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/share/work-experience') },
       { property: 'og:image', content: `${imgHost}/www/og/share-work.jpg` },
     ],
@@ -86,7 +86,7 @@ const helmetData = {
   EXPERIENCE_SEARCH: {
     title: '查詢面試、工作經驗',
     meta: [
-      { property: 'og:title', content: '查詢面試、工作經驗' },
+      { property: 'og:title', content: formatTitle('查詢面試、工作經驗', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/experiences/search') },
       { property: 'og:image', content: `${imgHost}/www/og/experience-search.jpg` },
     ],
@@ -101,7 +101,7 @@ const helmetData = {
     title: '勞動知識小教室',
     meta: [
       { name: 'description', content: '我們看見勞工們的需要，推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，內容涵蓋勞動基準法、性別工作平等法、就業服務法以及工會相關法令等勞工必備的權益資訊。讓勞工認識自己的權益，學會保護自己。' },
-      { property: 'og:title', content: '勞動知識小教室' },
+      { property: 'og:title', content: formatTitle('勞動知識小教室', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/labor-rights') },
       { property: 'og:image', content: `${imgHost}/www/og/labor-rights.jpg` },
       { property: 'og:description', content: '我們看見勞工們的需要，推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，內容涵蓋勞動基準法、性別工作平等法、就業服務法以及工會相關法令等勞工必備的權益資訊。讓勞工認識自己的權益，學會保護自己。' },
@@ -117,7 +117,7 @@ const helmetData = {
     title: '關於我們',
     meta: [
       { name: 'description', content: '在過去求職的經驗中，我們發現台灣的求職資訊相當不透明。 薪資、工時的資訊經常不得而知，而實際工作內容也與當初求職網站說明的有所出入。 因此，我們決定採取行動，嘗試解決求職市場資訊不透明的問題，讓我們在找工作時，能夠做出更好的選擇。' },
-      { property: 'og:title', content: '關於我們' },
+      { property: 'og:title', content: formatTitle('關於我們', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/about') },
       { property: 'og:image', content: `${imgHost}/www/og/about.jpg` },
       { property: 'og:description', content: '在過去求職的經驗中，我們發現台灣的求職資訊相當不透明。 薪資、工時的資訊經常不得而知，而實際工作內容也與當初求職網站說明的有所出入。 因此，我們決定採取行動，嘗試解決求職市場資訊不透明的問題，讓我們在找工作時，能夠做出更好的選擇。' },
@@ -130,7 +130,7 @@ const helmetData = {
     title: '隱私權政策',
     meta: [
       { name: 'description', content: '' },
-      { property: 'og:title', content: '隱私權政策' },
+      { property: 'og:title', content: formatTitle('隱私權政策', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/privacy-policy') },
     ],
     link: [
@@ -141,7 +141,7 @@ const helmetData = {
     title: '使用者條款',
     meta: [
       { name: 'description', content: '' },
-      { property: 'og:title', content: '使用者條款' },
+      { property: 'og:title', content: formatTitle('使用者條款', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/user-term') },
     ],
     link: [
@@ -152,7 +152,7 @@ const helmetData = {
     title: '常見問答',
     meta: [
       { name: 'description', content: '' },
-      { property: 'og:title', content: '常見問答' },
+      { property: 'og:title', content: formatTitle('常見問答', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/faq') },
       { property: 'og:image', content: `${imgHost}/www/og/faq.jpg` },
     ],
@@ -164,7 +164,7 @@ const helmetData = {
     title: '發文留言規則',
     meta: [
       { name: 'description', content: '' },
-      { property: 'og:title', content: '常見問答' },
+      { property: 'og:title', content: formatTitle('發文留言規則', SITE_NAME) },
       { property: 'og:url', content: formatCanonicalPath('/guidelines') },
       { property: 'og:image', content: `${imgHost}/www/og/guidelines.jpg` },
     ],
@@ -173,5 +173,3 @@ const helmetData = {
     ],
   },
 };
-
-export default helmetData;

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -76,11 +76,11 @@ export const HELMET_DATA = {
     title: '工作經驗分享',
     meta: [
       { property: 'og:title', content: formatTitle('工作經驗分享', SITE_NAME) },
-      { property: 'og:url', content: formatCanonicalPath('/share/work-experience') },
+      { property: 'og:url', content: formatCanonicalPath('/share/work-experiences') },
       { property: 'og:image', content: `${imgHost}/www/og/share-work.jpg` },
     ],
     link: [
-      { rel: 'canonical', href: formatCanonicalPath('/share/work-experience') },
+      { rel: 'canonical', href: formatCanonicalPath('/share/work-experiences') },
     ],
   },
   EXPERIENCE_SEARCH: {
@@ -142,10 +142,10 @@ export const HELMET_DATA = {
     meta: [
       { name: 'description', content: '' },
       { property: 'og:title', content: formatTitle('使用者條款', SITE_NAME) },
-      { property: 'og:url', content: formatCanonicalPath('/user-term') },
+      { property: 'og:url', content: formatCanonicalPath('/user-terms') },
     ],
     link: [
-      { rel: 'canonical', href: formatCanonicalPath('/user-term') },
+      { rel: 'canonical', href: formatCanonicalPath('/user-terms') },
     ],
   },
   FAQ: {

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -26,20 +26,20 @@ The followings are some useful elements from Open Graph Protocol:
 
 */
 
-const siteName = 'goodjob 透明資訊求職平台';
+const siteName = 'GoodJob 好工作評論網';
 const imgHost = 'https://s3-ap-northeast-1.amazonaws.com/goodjob.life';
 const helmetData = {
   DEFAULT: {
-    title: siteName,
+    defaultTitle: siteName,
     titleTemplate: `%s | ${siteName}`,
     meta: [
-      { name: 'description', content: '分享你的工時、薪資、面試經驗以及工作經驗，讓我們一起改善求職市場不透明的問題。' },
+      { name: 'description', content: '你是否曾覺得職場資訊不夠透明？分享你的職場或面試經驗，讓我們一起改變現狀、定義理想的工作！' },
       { name: 'keywords', content: '工作時間, 薪資, 面試經驗, 工作經驗, 工作評論' },
       { property: 'og:title', content: siteName },
       { property: 'og:url', content: formatCanonicalPath('/') },
       { property: 'og:type', content: 'website' },
       { property: 'og:image', content: `${imgHost}/www/og/default.jpg` },
-      { property: 'og:description', content: '分享你的工時、薪資、面試經驗以及工作經驗，讓我們一起改善求職市場不透明的問題。' },
+      { property: 'og:description', content: '你是否曾覺得職場資訊不夠透明？分享你的職場或面試經驗，讓我們一起改變現狀、定義理想的工作！' },
       { property: 'og:locale', content: 'zh_TW' },
       { property: 'og:site_name', content: siteName },
     ],
@@ -48,18 +48,14 @@ const helmetData = {
     ],
   },
   LANDING_PAGE: {
-    title: '首頁',
-    meta: [
-    ],
+    // same as default
   },
   SHARE: {
-    title: '分享資訊',
+    title: '分享你的職場資訊',
     meta: [
-      { name: 'description', content: '' },
-      { property: 'og:title', content: '' },
+      { property: 'og:title', content: '分享你的職場資訊' },
       { property: 'og:url', content: formatCanonicalPath('/share') },
       { property: 'og:image', content: `${imgHost}/www/og/share.jpg` },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/share') },
@@ -68,11 +64,9 @@ const helmetData = {
   SHARE_INTERVIEW: {
     title: '面試經驗分享',
     meta: [
-      { name: 'description', content: '' },
       { property: 'og:title', content: '面試經驗分享' },
       { property: 'og:url', content: formatCanonicalPath('/share/interview') },
       { property: 'og:image', content: `${imgHost}/www/og/share-interview.jpg` },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/share/interview') },
@@ -81,24 +75,20 @@ const helmetData = {
   SHARE_WORK: {
     title: '工作經驗分享',
     meta: [
-      { name: 'description', content: '' },
       { property: 'og:title', content: '工作經驗分享' },
       { property: 'og:url', content: formatCanonicalPath('/share/work-experience') },
       { property: 'og:image', content: `${imgHost}/www/og/share-work.jpg` },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/share/work-experience') },
     ],
   },
   EXPERIENCE_SEARCH: {
-    title: '搜尋面試及工作經驗',
+    title: '查詢面試、工作經驗',
     meta: [
-      { name: 'description', content: '' },
-      { property: 'og:title', content: '搜尋面試及工作經驗' },
+      { property: 'og:title', content: '查詢面試、工作經驗' },
       { property: 'og:url', content: formatCanonicalPath('/experiences/search') },
       { property: 'og:image', content: `${imgHost}/www/og/experience-search.jpg` },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/experiences/search') },
@@ -110,11 +100,11 @@ const helmetData = {
   LABOR_RIGHTS_MENU: {
     title: '勞動知識小教室',
     meta: [
-      { name: 'description', content: `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。` },
+      { name: 'description', content: '我們看見勞工們的需要，推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，內容涵蓋勞動基準法、性別工作平等法、就業服務法以及工會相關法令等勞工必備的權益資訊。讓勞工認識自己的權益，學會保護自己。' },
       { property: 'og:title', content: '勞動知識小教室' },
       { property: 'og:url', content: formatCanonicalPath('/labor-rights') },
       { property: 'og:image', content: `${imgHost}/www/og/labor-rights.jpg` },
-      { property: 'og:description', content: `${siteName}，看見勞工們的需要，自 2016 年底推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，讓勞工認識自己的權益，學會保護自己。內容涵蓋勞基法、性別工作平等法、就服法以及工會相關法令等勞工必備的權益資訊。` },
+      { property: 'og:description', content: '我們看見勞工們的需要，推出【勞動知識小教室】系列懶人包，將複雜的法律資訊轉換成易懂的圖文，內容涵蓋勞動基準法、性別工作平等法、就業服務法以及工會相關法令等勞工必備的權益資訊。讓勞工認識自己的權益，學會保護自己。' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/labor-rights') },
@@ -126,11 +116,11 @@ const helmetData = {
   ABOUT: {
     title: '關於我們',
     meta: [
-      { name: 'description', content: '' },
+      { name: 'description', content: '在過去求職的經驗中，我們發現台灣的求職資訊相當不透明。 薪資、工時的資訊經常不得而知，而實際工作內容也與當初求職網站說明的有所出入。 因此，我們決定採取行動，嘗試解決求職市場資訊不透明的問題，讓我們在找工作時，能夠做出更好的選擇。' },
       { property: 'og:title', content: '關於我們' },
       { property: 'og:url', content: formatCanonicalPath('/about') },
       { property: 'og:image', content: `${imgHost}/www/og/about.jpg` },
-      { property: 'og:description', content: '' },
+      { property: 'og:description', content: '在過去求職的經驗中，我們發現台灣的求職資訊相當不透明。 薪資、工時的資訊經常不得而知，而實際工作內容也與當初求職網站說明的有所出入。 因此，我們決定採取行動，嘗試解決求職市場資訊不透明的問題，讓我們在找工作時，能夠做出更好的選擇。' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/about') },
@@ -142,7 +132,6 @@ const helmetData = {
       { name: 'description', content: '' },
       { property: 'og:title', content: '隱私權政策' },
       { property: 'og:url', content: formatCanonicalPath('/privacy-policy') },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/privacy-policy') },
@@ -154,7 +143,6 @@ const helmetData = {
       { name: 'description', content: '' },
       { property: 'og:title', content: '使用者條款' },
       { property: 'og:url', content: formatCanonicalPath('/user-term') },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/user-term') },
@@ -167,20 +155,18 @@ const helmetData = {
       { property: 'og:title', content: '常見問答' },
       { property: 'og:url', content: formatCanonicalPath('/faq') },
       { property: 'og:image', content: `${imgHost}/www/og/faq.jpg` },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/faq') },
     ],
   },
   GUIDELINES: {
-    title: '發文留言規定',
+    title: '發文留言規則',
     meta: [
       { name: 'description', content: '' },
       { property: 'og:title', content: '常見問答' },
       { property: 'og:url', content: formatCanonicalPath('/guidelines') },
       { property: 'og:image', content: `${imgHost}/www/og/guidelines.jpg` },
-      { property: 'og:description', content: '' },
     ],
     link: [
       { rel: 'canonical', href: formatCanonicalPath('/guidelines') },

--- a/src/utils/helmetHelper.js
+++ b/src/utils/helmetHelper.js
@@ -1,6 +1,4 @@
-export const siteName = '工時薪資透明化運動';
-
-export const formatTitle = title =>
+export const formatTitle = (title, siteName) =>
   `${title} | ${siteName}`;
 
 export const formatCanonicalPath = path =>

--- a/src/utils/numberUtils.js
+++ b/src/utils/numberUtils.js
@@ -1,0 +1,16 @@
+/*
+  Get the scale number of given number
+  For instance, 55 => 50, 1234 => 1000, 3456 => 3000
+  (The highest digit padding with zeros)
+*/
+const getScale = num => {
+  let base = 1;
+  let current = num;
+  while (Math.floor(current / 10) !== 0) {
+    base *= 10;
+    current = Math.floor(current / 10);
+  }
+  return current * base;
+};
+
+export default getScale;


### PR DESCRIPTION
[參考文件](https://docs.google.com/document/d/17lHw-s1b29lm6_Lc-1TYEsL2I4ptkandGakI5ejp9rs/edit#heading=h.6hzv7y45tljp)

幾個地方特別說明：
1. App 這個 component 放了 default 的 helmet。
   如此一來，如果該頁面helmet 資訊跟default的一樣，就不須特別給定。

2. `/experiences/search` 這一頁，會根據文章分享的總數，去產生description。
     做法是，先取出資料數量的最大位數，後面補0 (e.g. 123 => 100, 3456 => 3000)。
     然後生成 `馬上查詢超過 xxx 篇面試...` 的字串

3. `隱私權政策` `使用者條款` `發文留言規定` `FAQ` 這四頁比較特別，都是讓description為空字串，讓爬蟲自己爬內文，但og:description有內容，FB分享時還是會出現指定文字。

4. `experiences/:id` title & og:title 就是`文章標題`，description & og:description 是 `公司＋職稱＋經驗分享種類＋內文第一段` 組合而成的字串。這樣做的考量是，因為標題可能被使用者改掉，至少要讓公司＋職稱出現。

