### PR TITLE
Select元件的placeholder修訂名稱為nullOption並增加參數

### DIFF
--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -209,6 +209,7 @@ export default class TimeAndSalaryBoard extends Component {
                 options={selectOptions(pathnameMapping)}
                 onChange={e => switchPath(e.target.value)}
                 value={path}
+                hasNullOption={false}
               />
             </div>
           </div>

--- a/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
@@ -85,6 +85,7 @@ export default class TimeAndSalaryCompany extends Component {
                 options={selectOptions(pathnameMapping)}
                 value={path}
                 onChange={e => switchPath(substituteKeyword(e.target.value))}
+                hasNullOption={false}
               />
             </div>
           </div>

--- a/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
@@ -85,6 +85,7 @@ export default class TimeAndSalaryJobTitle extends Component {
                 options={selectOptions(pathnameMapping)}
                 value={path}
                 onChange={e => switchPath(substituteKeyword(e.target.value, jobTitle))}
+                hasNullOption={false}
               />
             </div>
           </div>

--- a/src/components/common/form/Select.js
+++ b/src/components/common/form/Select.js
@@ -15,7 +15,9 @@ class Select extends React.PureComponent {
           value={this.props.value === null ? '' : this.props.value}
           onChange={e => this.props.onChange(e)}
         >
-          <option value={''}>{this.props.placeholder}</option>
+          {this.props.hasNullOption && (
+            <option value={''}>{this.props.nullOptionText}</option>
+          )}
           {
             this.props.options.map(option =>
               <option
@@ -61,15 +63,14 @@ Select.propTypes = {
     PropTypes.string,
     PropTypes.number,
   ]),
-  placeholder: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
+  hasNullOption: PropTypes.bool,
+  nullOptionText: PropTypes.string,
   onChange: PropTypes.func,
 };
 
 Select.defaultProps = {
-  placeholder: '- 請選擇 -',
+  hasNullOption: true,
+  nullOptionText: '- 請選擇 -',
 };
 
 export default Select;


### PR DESCRIPTION
此PR解決 #316 提到的移除切換route path的Select的placeholder。（討論串：#330 ）

![2017-10-23 9 32 29](https://user-images.githubusercontent.com/3805975/31891881-3a164ade-b83a-11e7-9500-9c01165ad6e2.png)

本PR將placeholder修正名稱為nullOption（空選項）並增加兩個相對應的參數：

- `hasNullOption`: 預設`true`
- `nullOptionText`: 預設為`- 請選擇 -`

`TimeAndSalary`所用到的`Select`指定`hasNullOption=false`