### PR TITLE
首頁不要顯示 header 上方的募資條

### DIFF
--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -86,10 +86,17 @@ class Header extends React.Component {
       .catch(() => {});
   }
 
+  renderTop = () => {
+    if (this.props.location.pathname === '/') {
+      return null;
+    }
+    return <Top />;
+  }
+
   render() {
     return (
       <div className={styles.root}>
-        <Top />
+        {this.renderTop()}
         <header className={styles.header}>
           <Wrapper size="l" className={styles.inner}>
             <HeaderButton
@@ -148,6 +155,7 @@ Header.propTypes = {
   getMe: React.PropTypes.func.isRequired,
   auth: React.PropTypes.object,
   FB: React.PropTypes.object,
+  location: React.PropTypes.object,
 };
 
 const HeaderButton = ({ isNavOpen, toggle }) => (

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -6,9 +6,9 @@ import Header from '../../containers/Layout/Header';
 import Footer from './Footer';
 import { HELMET_DATA } from '../../constants/helmetData';
 
-const App = ({ children }) => (
+const App = ({ children, location }) => (
   <div className={styles.App}>
-    <Header />
+    <Header location={location} />
     <Helmet {...HELMET_DATA.DEFAULT} />
     <div className={styles.content}>
       {children}
@@ -19,6 +19,7 @@ const App = ({ children }) => (
 
 App.propTypes = {
   children: PropTypes.node.isRequired,
+  location: PropTypes.object,
 };
 
 


### PR DESCRIPTION
part of #322 

## 這個 PR 是？ <!-- 必填 -->

讓首頁不要顯示上方的募資條。

## Screenshots  <!-- 選填，沒有就刪掉 -->

![2017-11-13 10 24 32](https://user-images.githubusercontent.com/3805975/32730259-77307bfa-c8c1-11e7-892e-fb3271f82bad.png)

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

實作方法是把 App component 從 router 拿到 location 物件往下傳到 Header ，在 Header 判定要不要 render Top component (header 上方的募資條）

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 切到首頁，不應該有 header 上方的募資條
- [ ] 切到其他頁面，應該要有 header 上方的募資條