### PR TITLE
薪時查詢頁面 - Select 跳轉 與參數改寫

### DIFF
--- a/src/actions/timeAndSalaryCompany.js
+++ b/src/actions/timeAndSalaryCompany.js
@@ -6,9 +6,9 @@ import fetchingStatus from '../constants/status';
 export const SET_COMPANY_DATA = '@@timeAndSalaryCompany/SET_COMPANY_DATA';
 export const SET_COMPANY_STATUS = '@@timeAndSalaryCompany/SET_COMPANY_STATUS';
 
-export const setCompanyData = (status, sortBy, order, company, data, error) => ({
+export const setCompanyData = (status, groupSortBy, order, company, data, error) => ({
   type: SET_COMPANY_DATA,
-  sortBy,
+  groupSortBy,
   order,
   company,
   status,
@@ -16,10 +16,10 @@ export const setCompanyData = (status, sortBy, order, company, data, error) => (
   error,
 });
 
-export const queryCompany = ({ sortBy, order, company }) =>
+export const queryCompany = ({ groupSortBy, order, company }) =>
   (dispatch, getState) => {
-    if (sortBy !== getState().timeAndSalaryCompany.get('sortBy') || order !== getState().timeAndSalaryCompany.get('order') || company !== getState().timeAndSalaryCompany.get('company')) {
-      dispatch(setCompanyData(fetchingStatus.UNFETCHED, sortBy, order, company, [], null));
+    if (groupSortBy !== getState().timeAndSalaryCompany.get('groupSortBy') || order !== getState().timeAndSalaryCompany.get('order') || company !== getState().timeAndSalaryCompany.get('company')) {
+      dispatch(setCompanyData(fetchingStatus.UNFETCHED, groupSortBy, order, company, [], null));
     }
 
     if (getState().timeAndSalaryCompany.get('status') === fetchingStatus.FETCHING) {
@@ -33,14 +33,14 @@ export const queryCompany = ({ sortBy, order, company }) =>
 
     const opt = {
       company,
-      group_sort_by: sortBy,
+      group_sort_by: groupSortBy,
       group_sort_order: order,
     };
 
     return fetchSearchCompany(opt).then(data => {
-      dispatch(setCompanyData(fetchingStatus.FETCHED, sortBy, order, company, data, null));
+      dispatch(setCompanyData(fetchingStatus.FETCHED, groupSortBy, order, company, data, null));
     }).catch(err => {
-      dispatch(setCompanyData(fetchingStatus.ERROR, sortBy, order, company, [], err));
+      dispatch(setCompanyData(fetchingStatus.ERROR, groupSortBy, order, company, [], err));
     });
   };
 

--- a/src/actions/timeAndSalaryCompany.js
+++ b/src/actions/timeAndSalaryCompany.js
@@ -1,3 +1,5 @@
+import { push } from 'react-router-redux';
+
 import { fetchSearchCompany } from '../apis/timeAndSalaryApi';
 import fetchingStatus from '../constants/status';
 
@@ -41,3 +43,7 @@ export const queryCompany = ({ sortBy, order, company }) =>
       dispatch(setCompanyData(fetchingStatus.ERROR, sortBy, order, company, [], err));
     });
   };
+
+export const switchPath = path =>
+  dispatch =>
+    dispatch(push(`/time-and-salary/${path}`));

--- a/src/actions/timeAndSalaryJobTitle.js
+++ b/src/actions/timeAndSalaryJobTitle.js
@@ -6,9 +6,9 @@ import fetchingStatus from '../constants/status';
 export const SET_JOB_TITLE_DATA = '@@timeAndSalaryJobTitle/SET_JOB_TITLE_DATA';
 export const SET_JOB_TITLE_STATUS = '@@timeAndSalaryJobTitle/SET_JOB_TITLE_STATUS';
 
-export const setJobTitleData = (status, sortBy, order, jobTitle, data, error) => ({
+export const setJobTitleData = (status, groupSortBy, order, jobTitle, data, error) => ({
   type: SET_JOB_TITLE_DATA,
-  sortBy,
+  groupSortBy,
   order,
   jobTitle,
   status,
@@ -16,10 +16,14 @@ export const setJobTitleData = (status, sortBy, order, jobTitle, data, error) =>
   error,
 });
 
-export const queryJobTitle = ({ sortBy, order, jobTitle }) =>
+export const queryJobTitle = ({ groupSortBy, order, jobTitle }) =>
   (dispatch, getState) => {
-    if (sortBy !== getState().timeAndSalaryJobTitle.get('sortBy') || order !== getState().timeAndSalaryJobTitle.get('order') || jobTitle !== getState().timeAndSalaryJobTitle.get('jobTitle')) {
-      dispatch(setJobTitleData(fetchingStatus.UNFETCHED, sortBy, order, jobTitle, [], null));
+    if (
+      groupSortBy !== getState().timeAndSalaryJobTitle.get('groupSortBy') ||
+      order !== getState().timeAndSalaryJobTitle.get('order') ||
+      jobTitle !== getState().timeAndSalaryJobTitle.get('jobTitle')
+    ) {
+      dispatch(setJobTitleData(fetchingStatus.UNFETCHED, groupSortBy, order, jobTitle, [], null));
     }
 
     if (getState().timeAndSalaryJobTitle.get('status') === fetchingStatus.FETCHING) {
@@ -33,14 +37,14 @@ export const queryJobTitle = ({ sortBy, order, jobTitle }) =>
 
     const opt = {
       job_title: jobTitle,
-      group_sort_by: sortBy,
+      group_sort_by: groupSortBy,
       group_sort_order: order,
     };
 
     return fetchSearchJobTitle(opt).then(data => {
-      dispatch(setJobTitleData(fetchingStatus.FETCHED, sortBy, order, jobTitle, data, null));
+      dispatch(setJobTitleData(fetchingStatus.FETCHED, groupSortBy, order, jobTitle, data, null));
     }).catch(err => {
-      dispatch(setJobTitleData(fetchingStatus.ERROR, sortBy, order, jobTitle, [], err));
+      dispatch(setJobTitleData(fetchingStatus.ERROR, groupSortBy, order, jobTitle, [], err));
     });
   };
 

--- a/src/actions/timeAndSalaryJobTitle.js
+++ b/src/actions/timeAndSalaryJobTitle.js
@@ -1,3 +1,5 @@
+import { push } from 'react-router-redux';
+
 import { fetchSearchJobTitle } from '../apis/timeAndSalaryApi';
 import fetchingStatus from '../constants/status';
 
@@ -41,3 +43,7 @@ export const queryJobTitle = ({ sortBy, order, jobTitle }) =>
       dispatch(setJobTitleData(fetchingStatus.ERROR, sortBy, order, jobTitle, [], err));
     });
   };
+
+export const switchPath = path =>
+  dispatch =>
+    dispatch(push(`/time-and-salary/${path}`));

--- a/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
@@ -12,34 +12,26 @@ const pathnameMapping = {
   'company/:keyword/work-time-dashboard': {
     title: '工時排行榜',
     label: '一週平均總工時（高到低）',
-    viewParams: {
-      groupSortBy: 'week_work_time',
-      order: 'descending',
-    },
+    groupSortBy: 'week_work_time',
+    order: 'descending',
   },
   'company/:keyword/sort/work-time-asc': {
     title: '工時排行榜（由低到高）',
     label: '一週平均總工時（低到高）',
-    viewParams: {
-      groupSortBy: 'week_work_time',
-      order: 'ascending',
-    },
+    groupSortBy: 'week_work_time',
+    order: 'ascending',
   },
   'company/:keyword/salary-dashboard': {
     title: '估算時薪排行榜',
     label: '估算時薪（高到低）',
-    viewParams: {
-      groupSortBy: 'estimated_hourly_wage',
-      order: 'descending',
-    },
+    groupSortBy: 'estimated_hourly_wage',
+    order: 'descending',
   },
   'company/:keyword/sort/salary-asc': {
     title: '估算時薪排行榜（由低到高）',
     label: '估算時薪（低到高）',
-    viewParams: {
-      groupSortBy: 'estimated_hourly_wage',
-      order: 'ascending',
-    },
+    groupSortBy: 'estimated_hourly_wage',
+    order: 'ascending',
   },
 };
 
@@ -59,23 +51,23 @@ export default class TimeAndSalaryCompany extends Component {
 
   componentDidMount() {
     const { path } = this.props.route;
-    const { viewParams: { sortBy, order } } = pathnameMapping[path];
+    const { groupSortBy, order } = pathnameMapping[path];
     const company = this.props.params.keyword;
-    this.props.queryCompany({ sortBy, order, company });
+    this.props.queryCompany({ groupSortBy, order, company });
   }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.route.path !== nextProps.route.path || this.props.params.keyword !== nextProps.params.keyword) {
       const { path } = nextProps.route;
-      const { viewParams: { sortBy, order } } = pathnameMapping[path];
+      const { groupSortBy, order } = pathnameMapping[path];
       const company = nextProps.params.keyword;
-      this.props.queryCompany({ sortBy, order, company });
+      this.props.queryCompany({ groupSortBy, order, company });
     }
   }
 
   render() {
     const { route: { path }, switchPath } = this.props;
-    const { viewParams: { groupSortBy } } = pathnameMapping[path];
+    const { groupSortBy } = pathnameMapping[path];
     const company = this.props.params.keyword;
     const raw = this.props.data.toJS();
 

--- a/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
@@ -1,9 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 // import { push } from 'react-router-redux';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import R from 'ramda';
 
+import Select from 'common/form/Select';
 import WorkingHourBlock from '../common/WorkingHourBlock';
-// import Select from 'common/form/Select';
 
 import styles from '../views/view.module.css';
 
@@ -42,12 +43,18 @@ const pathnameMapping = {
   },
 };
 
+const selectOptions = R.pipe(
+  R.toPairs,
+  R.map(([path, { label }]) => ({ value: path, label }))
+);
+
 export default class TimeAndSalaryCompany extends Component {
   static propTypes = {
     data: ImmutablePropTypes.list,
     route: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
     queryCompany: PropTypes.func,
+    switchPath: PropTypes.func,
   }
 
   componentDidMount() {
@@ -67,10 +74,14 @@ export default class TimeAndSalaryCompany extends Component {
   }
 
   render() {
-    const { path } = this.props.route;
+    const { route: { path }, switchPath } = this.props;
     const { viewParams: { groupSortBy } } = pathnameMapping[path];
     const company = this.props.params.keyword;
     const raw = this.props.data.toJS();
+
+    const substituteKeyword =
+      R.invoker(2, 'replace')(/:keyword/, company);
+
     return (
       <section className={styles.searchResult}>
         <h2 className={styles.heading}>搜尋 “{company}” 的薪時資訊</h2>
@@ -78,11 +89,11 @@ export default class TimeAndSalaryCompany extends Component {
           <div className={styles.sort}>
             <div className={styles.label}> 排序：</div>
             <div className={styles.select}>
-              { /* <Select
-                options={pathOptions.map(({ path: value, label }) => ({ value, label }))}
+              <Select
+                options={selectOptions(pathnameMapping)}
                 value={path}
-                onChange={e => push(`/time-and-salary/${e.target.value.replace(':keyword', encodeURIComponent(keyword))}`)}
-              />*/ }
+                onChange={e => switchPath(substituteKeyword(e.target.value))}
+              />
             </div>
           </div>
         </div>

--- a/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
@@ -72,7 +72,7 @@ export default class TimeAndSalaryCompany extends Component {
     const raw = this.props.data.toJS();
 
     const substituteKeyword =
-      R.invoker(2, 'replace')(/:keyword/, company);
+      R.invoker(2, 'replace')(/:keyword/, encodeURIComponent(company));
 
     return (
       <section className={styles.searchResult}>

--- a/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
@@ -1,9 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 // import { push } from 'react-router-redux';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import R from 'ramda';
 
+import Select from 'common/form/Select';
 import WorkingHourBlock from '../common/WorkingHourBlock';
-// import Select from 'common/form/Select';
 
 import styles from '../views/view.module.css';
 
@@ -42,12 +43,18 @@ const pathnameMapping = {
   },
 };
 
+const selectOptions = R.pipe(
+  R.toPairs,
+  R.map(([path, { label }]) => ({ value: path, label }))
+);
+
 export default class TimeAndSalaryJobTitle extends Component {
   static propTypes = {
     data: ImmutablePropTypes.list,
     route: PropTypes.object.isRequired,
     params: PropTypes.object.isRequired,
     queryJobTitle: PropTypes.func,
+    switchPath: PropTypes.func,
   }
 
   componentDidMount() {
@@ -67,10 +74,14 @@ export default class TimeAndSalaryJobTitle extends Component {
   }
 
   render() {
-    const { path } = this.props.route;
+    const { route: { path }, switchPath } = this.props;
     const { title, viewParams: { groupSortBy } } = pathnameMapping[path];
     const jobTitle = this.props.params.keyword;
     const raw = this.props.data.toJS();
+
+    const substituteKeyword =
+      R.invoker(2, 'replace')(/:keyword/, jobTitle);
+
     return (
       <section className={styles.searchResult}>
         <h2 className={styles.heading}>“{jobTitle}” 的 {title}</h2>
@@ -78,11 +89,11 @@ export default class TimeAndSalaryJobTitle extends Component {
           <div className={styles.sort}>
             <div className={styles.label}> 排序：</div>
             <div className={styles.select}>
-              { /* <Select
-                options={pathOptions.map(({ path: value, label }) => ({ value, label }))}
+              <Select
+                options={selectOptions(pathnameMapping)}
                 value={path}
-                onChange={e => push(`/time-and-salary/${e.target.value.replace(':keyword', encodeURIComponent(keyword))}`)}
-              />*/ }
+                onChange={e => switchPath(substituteKeyword(e.target.value, jobTitle))}
+              />
             </div>
           </div>
         </div>

--- a/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
@@ -12,34 +12,26 @@ const pathnameMapping = {
   'job-title/:keyword/work-time-dashboard': {
     title: '工時排行榜',
     label: '一週平均總工時（高到低）',
-    viewParams: {
-      groupSortBy: 'week_work_time',
-      order: 'descending',
-    },
+    groupSortBy: 'week_work_time',
+    order: 'descending',
   },
   'job-title/:keyword/sort/work-time-asc': {
     title: '工時排行榜（由低到高）',
     label: '一週平均總工時（低到高）',
-    viewParams: {
-      groupSortBy: 'week_work_time',
-      order: 'ascending',
-    },
+    groupSortBy: 'week_work_time',
+    order: 'ascending',
   },
   'job-title/:keyword/salary-dashboard': {
     title: '估算時薪排行榜',
     label: '估算時薪（高到低）',
-    viewParams: {
-      groupSortBy: 'estimated_hourly_wage',
-      order: 'descending',
-    },
+    groupSortBy: 'estimated_hourly_wage',
+    order: 'descending',
   },
   'job-title/:keyword/sort/salary-asc': {
     title: '估算時薪排行榜（由低到高）',
     label: '估算時薪（低到高）',
-    viewParams: {
-      groupSortBy: 'estimated_hourly_wage',
-      order: 'ascending',
-    },
+    groupSortBy: 'estimated_hourly_wage',
+    order: 'ascending',
   },
 };
 
@@ -59,23 +51,23 @@ export default class TimeAndSalaryJobTitle extends Component {
 
   componentDidMount() {
     const { path } = this.props.route;
-    const { viewParams: { sortBy, order } } = pathnameMapping[path];
+    const { groupSortBy, order } = pathnameMapping[path];
     const jobTitle = this.props.params.keyword;
-    this.props.queryJobTitle({ sortBy, order, jobTitle });
+    this.props.queryJobTitle({ groupSortBy, order, jobTitle });
   }
 
   componentWillReceiveProps(nextProps) {
     if (this.props.route.path !== nextProps.route.path || this.props.params.keyword !== nextProps.params.keyword) {
       const { path } = nextProps.route;
-      const { viewParams: { sortBy, order } } = pathnameMapping[path];
+      const { groupSortBy, order } = pathnameMapping[path];
       const jobTitle = nextProps.params.keyword;
-      this.props.queryJobTitle({ sortBy, order, jobTitle });
+      this.props.queryJobTitle({ groupSortBy, order, jobTitle });
     }
   }
 
   render() {
     const { route: { path }, switchPath } = this.props;
-    const { title, viewParams: { groupSortBy } } = pathnameMapping[path];
+    const { title, groupSortBy } = pathnameMapping[path];
     const jobTitle = this.props.params.keyword;
     const raw = this.props.data.toJS();
 

--- a/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
@@ -72,7 +72,7 @@ export default class TimeAndSalaryJobTitle extends Component {
     const raw = this.props.data.toJS();
 
     const substituteKeyword =
-      R.invoker(2, 'replace')(/:keyword/, jobTitle);
+      R.invoker(2, 'replace')(/:keyword/, encodeURIComponent(jobTitle));
 
     return (
       <section className={styles.searchResult}>

--- a/src/containers/TimeAndSalary/TimeAndSalaryCompany.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryCompany.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryCompany from '../../components/TimeAndSalary/TimeAndSalaryCompany';
-import { queryCompany } from '../../actions/timeAndSalaryCompany';
+import { queryCompany, switchPath } from '../../actions/timeAndSalaryCompany';
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryCompany.get('data'),
@@ -9,6 +9,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryCompany }, dispatch);
+  bindActionCreators({ queryCompany, switchPath }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryCompany);

--- a/src/containers/TimeAndSalary/TimeAndSalaryJobTitle.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryJobTitle.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryJobTitle from '../../components/TimeAndSalary/TimeAndSalaryJobTitle';
-import { queryJobTitle } from '../../actions/timeAndSalaryJobTitle';
+import { queryJobTitle, switchPath } from '../../actions/timeAndSalaryJobTitle';
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryJobTitle.get('data'),
@@ -9,6 +9,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryJobTitle }, dispatch);
+  bindActionCreators({ queryJobTitle, switchPath }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryJobTitle);

--- a/src/reducers/timeAndSalaryBoard.js
+++ b/src/reducers/timeAndSalaryBoard.js
@@ -5,7 +5,7 @@ import { SET_BOARD_DATA, SET_BOARD_STATUS } from '../actions/timeAndSalaryBoard'
 import fetchingStatus from '../constants/status';
 
 const preloadedState = fromJS({
-  sortBy: null,
+  soryBy: null,
   order: null,
   data: [],
   status: fetchingStatus.UNFETCHED,

--- a/src/reducers/timeAndSalaryBoard.js
+++ b/src/reducers/timeAndSalaryBoard.js
@@ -5,7 +5,7 @@ import { SET_BOARD_DATA, SET_BOARD_STATUS } from '../actions/timeAndSalaryBoard'
 import fetchingStatus from '../constants/status';
 
 const preloadedState = fromJS({
-  soryBy: null,
+  sortBy: null,
   order: null,
   data: [],
   status: fetchingStatus.UNFETCHED,

--- a/src/reducers/timeAndSalaryCompany.js
+++ b/src/reducers/timeAndSalaryCompany.js
@@ -5,7 +5,7 @@ import { SET_COMPANY_DATA, SET_COMPANY_STATUS } from '../actions/timeAndSalaryCo
 import fetchingStatus from '../constants/status';
 
 const preloadedState = fromJS({
-  soryBy: null,
+  groupSortBy: null,
   order: null,
   company: null,
   data: [],
@@ -14,12 +14,12 @@ const preloadedState = fromJS({
 });
 
 export default createReducer(preloadedState, {
-  [SET_COMPANY_DATA]: (state, { sortBy, order, company, data, status, error }) =>
+  [SET_COMPANY_DATA]: (state, { groupSortBy, order, company, data, status, error }) =>
     state
       .set('data', fromJS(data))
       .set('status', status)
       .set('error', error)
-      .set('sortBy', sortBy)
+      .set('groupSortBy', groupSortBy)
       .set('order', order)
       .set('company', company),
   [SET_COMPANY_STATUS]: (state, { status }) =>

--- a/src/reducers/timeAndSalaryJobTitle.js
+++ b/src/reducers/timeAndSalaryJobTitle.js
@@ -14,14 +14,14 @@ const preloadedState = fromJS({
 });
 
 export default createReducer(preloadedState, {
-  [SET_JOB_TITLE_DATA]: (state, { sortBy, order, job_title, data, status, error }) =>
+  [SET_JOB_TITLE_DATA]: (state, { sortBy, order, jobTitle, data, status, error }) =>
     state
       .set('data', fromJS(data))
       .set('status', status)
       .set('error', error)
       .set('sortBy', sortBy)
       .set('order', order)
-      .set('job_title', job_title),
+      .set('job_title', jobTitle),
   [SET_JOB_TITLE_STATUS]: (state, { status }) =>
     state.set('status', status),
 });

--- a/src/reducers/timeAndSalaryJobTitle.js
+++ b/src/reducers/timeAndSalaryJobTitle.js
@@ -5,7 +5,7 @@ import { SET_JOB_TITLE_DATA, SET_JOB_TITLE_STATUS } from '../actions/timeAndSala
 import fetchingStatus from '../constants/status';
 
 const preloadedState = fromJS({
-  soryBy: null,
+  sortBy: null,
   order: null,
   job_title: null,
   data: [],

--- a/src/reducers/timeAndSalaryJobTitle.js
+++ b/src/reducers/timeAndSalaryJobTitle.js
@@ -5,23 +5,23 @@ import { SET_JOB_TITLE_DATA, SET_JOB_TITLE_STATUS } from '../actions/timeAndSala
 import fetchingStatus from '../constants/status';
 
 const preloadedState = fromJS({
-  sortBy: null,
+  groupSortBy: null,
   order: null,
-  job_title: null,
+  jobTitle: null,
   data: [],
   status: fetchingStatus.UNFETCHED,
   error: null,
 });
 
 export default createReducer(preloadedState, {
-  [SET_JOB_TITLE_DATA]: (state, { sortBy, order, jobTitle, data, status, error }) =>
+  [SET_JOB_TITLE_DATA]: (state, { groupSortBy, order, jobTitle, data, status, error }) =>
     state
       .set('data', fromJS(data))
       .set('status', status)
       .set('error', error)
-      .set('sortBy', sortBy)
+      .set('groupSortBy', groupSortBy)
       .set('order', order)
-      .set('job_title', jobTitle),
+      .set('jobTitle', jobTitle),
   [SET_JOB_TITLE_STATUS]: (state, { status }) =>
     state.set('status', status),
 });


### PR DESCRIPTION
#316 

本PR做了以下事情：

1. `TimeAnsSalary{Company, JobTitle}`的Select onChange觸發`swtichPath`跳轉
2. 把`TimeAndSalary{Company, JobTitle}`中`pathnameMapping`的`{viewParams: { sortBy/groupSortBy, order }}`一律統一改寫為`{ groupSortBy, order }`，減少物件的深度，並保持參數原本的命名意義