### PR TITLE
最新薪時頁面的table style

### DIFF
--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -1,0 +1,25 @@
+.latestTable {
+  background-color: #fff;
+  .colCompany {
+    width: 25%;
+  }
+  .colPosition {
+    width: 21%;
+  }
+  .colWeekTime {
+    width: 10%;
+  }
+  .colFrequency {
+    width: 10%;
+  }
+  .colSalary {
+    width: 14%;
+  }
+  .colHourly {
+    width: 12%;
+  }
+  .colDataTime {
+    width: 10%;
+  }
+}
+

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -8,7 +8,8 @@ import Table from 'common/table/Table';
 import { InfoButton } from 'common/Modal';
 import InfoTimeModal from '../common/InfoTimeModal';
 import InfoSalaryModal from '../common/InfoSalaryModal';
-import styles from '../views/view.module.css';
+import styles from './TimeAndSalaryBoard.module.css';
+import commonStyles from '../views/view.module.css';
 import fetchingStatus from '../../../constants/status';
 
 const pathnameMapping = {
@@ -64,14 +65,14 @@ const getTitle = (val, row) => (
   <div>
     {val}
     {' '}
-    <span className={`pM ${styles.sector}`}>
+    <span className={`pM ${commonStyles.sector}`}>
       {row.sector}
     </span>
   </div>
 );
 const getWorkingTime = val => (
   <div
-    className={styles.bar}
+    className={commonStyles.bar}
     style={{ width: `${val >= 100 ? 100 : val}%` }}
   >
     {val}
@@ -83,27 +84,27 @@ const getFrequency = val => {
   switch (val) {
     case 0:
       text = '幾乎不';
-      style = styles.hardly;
+      style = commonStyles.hardly;
       break;
     case 1:
       text = '偶爾';
-      style = styles.sometimes;
+      style = commonStyles.sometimes;
       break;
     case 2:
       text = '經常';
-      style = styles.usually;
+      style = commonStyles.usually;
       break;
     case 3:
       text = '幾乎每天';
-      style = styles.always;
+      style = commonStyles.always;
       break;
     default:
       text = '幾乎不';
-      style = styles.hardly;
+      style = commonStyles.hardly;
   }
   return (
     <div>
-      <div className={`${styles.dot} ${style}`} />
+      <div className={`${commonStyles.dot} ${style}`} />
       {text}
     </div>
   );
@@ -199,12 +200,12 @@ export default class TimeAndSalaryBoard extends Component {
     const { status, switchPath } = this.props;
 
     return (
-      <section className={styles.searchResult}>
-        <h2 className={styles.heading}>{title}</h2>
-        <div className={styles.result}>
-          <div className={styles.sort}>
-            <div className={styles.label}> 排序：</div>
-            <div className={styles.select}>
+      <section className={commonStyles.searchResult}>
+        <h2 className={commonStyles.heading}>{title}</h2>
+        <div className={commonStyles.result}>
+          <div className={commonStyles.sort}>
+            <div className={commonStyles.label}> 排序：</div>
+            <div className={commonStyles.select}>
               <Select
                 options={selectOptions(pathnameMapping)}
                 onChange={e => switchPath(e.target.value)}
@@ -212,7 +213,7 @@ export default class TimeAndSalaryBoard extends Component {
               />
             </div>
           </div>
-          <Table className={styles.companyTable} data={raw} primaryKey="_id">
+          <Table className={styles.latestTable} data={raw} primaryKey="_id">
             <Table.Column
               className={styles.colCompany}
               title="公司名稱"

--- a/src/components/TimeAndSalary/common/WorkingHourTable.js
+++ b/src/components/TimeAndSalary/common/WorkingHourTable.js
@@ -5,7 +5,7 @@ import Table from 'common/table/Table';
 import InfoSalaryModal from './InfoSalaryModal';
 import InfoTimeModal from './InfoTimeModal';
 import styles from './WorkingHourTable.module.css';
-import colStyles from '../views/view.module.css';
+import commonStyles from '../views/view.module.css';
 import employmentType from '../../../constants/employmentType';
 
 class WorkingHourTable extends Component {
@@ -16,7 +16,7 @@ class WorkingHourTable extends Component {
     <div>
       {val}
       {' '}
-      <span className={`pM ${colStyles.sector}`}>
+      <span className={`pM ${commonStyles.sector}`}>
         {row.sector}
       </span>
     </div>
@@ -27,7 +27,7 @@ class WorkingHourTable extends Component {
   )
   static getWorkingTime = val => (
     <div
-      className={colStyles.bar}
+      className={commonStyles.bar}
       style={{ width: `${val >= 100 ? 100 : val}%` }}
     >
       {val}
@@ -39,27 +39,27 @@ class WorkingHourTable extends Component {
     switch (val) {
       case 0:
         text = '幾乎不';
-        style = colStyles.hardly;
+        style = commonStyles.hardly;
         break;
       case 1:
         text = '偶爾';
-        style = colStyles.sometimes;
+        style = commonStyles.sometimes;
         break;
       case 2:
         text = '經常';
-        style = colStyles.usually;
+        style = commonStyles.usually;
         break;
       case 3:
         text = '幾乎每天';
-        style = colStyles.always;
+        style = commonStyles.always;
         break;
       default:
         text = '幾乎不';
-        style = colStyles.hardly;
+        style = commonStyles.hardly;
     }
     return (
       <div>
-        <div className={`${colStyles.dot} ${style}`} />
+        <div className={`${commonStyles.dot} ${style}`} />
         {text}
       </div>
     );

--- a/src/components/TimeAndSalary/common/WorkingHourTable.js
+++ b/src/components/TimeAndSalary/common/WorkingHourTable.js
@@ -5,6 +5,7 @@ import Table from 'common/table/Table';
 import InfoSalaryModal from './InfoSalaryModal';
 import InfoTimeModal from './InfoTimeModal';
 import styles from './WorkingHourTable.module.css';
+import colStyles from '../views/view.module.css';
 import employmentType from '../../../constants/employmentType';
 
 class WorkingHourTable extends Component {
@@ -15,7 +16,7 @@ class WorkingHourTable extends Component {
     <div>
       {val}
       {' '}
-      <span className={`pM ${styles.sector}`}>
+      <span className={`pM ${colStyles.sector}`}>
         {row.sector}
       </span>
     </div>
@@ -26,7 +27,7 @@ class WorkingHourTable extends Component {
   )
   static getWorkingTime = val => (
     <div
-      className={styles.bar}
+      className={colStyles.bar}
       style={{ width: `${val >= 100 ? 100 : val}%` }}
     >
       {val}
@@ -38,27 +39,27 @@ class WorkingHourTable extends Component {
     switch (val) {
       case 0:
         text = '幾乎不';
-        style = styles.hardly;
+        style = colStyles.hardly;
         break;
       case 1:
         text = '偶爾';
-        style = styles.sometimes;
+        style = colStyles.sometimes;
         break;
       case 2:
         text = '經常';
-        style = styles.usually;
+        style = colStyles.usually;
         break;
       case 3:
         text = '幾乎每天';
-        style = styles.always;
+        style = colStyles.always;
         break;
       default:
         text = '幾乎不';
-        style = styles.hardly;
+        style = colStyles.hardly;
     }
     return (
       <div>
-        <div className={`${styles.dot} ${style}`} />
+        <div className={`${colStyles.dot} ${style}`} />
         {text}
       </div>
     );

--- a/src/components/TimeAndSalary/common/WorkingHourTable.module.css
+++ b/src/components/TimeAndSalary/common/WorkingHourTable.module.css
@@ -1,31 +1,3 @@
-@value yellow-bar, gray-dark, main-gray, main-yellow, warning-red from "../../common/variables.module.css";
-
-.bar {
-  background-color: yellow-bar;
-  padding: 5px;
-}
-.dot {
-  display: inline-block;
-  border-radius: 50%;
-  width: 10px;
-  height: 10px;
-  margin-right: 10px;
-  &.hardly {
-    background-color: main-gray;
-  }
-  &.sometimes {
-    background-color: gray-dark;
-  }
-  &.usually {
-    background-color: main-yellow;
-  }
-  &.always {
-    background-color: warning-red;
-  }
-}
-.sector {
-  color: main-gray;
-}
 .companyTable {
   .colPosition,
   .colCompany {

--- a/src/components/TimeAndSalary/views/view.module.css
+++ b/src/components/TimeAndSalary/views/view.module.css
@@ -1,3 +1,4 @@
+@value yellow-bar, gray-dark, main-gray, main-yellow, warning-red from "../../common/variables.module.css";
 $below-mobile: 550px;
 $below-small: 850px;
 $above-desktop: 1025px;
@@ -92,4 +93,33 @@ $bold: 700;
   @media (max-width: $below-mobile) {
     margin-bottom: $block-gutter-s;
   }
+}
+
+.bar {
+  background-color: yellow-bar;
+  padding: 5px;
+}
+
+.dot {
+  display: inline-block;
+  border-radius: 50%;
+  width: 10px;
+  height: 10px;
+  margin-right: 10px;
+  &.hardly {
+    background-color: main-gray;
+  }
+  &.sometimes {
+    background-color: gray-dark;
+  }
+  &.usually {
+    background-color: main-yellow;
+  }
+  &.always {
+    background-color: warning-red;
+  }
+}
+
+.sector {
+  color: main-gray;
 }


### PR DESCRIPTION
#316 

為了重覆利用`common/WorkTimeTable`已寫好的table style，本PR將`common/WorkTimeTable`的style拆成兩部份：

1. 共用的style，如`.bar`、`.dot`等等
2. 個別頁面的style，如只有`common/WorkTimeTable`才會用到的`.companyTable`不同column的欄寬等等

然後便可以調整`TimeAndSalaryBoard`的style為：

1. 使用共用style
2. 唯`TimeAndSalaryBoard`才會使用的`.latestTable`

目前是把`1.`的共用styles移往`views/view.module.css`，因為`views/view`是目前TimeAndSalary每一頁必引入的共用style。