### PR TITLE
Update: 薪時查詢極端值

### DIFF
--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -109,7 +109,8 @@ const setBoardExtremeData = ({ sortBy, order }, { extremeStatus, extremeData, ex
 
 export const queryExtremeTimeAndSalary = () =>
   (dispatch, getState) => {
-    if (sortBySelector(getState()) !== 'created_at') {
+    // extreme data only available for data sorted by estimated_hourly_wage and week_work_time
+    if (sortBySelector(getState()) !== 'estimated_hourly_wage' && sortBySelector(getState()) !== 'week_work_time') {
       return Promise.resolve();
     }
     if (extremeStatusSelector(getState()) === fetchingStatus.FETCHED) {

--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -146,7 +146,7 @@ export const queryExtremeTimeAndSalary = () =>
 
         dispatch(setBoardExtremeData({ sortBy, order }, { extremeStatus: fetchingStatus.FETCHED, extremeData }));
       })
-      .catch(error => {
-        dispatch(setBoardExtremeData({ sortBy, order }, { extremeStatus: fetchingStatus.ERROR, extremeData: [], error }));
+      .catch(extremeError => {
+        dispatch(setBoardExtremeData({ sortBy, order }, { extremeStatus: fetchingStatus.ERROR, extremeData: [], extremeError }));
       });
   };

--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -93,6 +93,13 @@ export const switchPath = path =>
   dispatch =>
     dispatch(push(`/time-and-salary/${path}`));
 
+export const resetBoardExtremeData = () => ({
+  type: SET_BOARD_EXTREME_DATA,
+  extremeStatus: fetchingStatus.UNFETCHED,
+  extremeData: [],
+  extremeError: null,
+});
+
 const setBoardExtremeData = ({ sortBy, order }, { extremeStatus, extremeData, extremeError = null }) =>
   (dispatch, getState) => {
     // make sure the store is consistent

--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -13,6 +13,7 @@ const sortBySelector = state => state.timeAndSalaryBoard.get('sortBy');
 const orderSelector = state => state.timeAndSalaryBoard.get('order');
 const dataSelector = state => state.timeAndSalaryBoard.get('data');
 const statusSelector = state => state.timeAndSalaryBoard.get('status');
+const extremeStatusSelector = state => state.timeAndSalaryBoard.get('extremeStatus');
 
 const resetBoard = ({ sortBy, order }) => ({
   type: SET_BOARD_DATA,
@@ -109,6 +110,9 @@ const setBoardExtremeData = ({ sortBy, order }, { extremeStatus, extremeData, ex
 export const queryExtremeTimeAndSalary = () =>
   (dispatch, getState) => {
     if (sortBySelector(getState()) !== 'created_at') {
+      return Promise.resolve();
+    }
+    if (extremeStatusSelector(getState()) === fetchingStatus.FETCHED) {
       return Promise.resolve();
     }
     dispatch({

--- a/src/apis/timeAndSalaryApi.js
+++ b/src/apis/timeAndSalaryApi.js
@@ -12,6 +12,9 @@ export const fetchJobTitleCandidates = key =>
 export const fetchTimeAndSalary = opt =>
   fetchUtil(`${endpoint}?${qs.stringify(opt)}`)('GET');
 
+export const fetchTimeAndSalaryExtreme = opt =>
+  fetchUtil(`${endpoint}?${qs.stringify(opt)}/extreme`)('GET');
+
 export const fetchSearchCompany = opt =>
   fetchUtil(`${endpoint}/search_by/company/group_by/company?${qs.stringify(opt)}`)('GET');
 

--- a/src/apis/timeAndSalaryApi.js
+++ b/src/apis/timeAndSalaryApi.js
@@ -13,7 +13,7 @@ export const fetchTimeAndSalary = opt =>
   fetchUtil(`${endpoint}?${qs.stringify(opt)}`)('GET');
 
 export const fetchTimeAndSalaryExtreme = opt =>
-  fetchUtil(`${endpoint}?${qs.stringify(opt)}/extreme`)('GET');
+  fetchUtil(`${endpoint}/extreme?${qs.stringify(opt)}`)('GET');
 
 export const fetchSearchCompany = opt =>
   fetchUtil(`${endpoint}/search_by/company/group_by/company?${qs.stringify(opt)}`)('GET');

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -23,3 +23,20 @@
   }
 }
 
+.sortRow {
+  margin-bottom: 20px;
+  display: flex;
+
+  .extremeDescription {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    font-size: 14px;
+    line-height: 18px;
+    color: #626262;
+
+    .toggle {
+      color: #325bbd;
+    }
+  }
+}

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -28,16 +28,21 @@
   display: flex;
 
   .extremeDescription {
-    flex: 1;
-    display: flex;
-    align-items: center;
+    justify-content: flex-start;
     font-size: 14px;
     line-height: 18px;
     color: #626262;
+  }
+}
 
-    .toggle {
-      color: #325bbd;
-    }
+.extremeDescription {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .toggle {
+    color: #325bbd;
   }
 }
 

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -40,3 +40,7 @@
     }
   }
 }
+
+.extremeRow {
+  background-color: #f1f1f1;
+}

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -48,4 +48,8 @@
 
 .extremeRow {
   background-color: #f1f1f1;
+
+  .noBefore::before {
+    content: none !important;
+  }
 }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -24,13 +24,13 @@
 }
 
 .sortRow {
-  margin-bottom: 20px;
   display: flex;
 
   .extremeDescription {
     justify-content: flex-start;
     font-size: 14px;
     line-height: 18px;
+    margin-bottom: 20px;
     color: #626262;
   }
 }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -288,6 +288,7 @@ export default class TimeAndSalaryBoard extends Component {
       });
     return R.pipe(
       mapIndexed(IfExtremeRow(wearExtremeStyle)),
+      // inject a divider here to tell extreme rows apart from other rows
       injectExtremeDividerAt(nExtremeRows)(this.toggleShowExtreme),
     )(rows);
   }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -255,7 +255,14 @@ export default class TimeAndSalaryBoard extends Component {
           nExtremeRows, (
             <tr key="extreme-divider" className={styles.extremeRow}>
               <td colSpan="7">
-                Divider
+                <div className={styles.extremeDescription}>
+                  <span>
+                    以上資料為前 1 % 的資料，可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
+                    <button className={styles.toggle} onClick={this.toggleShowExtreme}>
+                      隱藏 -
+                    </button>
+                  </span>
+                </div>
               </td>
             </tr>
           )

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -169,6 +169,7 @@ export default class TimeAndSalaryBoard extends Component {
     route: PropTypes.object.isRequired,
     queryTimeAndSalary: PropTypes.func,
     switchPath: PropTypes.func,
+    queryExtremeTimeAndSalary: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -233,6 +234,7 @@ export default class TimeAndSalaryBoard extends Component {
   toggleShowExtreme = () => {
     const { showExtreme } = this.state;
     this.setState({ showExtreme: !showExtreme });
+    this.props.queryExtremeTimeAndSalary();
   }
 
   render() {

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -241,37 +241,10 @@ export default class TimeAndSalaryBoard extends Component {
   }
 
   decorateExtremeRows = rows => {
-    if (this.state.showExtreme) {
-      if (this.props.extremeStatus === fetchingStatus.FETCHED) {
-        const nExtremeRows = this.props.extremeData.size;
-        const mapIndexed = R.addIndex(R.map);
-        const IfExtremeRow = then => (row, i) =>
-          ((i < nExtremeRows) ? then(row) : row);
-        const wearExtremeStyle = row =>
-          cloneElement(row, {
-            className: cn(row.props.className, styles.extremeRow),
-          });
-        const injectExtremeDivider = R.insert(
-          nExtremeRows, (
-            <tr key="extreme-divider" className={styles.extremeRow}>
-              <td colSpan="7" className={styles.noBefore}>
-                <div className={styles.extremeDescription}>
-                  <span>
-                    以上資料為前 1 % 的資料，可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
-                    <button className={styles.toggle} onClick={this.toggleShowExtreme}>
-                      隱藏 -
-                    </button>
-                  </span>
-                </div>
-              </td>
-            </tr>
-          )
-        );
-        return R.pipe(
-          mapIndexed(IfExtremeRow(wearExtremeStyle)),
-          injectExtremeDivider,
-        )(rows);
-      }
+    if (!this.state.showExtreme) {
+      return rows;
+    }
+    if (this.props.extremeStatus !== fetchingStatus.FETCHED) {
       const injectLoadingIconRow = R.prepend(
         <tr key="extreme-loading" className={styles.extremeRow}>
           <td colSpan="7" className={styles.noBefore}>
@@ -281,7 +254,34 @@ export default class TimeAndSalaryBoard extends Component {
       );
       return injectLoadingIconRow(rows);
     }
-    return rows;
+    const nExtremeRows = this.props.extremeData.size;
+    const mapIndexed = R.addIndex(R.map);
+    const IfExtremeRow = then => (row, i) =>
+      ((i < nExtremeRows) ? then(row) : row);
+    const wearExtremeStyle = row =>
+      cloneElement(row, {
+        className: cn(row.props.className, styles.extremeRow),
+      });
+    const injectExtremeDivider = R.insert(
+      nExtremeRows, (
+        <tr key="extreme-divider" className={styles.extremeRow}>
+          <td colSpan="7" className={styles.noBefore}>
+            <div className={styles.extremeDescription}>
+              <span>
+                以上資料為前 1 % 的資料，可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
+                <button className={styles.toggle} onClick={this.toggleShowExtreme}>
+                  隱藏 -
+                </button>
+              </span>
+            </div>
+          </td>
+        </tr>
+      )
+    );
+    return R.pipe(
+      mapIndexed(IfExtremeRow(wearExtremeStyle)),
+      injectExtremeDivider,
+    )(rows);
   }
 
   render() {

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -169,6 +169,14 @@ const injectCallToActions = rows => {
   return flapMapIndexed(injectEvery(100))(rows);
 };
 
+const injectLoadingIconRow = R.prepend(
+  <tr key="extreme-loading" className={styles.extremeRow}>
+    <td colSpan="7" className={styles.noBefore}>
+      <Loading size="s" />
+    </td>
+  </tr>
+);
+
 export default class TimeAndSalaryBoard extends Component {
   static propTypes = {
     data: ImmutablePropTypes.list,
@@ -251,13 +259,6 @@ export default class TimeAndSalaryBoard extends Component {
       return rows;
     }
     if (this.props.extremeStatus !== fetchingStatus.FETCHED) {
-      const injectLoadingIconRow = R.prepend(
-        <tr key="extreme-loading" className={styles.extremeRow}>
-          <td colSpan="7" className={styles.noBefore}>
-            <Loading size="s" />
-          </td>
-        </tr>
-      );
       return injectLoadingIconRow(rows);
     }
     const nExtremeRows = this.props.extremeData.size;

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -236,6 +236,7 @@ export default class TimeAndSalaryBoard extends Component {
     if (this.props.route.path !== nextProps.route.path) {
       const { path } = nextProps.route;
       const { sortBy, order } = pathnameMapping[path];
+      this.setState({ showExtreme: false });
       this.props.queryTimeAndSalary({ sortBy, order });
     }
   }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -177,6 +177,23 @@ const injectLoadingIconRow = R.prepend(
   </tr>
 );
 
+const injectExtremeDividerAt = nthRow => onClick => R.insert(
+  nthRow, (
+    <tr key="extreme-divider" className={styles.extremeRow}>
+      <td colSpan="7" className={styles.noBefore}>
+        <div className={styles.extremeDescription}>
+          <span>
+            以上資料為前 1 % 的資料，可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
+            <button className={styles.toggle} onClick={onClick}>
+              隱藏 -
+            </button>
+          </span>
+        </div>
+      </td>
+    </tr>
+  )
+);
+
 export default class TimeAndSalaryBoard extends Component {
   static propTypes = {
     data: ImmutablePropTypes.list,
@@ -269,25 +286,9 @@ export default class TimeAndSalaryBoard extends Component {
       cloneElement(row, {
         className: cn(row.props.className, styles.extremeRow),
       });
-    const injectExtremeDivider = R.insert(
-      nExtremeRows, (
-        <tr key="extreme-divider" className={styles.extremeRow}>
-          <td colSpan="7" className={styles.noBefore}>
-            <div className={styles.extremeDescription}>
-              <span>
-                以上資料為前 1 % 的資料，可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
-                <button className={styles.toggle} onClick={this.toggleShowExtreme}>
-                  隱藏 -
-                </button>
-              </span>
-            </div>
-          </td>
-        </tr>
-      )
-    );
     return R.pipe(
       mapIndexed(IfExtremeRow(wearExtremeStyle)),
-      injectExtremeDivider,
+      injectExtremeDividerAt(nExtremeRows)(this.toggleShowExtreme),
     )(rows);
   }
 

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -21,36 +21,42 @@ const pathnameMapping = {
     label: '一週平均總工時（高到低）',
     sortBy: 'week_work_time',
     order: 'descending',
+    hasExtreme: true,
   },
   'sort/work-time-asc': {
     title: '工時排行榜（由低到高）',
     label: '一週平均總工時（低到高）',
     sortBy: 'week_work_time',
     order: 'ascending',
+    hasExtreme: true,
   },
   'salary-dashboard': {
     title: '估算時薪排行榜',
     label: '估算時薪（高到低）',
     sortBy: 'estimated_hourly_wage',
     order: 'descending',
+    hasExtreme: true,
   },
   'sort/salary-asc': {
     title: '估算時薪排行榜（由低到高）',
     label: '估算時薪（低到高）',
     sortBy: 'estimated_hourly_wage',
     order: 'ascending',
+    hasExtreme: true,
   },
   latest: {
     title: '最新薪時資訊',
     label: '資料時間（新到舊）',
     sortBy: 'created_at',
     order: 'descending',
+    hasExtreme: false,
   },
   'sort/time-asc': {
     title: '最舊薪時資訊',
     label: '資料時間（舊到新）',
     sortBy: 'created_at',
     order: 'ascending',
+    hasExtreme: false,
   },
 };
 
@@ -286,7 +292,7 @@ export default class TimeAndSalaryBoard extends Component {
 
   render() {
     const { path } = this.props.route;
-    const { title } = pathnameMapping[path];
+    const { title, hasExtreme } = pathnameMapping[path];
     const { status, data, switchPath, extremeStatus, extremeData } = this.props;
     const { showExtreme } = this.state;
     let raw;
@@ -302,12 +308,14 @@ export default class TimeAndSalaryBoard extends Component {
         <div className={commonStyles.result}>
           <div className={styles.sortRow}>
             <div className={styles.extremeDescription}>
-              <span>
-                前 1 % 的資料可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
-                <button className={styles.toggle} onClick={this.toggleShowExtreme}>
-                  {showExtreme ? '隱藏 -' : '展開 +'}
-                </button>
-              </span>
+              {hasExtreme && (
+                <span>
+                  前 1 % 的資料可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
+                  <button className={styles.toggle} onClick={this.toggleShowExtreme}>
+                    {showExtreme ? '隱藏 -' : '展開 +'}
+                  </button>
+                </span>
+              )}
             </div>
             <div className={commonStyles.sort}>
               <div className={commonStyles.label}> 排序：</div>

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -1,8 +1,9 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component, PropTypes, cloneElement } from 'react';
 import R from 'ramda';
 import Loading from 'common/Loader';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import $ from 'jquery';
+import cn from 'classnames';
 
 import Select from 'common/form/Select';
 import Table from 'common/table/Table';
@@ -239,6 +240,24 @@ export default class TimeAndSalaryBoard extends Component {
     this.props.queryExtremeTimeAndSalary();
   }
 
+  decorateExtremeRows = rows => {
+    if (this.state.showExtreme) {
+      if (this.props.extremeStatus === fetchingStatus.FETCHED) {
+        const nExtremeRows = this.props.extremeData.size;
+        const mapIndexed = R.addIndex(R.map);
+        const IfExtremeRow = then => (row, i) =>
+          ((i < nExtremeRows) ? then(row) : row);
+        const wearExtremeStyle = row =>
+          cloneElement(row, {
+            className: cn(row.props.className, styles.extremeRow),
+          });
+        return mapIndexed(IfExtremeRow(wearExtremeStyle))(rows);
+      }
+      return rows;
+    }
+    return rows;
+  }
+
   render() {
     const { path } = this.props.route;
     const { title } = pathnameMapping[path];
@@ -280,7 +299,10 @@ export default class TimeAndSalaryBoard extends Component {
             className={styles.latestTable}
             data={raw}
             primaryKey="_id"
-            postProcessRows={injectCallToActions}
+            postProcessRows={R.pipe(
+              this.decorateExtremeRows,
+              injectCallToActions,
+            )}
           >
             <Table.Column
               className={styles.colCompany}

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -251,7 +251,19 @@ export default class TimeAndSalaryBoard extends Component {
           cloneElement(row, {
             className: cn(row.props.className, styles.extremeRow),
           });
-        return mapIndexed(IfExtremeRow(wearExtremeStyle))(rows);
+        const injectExtremeDivider = R.insert(
+          nExtremeRows, (
+            <tr key="extreme-divider" className={styles.extremeRow}>
+              <td colSpan="7">
+                Divider
+              </td>
+            </tr>
+          )
+        );
+        return R.pipe(
+          mapIndexed(IfExtremeRow(wearExtremeStyle)),
+          injectExtremeDivider,
+        )(rows);
       }
       const injectLoadingIconRow = R.prepend(
         <tr key="extreme-loading" className={styles.extremeRow}>

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -253,7 +253,14 @@ export default class TimeAndSalaryBoard extends Component {
           });
         return mapIndexed(IfExtremeRow(wearExtremeStyle))(rows);
       }
-      return rows;
+      const injectLoadingIconRow = R.prepend(
+        <tr key="extreme-loading" className={styles.extremeRow}>
+          <td colSpan="7">
+            <Loading size="s" />
+          </td>
+        </tr>
+      );
+      return injectLoadingIconRow(rows);
     }
     return rows;
   }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -170,6 +170,8 @@ export default class TimeAndSalaryBoard extends Component {
     queryTimeAndSalary: PropTypes.func,
     switchPath: PropTypes.func,
     queryExtremeTimeAndSalary: PropTypes.func.isRequired,
+    extremeStatus: PropTypes.string,
+    extremeData: ImmutablePropTypes.list,
   }
 
   constructor(props) {
@@ -240,9 +242,14 @@ export default class TimeAndSalaryBoard extends Component {
   render() {
     const { path } = this.props.route;
     const { title } = pathnameMapping[path];
-    const raw = this.props.data.toJS();
-    const { status, switchPath } = this.props;
+    const { status, data, switchPath, extremeStatus, extremeData } = this.props;
     const { showExtreme } = this.state;
+    let raw;
+    if (showExtreme && extremeStatus === fetchingStatus.FETCHED) {
+      raw = extremeData.concat(data).toJS();
+    } else {
+      raw = data.toJS();
+    }
 
     return (
       <section className={commonStyles.searchResult}>

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -202,6 +202,7 @@ export default class TimeAndSalaryBoard extends Component {
     queryTimeAndSalary: PropTypes.func,
     switchPath: PropTypes.func,
     queryExtremeTimeAndSalary: PropTypes.func.isRequired,
+    resetBoardExtremeData: PropTypes.func.isRequired,
     extremeStatus: PropTypes.string,
     extremeData: ImmutablePropTypes.list,
   }
@@ -237,6 +238,7 @@ export default class TimeAndSalaryBoard extends Component {
       const { path } = nextProps.route;
       const { sortBy, order } = pathnameMapping[path];
       this.setState({ showExtreme: false });
+      this.props.resetBoardExtremeData();
       this.props.queryTimeAndSalary({ sortBy, order });
     }
   }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -281,6 +281,8 @@ export default class TimeAndSalaryBoard extends Component {
     if (this.props.extremeStatus !== fetchingStatus.FETCHED) {
       return injectLoadingIconRow(rows);
     }
+    // here, the first {nExtremeRows} rows are extreme data
+    // we would like to highlight them with the right style
     const nExtremeRows = this.props.extremeData.size;
     const mapIndexed = R.addIndex(R.map);
     const IfExtremeRow = then => (row, i) =>

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -185,6 +185,7 @@ export default class TimeAndSalaryBoard extends Component {
     infoTimeModal: {
       isOpen: false,
     },
+    showExtreme: false,
   }
 
   componentDidMount() {
@@ -229,11 +230,17 @@ export default class TimeAndSalaryBoard extends Component {
     this.props.queryTimeAndSalary({ sortBy, order });
   }
 
+  toggleShowExtreme = () => {
+    const { showExtreme } = this.state;
+    this.setState({ showExtreme: !showExtreme });
+  }
+
   render() {
     const { path } = this.props.route;
     const { title } = pathnameMapping[path];
     const raw = this.props.data.toJS();
     const { status, switchPath } = this.props;
+    const { showExtreme } = this.state;
 
     return (
       <section className={commonStyles.searchResult}>
@@ -243,7 +250,9 @@ export default class TimeAndSalaryBoard extends Component {
             <div className={styles.extremeDescription}>
               <span>
                 前 1 % 的資料可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
-                <button className={styles.toggle}>展開 +</button>
+                <button className={styles.toggle} onClick={this.toggleShowExtreme}>
+                  {showExtreme ? '隱藏 -' : '展開 +'}
+                </button>
               </span>
             </div>
             <div className={commonStyles.sort}>

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -239,15 +239,23 @@ export default class TimeAndSalaryBoard extends Component {
       <section className={commonStyles.searchResult}>
         <h2 className={commonStyles.heading}>{title}</h2>
         <div className={commonStyles.result}>
-          <div className={commonStyles.sort}>
-            <div className={commonStyles.label}> 排序：</div>
-            <div className={commonStyles.select}>
-              <Select
-                options={selectOptions(pathnameMapping)}
-                onChange={e => switchPath(e.target.value)}
-                value={path}
-                hasNullOption={false}
-              />
+          <div className={styles.sortRow}>
+            <div className={styles.extremeDescription}>
+              <span>
+                前 1 % 的資料可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
+                <button className={styles.toggle}>展開 +</button>
+              </span>
+            </div>
+            <div className={commonStyles.sort}>
+              <div className={commonStyles.label}> 排序：</div>
+              <div className={commonStyles.select}>
+                <Select
+                  options={selectOptions(pathnameMapping)}
+                  onChange={e => switchPath(e.target.value)}
+                  value={path}
+                  hasNullOption={false}
+                />
+              </div>
             </div>
           </div>
           <Table

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -254,7 +254,7 @@ export default class TimeAndSalaryBoard extends Component {
         const injectExtremeDivider = R.insert(
           nExtremeRows, (
             <tr key="extreme-divider" className={styles.extremeRow}>
-              <td colSpan="7">
+              <td colSpan="7" className={styles.noBefore}>
                 <div className={styles.extremeDescription}>
                   <span>
                     以上資料為前 1 % 的資料，可能包含極端值或為使用者誤填，較不具參考價值，預設為隱藏。
@@ -274,7 +274,7 @@ export default class TimeAndSalaryBoard extends Component {
       }
       const injectLoadingIconRow = R.prepend(
         <tr key="extreme-loading" className={styles.extremeRow}>
-          <td colSpan="7">
+          <td colSpan="7" className={styles.noBefore}>
             <Loading size="s" />
           </td>
         </tr>

--- a/src/components/TimeAndSalary/views/view.module.css
+++ b/src/components/TimeAndSalary/views/view.module.css
@@ -57,8 +57,9 @@ $bold: 700;
 }
 
 .sort {
-  text-align: right;
-  margin-bottom: 20px;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 
   @media (max-width: $below-mobile) {
     text-align: left;

--- a/src/components/TimeAndSalary/views/view.module.css
+++ b/src/components/TimeAndSalary/views/view.module.css
@@ -60,6 +60,7 @@ $bold: 700;
   display: flex;
   justify-content: flex-end;
   align-items: center;
+  margin-bottom: 20px;
 
   @media (max-width: $below-mobile) {
     text-align: left;

--- a/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryBoard from '../../components/TimeAndSalary/TimeAndSalaryBoard';
-import { queryTimeAndSalary, switchPath, queryExtremeTimeAndSalary } from '../../actions/timeAndSalaryBoard';
+import { queryTimeAndSalary, switchPath, resetBoardExtremeData, queryExtremeTimeAndSalary } from '../../actions/timeAndSalaryBoard';
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryBoard.get('data'),
@@ -11,6 +11,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryTimeAndSalary, switchPath, queryExtremeTimeAndSalary }, dispatch);
+  bindActionCreators({ queryTimeAndSalary, switchPath, resetBoardExtremeData, queryExtremeTimeAndSalary }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryBoard);

--- a/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryBoard from '../../components/TimeAndSalary/TimeAndSalaryBoard';
-import { queryTimeAndSalary, switchPath } from '../../actions/timeAndSalaryBoard';
+import { queryTimeAndSalary, switchPath, queryExtremeTimeAndSalary } from '../../actions/timeAndSalaryBoard';
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryBoard.get('data'),
@@ -9,6 +9,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryTimeAndSalary, switchPath }, dispatch);
+  bindActionCreators({ queryTimeAndSalary, switchPath, queryExtremeTimeAndSalary }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryBoard);

--- a/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
@@ -6,6 +6,8 @@ import { queryTimeAndSalary, switchPath, queryExtremeTimeAndSalary } from '../..
 const mapStateToProps = state => ({
   data: state.timeAndSalaryBoard.get('data'),
   status: state.timeAndSalaryBoard.get('status'),
+  extremeStatus: state.timeAndSalaryBoard.get('extremeStatus'),
+  extremeData: state.timeAndSalaryBoard.get('extremeData'),
 });
 
 const mapDispatchToProps = dispatch =>

--- a/src/reducers/timeAndSalaryBoard.js
+++ b/src/reducers/timeAndSalaryBoard.js
@@ -1,7 +1,7 @@
 import { fromJS } from 'immutable';
 import createReducer from 'utils/createReducer';
 
-import { SET_BOARD_DATA, SET_BOARD_STATUS } from '../actions/timeAndSalaryBoard';
+import { SET_BOARD_DATA, SET_BOARD_STATUS, SET_BOARD_EXTREME_DATA, SET_BOARD_EXTREME_STATUS } from '../actions/timeAndSalaryBoard';
 import fetchingStatus from '../constants/status';
 
 const preloadedState = fromJS({
@@ -10,6 +10,9 @@ const preloadedState = fromJS({
   data: [],
   status: fetchingStatus.UNFETCHED,
   error: null,
+  extremeData: [],
+  extremeStatus: fetchingStatus.UNFETCHED,
+  extremeError: null,
 });
 
 export default createReducer(preloadedState, {
@@ -22,4 +25,11 @@ export default createReducer(preloadedState, {
       .set('order', order),
   [SET_BOARD_STATUS]: (state, { status }) =>
     state.set('status', status),
+  [SET_BOARD_EXTREME_DATA]: (state, { extremeData, extremeStatus, extremeError }) =>
+    state
+      .set('extremeData', fromJS(extremeData))
+      .set('extremeStatus', extremeStatus)
+      .set('extremeError', extremeError),
+  [SET_BOARD_EXTREME_STATUS]: (state, { extremeStatus }) =>
+    state.set('extremeStatus', extremeStatus),
 });


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue --> 

## 這個 PR 是？ <!-- 必填 -->

1. 薪時查詢頁面放上極端值的說明 & 隱藏/顯示鈕
2. 完成極端薪時的action、reducer、api，並顯示於表格中
3. 極端薪時的資料置於`state.timeAndSalaryBoard.{extremeData, extremeStatus, extremeError}`

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

<!-- 這個 PR 需要先等其它前端 PR merge 之後才能 merge -->
#337 

## Screenshots  <!-- 選填，沒有就刪掉 -->
![2017-11-07 3 06 28](http://g.recordit.co/t3o02l7cqW.gif)

on small device: 
![2017-11-07 3 06 28](http://g.recordit.co/F3PZlKvDxd.gif)

<!-- 可以的話，請提供畫面截圖，如果是 GIF 的話更好 -->

## 我應該如何手動測試？ <!-- 必填 -->

- 點選「顯示」會載入極端薪時
- log會顯示state change