### PR TITLE
將 ProgressBar 與後端資料串接

### DIFF
--- a/src/components/ExperienceSearch/Banners/Banner1.js
+++ b/src/components/ExperienceSearch/Banners/Banner1.js
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
-import ProgressBar from 'common/ProgressBar';
+import RaiseExperiencesProgressBar from 'common/RaiseExperiencesProgressBar';
 import styles from './Banners.module.css';
 
 const Banner1 = ({ className }) => (
@@ -11,7 +11,7 @@ const Banner1 = ({ className }) => (
       alt="好工作評論網募資中"
       className={styles.banner1}
     />
-    <ProgressBar totalData={250} size="m" theme="gray" rootClassName={styles.progress} />
+    <RaiseExperiencesProgressBar size="m" theme="gray" rootClassName={styles.progress} />
   </Link>
 );
 Banner1.propTypes = {

--- a/src/components/LandingPage/Banner.js
+++ b/src/components/LandingPage/Banner.js
@@ -2,7 +2,7 @@ import React from 'react';
 import cn from 'classnames';
 import { Link } from 'react-router';
 import { Wrapper } from 'common/base';
-import ProgressBar from 'common/ProgressBar';
+import RaiseExperiencesProgressBar from 'common/RaiseExperiencesProgressBar';
 import styles from './Banner.module.css';
 
 const Banner = () => (
@@ -13,7 +13,7 @@ const Banner = () => (
       </div>
       <div className={styles.content}>
         <h1 className={styles.heading}><span>好工作評論網募「資」中 </span>(๑•̀ㅂ•́)و✧</h1>
-        <ProgressBar totalData={400} rootClassName={styles.progressBar} />
+        <RaiseExperiencesProgressBar rootClassName={styles.progressBar} />
         <h2 className={styles.subheading}>
           目標 <strong>500</strong> 筆資料，不需要花上辛苦錢，只需要動動你的手，<br />
           將你的面試、工作經驗分享給更多人知道。

--- a/src/components/Layout/Header/Top/index.js
+++ b/src/components/Layout/Header/Top/index.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Link } from 'react-router';
 import { Wrapper } from 'common/base';
-import ProgressBar from 'common/ProgressBar';
+import RaiseExperiencesProgressBar from 'common/RaiseExperiencesProgressBar';
 import styles from './Top.module.css';
 
 const Top = () => (
   <Link to="/share" className={styles.root}>
     <Wrapper size="l" className={styles.inner}>
       <div className={styles.heading}>\  好工作評論網募「資」中  /</div>
-      <ProgressBar totalData={20} size="s" theme="black" />
+      <RaiseExperiencesProgressBar size="s" theme="black" />
       <div className={styles.subheading}>
         不需要花上辛苦錢，只需要動動你的手，將你的面試、工作經驗分享出去！
       </div>

--- a/src/components/common/RaiseExperiencesProgressBar/index.js
+++ b/src/components/common/RaiseExperiencesProgressBar/index.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react';
+import ProgressBar from '../ProgressBar';
+import {
+  getExperiences as getExperiencesApi,
+} from '../../../apis/experiencesApi';
+
+
+export default class RaiseExperiencesProgressBar extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      total: 0,
+    };
+  }
+
+  componentDidMount() {
+    getExperiencesApi({ limit: 1 })
+      .then(data => {
+        this.setState({ total: data.total });
+      })
+      .catch(() => {
+        this.setState({ total: 0 });
+      });
+  }
+
+  render() {
+    return (
+      <ProgressBar totalData={this.state.total} {...this.props} />
+    );
+  }
+}


### PR DESCRIPTION
part of #322

## 這個 PR 是？ <!-- 必填 -->

將 ProgressBar 串接後端的資料

## Screenshots  <!-- 選填，沒有就刪掉 -->

![image](https://user-images.githubusercontent.com/1908007/32734742-d35b6e38-c8cd-11e7-99d5-c01d8bd77e17.png)

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

1. 這個 PR 將 ProgressBar 抽象化一層，由 RaiseExperiencesProgressBar 決定目前的資料進度
2. 當 component 被 mount 時，會抓取後端資料（這步驟沒有考慮是否有同樣資料，或抓取中就不抓）

## 我應該如何手動測試？ <!-- 必填 -->

1. 檢查 Landing Page 的 Top 與 Banner
2. 檢查經驗列表頁的 Banner

與 #345 重複，但 address 不同的點

## 討論與問題

1. 這個 PR 會導致每當 component 被 mount，就會 fetch 一次後端，當頁面上重新 render 出多個 ProgressBar，就會造成多重 query

可能的解法：

- [ ] 可以透過 store/state 去確保只會有一個 ground truth，且一個 fetch
- [ ] 而實際上，component 被 mount 的次數也不多，大概就是 0~1 個 / 頁面切換，所以問題也還好