### PR TITLE
Progress bar 串接資料

### DIFF
--- a/src/components/ExperienceSearch/Banners/Banner1.js
+++ b/src/components/ExperienceSearch/Banners/Banner1.js
@@ -4,17 +4,18 @@ import { Link } from 'react-router';
 import ProgressBar from 'common/ProgressBar';
 import styles from './Banners.module.css';
 
-const Banner1 = ({ className }) => (
+const Banner1 = ({ experienceCount, className }) => (
   <Link to="/share/interview" className={className}>
     <img
       src="https://image.goodjob.life/banners/banner2_2x.jpg"
       alt="好工作評論網募資中"
       className={styles.banner1}
     />
-    <ProgressBar totalData={250} size="m" theme="gray" rootClassName={styles.progress} />
+    <ProgressBar totalData={experienceCount} size="m" theme="gray" rootClassName={styles.progress} />
   </Link>
 );
 Banner1.propTypes = {
+  experienceCount: PropTypes.number,
   className: PropTypes.string,
 };
 

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -295,7 +295,7 @@ class ExperienceSearch extends Component {
                 setSearchType={this.setSearchType}
                 className={styles.filter}
               />
-              <Banner1 className={styles.banner} />
+              <Banner1 experienceCount={this.props.experienceSearch.get('experienceCount')} className={styles.banner} />
             </aside>
 
             <section className={styles.content}>

--- a/src/components/LaborRightsSingle/Body.js
+++ b/src/components/LaborRightsSingle/Body.js
@@ -6,7 +6,7 @@ import MarkdownParser from './MarkdownParser';
 import styles from './Body.module.css';
 import LeftBanner from '../ExperienceSearch/Banners/Banner1';
 
-const Body = ({ title, seoText, description, content }) => (
+const Body = ({ title, seoText, description, content, experienceCount }) => (
   <Section Tag="main" pageTop>
     <Wrapper size="m">
       <Heading size="l" bold marginBottom>{title}</Heading>
@@ -20,7 +20,7 @@ const Body = ({ title, seoText, description, content }) => (
           <Sticky disableCompensation>
             {({ style }) => (
               <div style={style}>
-                <LeftBanner />
+                <LeftBanner experienceCount={experienceCount} />
               </div>
             )}
           </Sticky>
@@ -41,6 +41,7 @@ Body.propTypes = {
   seoText: PropTypes.string,
   description: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
+  experienceCount: PropTypes.number,
 };
 Body.defaultProps = {
   title: '',

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -79,6 +79,7 @@ class LaborRightsSingle extends React.Component {
                 seoText={seoText}
                 description={description}
                 content={content}
+                experienceCount={this.props.experienceCount}
               />
               <CallToAction
                 imgSrc="https://image.goodjob.life/cta-02.jpg"
@@ -105,6 +106,7 @@ LaborRightsSingle.propTypes = {
   fetchDataIfNeeded: React.PropTypes.func.isRequired,
   status: React.PropTypes.string.isRequired,
   error: ImmutablePropTypes.map,
+  experienceCount: React.PropTypes.number,
 };
 
 export default LaborRightsSingle;

--- a/src/components/LandingPage/Banner.js
+++ b/src/components/LandingPage/Banner.js
@@ -5,7 +5,7 @@ import { Wrapper } from 'common/base';
 import ProgressBar from 'common/ProgressBar';
 import styles from './Banner.module.css';
 
-const Banner = () => (
+const Banner = ({ experienceCount }) => (
   <section className={styles.banner}>
     <Wrapper size="l">
       <div className={styles.image}>
@@ -13,7 +13,7 @@ const Banner = () => (
       </div>
       <div className={styles.content}>
         <h1 className={styles.heading}><span>好工作評論網募「資」中 </span>(๑•̀ㅂ•́)و✧</h1>
-        <ProgressBar totalData={400} rootClassName={styles.progressBar} />
+        <ProgressBar totalData={experienceCount} rootClassName={styles.progressBar} />
         <h2 className={styles.subheading}>
           目標 <strong>500</strong> 筆資料，不需要花上辛苦錢，只需要動動你的手，<br />
           將你的面試、工作經驗分享給更多人知道。
@@ -23,5 +23,9 @@ const Banner = () => (
     </Wrapper>
   </section>
 );
+
+Banner.propTypes = {
+  experienceCount: React.PropTypes.number,
+};
 
 export default Banner;

--- a/src/components/LandingPage/index.js
+++ b/src/components/LandingPage/index.js
@@ -39,7 +39,7 @@ class LandingPage extends Component {
     return (
       <main>
         <Helmet {...HELMET_DATA.LANDING_PAGE} />
-        <Banner />
+        <Banner experienceCount={this.props.experienceSearch.get('experienceCount')} />
         <Dashboard />
         <ShareExpSection heading="現在就留下你的資料" />
         <Section padding bg="white">

--- a/src/components/Layout/Header/Top/index.js
+++ b/src/components/Layout/Header/Top/index.js
@@ -4,11 +4,11 @@ import { Wrapper } from 'common/base';
 import ProgressBar from 'common/ProgressBar';
 import styles from './Top.module.css';
 
-const Top = () => (
+const Top = ({ experienceCount }) => (
   <Link to="/share" className={styles.root}>
     <Wrapper size="l" className={styles.inner}>
       <div className={styles.heading}>\  好工作評論網募「資」中  /</div>
-      <ProgressBar totalData={20} size="s" theme="black" />
+      <ProgressBar totalData={experienceCount} size="s" theme="black" />
       <div className={styles.subheading}>
         不需要花上辛苦錢，只需要動動你的手，將你的面試、工作經驗分享出去！
       </div>
@@ -16,5 +16,9 @@ const Top = () => (
     </Wrapper>
   </Link>
 );
+
+Top.propTypes = {
+  experienceCount: React.PropTypes.number,
+};
 
 export default Top;

--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -90,7 +90,7 @@ class Header extends React.Component {
     if (this.props.location.pathname === '/') {
       return null;
     }
-    return <Top />;
+    return <Top experienceCount={this.props.experienceCount} />;
   }
 
   render() {
@@ -156,6 +156,7 @@ Header.propTypes = {
   auth: React.PropTypes.object,
   FB: React.PropTypes.object,
   location: React.PropTypes.object,
+  experienceCount: React.PropTypes.number,
 };
 
 const HeaderButton = ({ isNavOpen, toggle }) => (

--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -86,10 +86,17 @@ class Header extends React.Component {
       .catch(() => {});
   }
 
+  renderTop = () => {
+    if (this.props.location.pathname === '/') {
+      return null;
+    }
+    return <Top />;
+  }
+
   render() {
     return (
       <div className={styles.root}>
-        <Top />
+        {this.renderTop()}
         <header className={styles.header}>
           <Wrapper size="l" className={styles.inner}>
             <HeaderButton
@@ -148,6 +155,7 @@ Header.propTypes = {
   getMe: React.PropTypes.func.isRequired,
   auth: React.PropTypes.object,
   FB: React.PropTypes.object,
+  location: React.PropTypes.object,
 };
 
 const HeaderButton = ({ isNavOpen, toggle }) => (

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -6,9 +6,9 @@ import Header from '../../containers/Layout/Header';
 import Footer from './Footer';
 import { HELMET_DATA } from '../../constants/helmetData';
 
-const App = ({ children }) => (
+const App = ({ children, location }) => (
   <div className={styles.App}>
-    <Header />
+    <Header location={location} />
     <Helmet {...HELMET_DATA.DEFAULT} />
     <div className={styles.content}>
       {children}
@@ -19,6 +19,7 @@ const App = ({ children }) => (
 
 App.propTypes = {
   children: PropTypes.node.isRequired,
+  location: PropTypes.object,
 };
 
 

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -6,20 +6,39 @@ import Header from '../../containers/Layout/Header';
 import Footer from './Footer';
 import { HELMET_DATA } from '../../constants/helmetData';
 
-const App = ({ children, location }) => (
-  <div className={styles.App}>
-    <Header location={location} />
-    <Helmet {...HELMET_DATA.DEFAULT} />
-    <div className={styles.content}>
-      {children}
-    </div>
-    <Footer />
-  </div>
-);
+import { fetchExperiences } from '../../actions/experienceSearch';
+
+class App extends React.Component {
+  static fetchData({ store: { dispatch } }) {
+    return Promise.all([
+      dispatch(fetchExperiences(0, 1, 'popularity', 'created_at', '')),
+    ]);
+  }
+
+  componentDidMount() {
+    this.props.fetchExperiences(0, 1, 'popularity', 'created_at', '');
+  }
+
+  render() {
+    const { children, location, experienceCount } = this.props;
+    return (
+      <div className={styles.App}>
+        <Header location={location} experienceCount={experienceCount} />
+        <Helmet {...HELMET_DATA.DEFAULT} />
+        <div className={styles.content}>
+          {children}
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+}
 
 App.propTypes = {
   children: PropTypes.node.isRequired,
   location: PropTypes.object,
+  experienceCount: PropTypes.number,
+  fetchExperiences: PropTypes.func.isRequired,
 };
 
 

--- a/src/containers/LaborRightsSingle.js
+++ b/src/containers/LaborRightsSingle.js
@@ -26,12 +26,14 @@ export default connect(
       metaList.get(index > 0 ? index - 1 : undefined);
     const nextData =
       metaList.get(index < ids.count() - 1 ? index + 1 : undefined);
+    const experienceCount = state.experienceSearch.get('experienceCount');
     return {
       data,
       prev: prevData,
       next: nextData,
       status: dataStatus,
       error: dataError,
+      experienceCount,
     };
   },
   dispatch => bindActionCreators(actionCreators, dispatch),

--- a/src/containers/Layout/index.js
+++ b/src/containers/Layout/index.js
@@ -1,9 +1,16 @@
 import { connect } from 'react-redux';
-
+import { bindActionCreators } from 'redux';
 import App from '../../components/Layout';
 
+import * as ExperienceSearchActions from '../../actions/experienceSearch';
 
-const mapStateToProps = () => ({});
+const mapStateToProps = state => ({
+  experienceCount: state.experienceSearch.get('experienceCount'),
+});
 
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({
+    ...ExperienceSearchActions,
+  }, dispatch);
 
-export default connect(mapStateToProps)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(App);


### PR DESCRIPTION
part of #322  

## 這個 PR 是？ <!-- 必填 -->

募資條的資料數量 串接後端 API 

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Front-end PR：merge after #344 

## Screenshots  <!-- 選填，沒有就刪掉 -->
![slrcactgds](https://user-images.githubusercontent.com/3805975/32733400-1f9a9c5a-c8ca-11e7-8665-a1d107cff98a.gif)

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

1. App component 的地方去 fetchExperience，並把 experienceCount 串到 Top component  63ac041
2.  experienceCount 串到 LandingPage 的 Banner 855d37f
3.  experienceCount 串到 LaborRightSingle 的 Banner 5a9c72c

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進首頁 `/` ，看首頁 Banner 資料數是否正確
- [ ] 進經驗分享查詢頁 `/experiences/search` 看左邊 Banner 資料數是否正確。重新整理，再看資料數是否正確。
- [ ] 進小教室單篇頁 `/labor-rights/xxxxxxx` 看左邊 Banner 資料數是否正確。重新整理，再看資料數是否正確。
- [ ] 進到除了首頁的每一頁，重新整理，看 header 上方的資料數是否正確
