### PR TITLE
Select修改placeholder

### DIFF
--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewTime.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewTime.js
@@ -67,6 +67,7 @@ const InterviewTime = (
             }}
           >
             <Select
+              placeholder="- 請選擇 -"
               options={yearMap}
               value={interviewTimeYear}
               onChange={

--- a/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/IsEmployed.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/WorkInfo/IsEmployed.js
@@ -51,6 +51,7 @@ const IsEmployed = ({
           />
           <div className={styles.selects}>
             <Select
+              placeholder="- 請選擇 -"
               options={jobEndingTimeYearOptions}
               value={jobEndingTimeYear}
               onChange={e => onJobEndingTimeYear(Number(e.target.value))}

--- a/src/components/ShareExperience/common/Education.js
+++ b/src/components/ShareExperience/common/Education.js
@@ -18,6 +18,7 @@ const Education = ({ education, onChange }) => (
       className={shareStyles.single__select__input}
     >
       <Select
+        placeholder="- 請選擇 -"
         options={educationOptions}
         value={education}
         onChange={

--- a/src/components/ShareExperience/common/ExperienceInYear.js
+++ b/src/components/ShareExperience/common/ExperienceInYear.js
@@ -27,6 +27,7 @@ const ExperienceInYear = ({ experienceInYear, onChange }) => (
         }}
       >
         <Select
+          placeholder="- 請選擇 -"
           options={experienceInYearOptions}
           value={experienceInYear}
           onChange={

--- a/src/components/ShareExperience/common/Region.js
+++ b/src/components/ShareExperience/common/Region.js
@@ -26,6 +26,7 @@ const Region = ({ region, inputTitle, onChange, validator, submitted }) => {
         }}
       >
         <Select
+          placeholder="- 請選擇 -"
           options={regionOptions}
           value={region}
           onChange={

--- a/src/components/common/form/Select.js
+++ b/src/components/common/form/Select.js
@@ -15,7 +15,9 @@ class Select extends React.PureComponent {
           value={this.props.value === null ? '' : this.props.value}
           onChange={e => this.props.onChange(e)}
         >
-          <option value={''}>{this.props.placeholder}</option>
+          {this.props.placeholder && (
+            <option value={''}>{this.props.placeholder}</option>
+          )}
           {
             this.props.options.map(option =>
               <option
@@ -66,10 +68,6 @@ Select.propTypes = {
     PropTypes.number,
   ]),
   onChange: PropTypes.func,
-};
-
-Select.defaultProps = {
-  placeholder: '- 請選擇 -',
 };
 
 export default Select;


### PR DESCRIPTION
此PR解決 #316 提到的移除切換route path的`Select`的placeholder。

![2017-10-23 9 32 29](https://user-images.githubusercontent.com/3805975/31891881-3a164ade-b83a-11e7-9500-9c01165ad6e2.png)

原本的`Select`設計是一定會有placeholder (也就是`- 請選擇 -`)，本PR移除placeholder的default value，並且只有在指定placeholder時才會產生placeholder選項。

除了薪時查詢頁面，原本使用到`Select`的地方在經驗分享的六處：
1. `Education`
2. `ExperienceInYear`
3. `Region`
4. `Salary`
5. `InterviewTime`
6. `IsEmployed`

其中，`Salary`被預設為`月薪`，我就不另外加回placeholder，其餘的都加上`placeholder="- 請選擇 -"`。