### PR TITLE
所有 call to action 用途的連結改為隨機到面試/工作經驗表單頁

### DIFF
--- a/src/components/ExperienceSearch/Banners/Banner1.js
+++ b/src/components/ExperienceSearch/Banners/Banner1.js
@@ -2,10 +2,11 @@ import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
 import ProgressBar from 'common/ProgressBar';
+import getCallToActionLink from 'utils/callToActionUtils';
 import styles from './Banners.module.css';
 
 const Banner1 = ({ className }) => (
-  <Link to="/share/interview" className={className}>
+  <Link to={getCallToActionLink()} className={className}>
     <img
       src="https://image.goodjob.life/banners/banner2_2x.jpg"
       alt="好工作評論網募資中"

--- a/src/components/ExperienceSearch/Banners/Banner2.js
+++ b/src/components/ExperienceSearch/Banners/Banner2.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router';
-
+import getCallToActionLink from 'utils/callToActionUtils';
 import styles from './Banners.module.css';
 
 const Banner2 = () => (
-  <Link to="/share/work-experiences">
+  <Link to={getCallToActionLink()}>
     <img
       src="https://image.goodjob.life/banners/banner1_2x.jpg"
       alt="好工作評論網募資中"

--- a/src/components/LaborRightsMenu/index.js
+++ b/src/components/LaborRightsMenu/index.js
@@ -4,6 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Loader from 'common/Loader';
 import Columns from 'common/Columns';
 import { Section, Wrapper, Heading } from 'common/base';
+import getCallToActionLink from 'utils/callToActionUtils';
 import {
   fetchMetaListIfNeeded,
 } from '../../actions/laborRightsMenu';
@@ -30,7 +31,7 @@ class LaborRightsMenu extends React.Component {
       title,
     }));
     items.splice(4, 0, {
-      link: '/share',
+      link: getCallToActionLink(),
       coverUrl: 'https://image.goodjob.life/banners/banner3_2x.jpg',
       title: '留下你的面試經驗、工作經驗',
     });

--- a/src/components/LandingPage/Banner.js
+++ b/src/components/LandingPage/Banner.js
@@ -3,6 +3,7 @@ import cn from 'classnames';
 import { Link } from 'react-router';
 import { Wrapper } from 'common/base';
 import ProgressBar from 'common/ProgressBar';
+import getCallToActionLink from 'utils/callToActionUtils';
 import styles from './Banner.module.css';
 
 const Banner = () => (
@@ -18,7 +19,7 @@ const Banner = () => (
           目標 <strong>500</strong> 筆資料，不需要花上辛苦錢，只需要動動你的手，<br />
           將你的面試、工作經驗分享給更多人知道。
         </h2>
-        <Link to="/share/work-experiences" className={cn('buttonCircleM', 'buttonBlack2')}>GO!</Link>
+        <Link to={getCallToActionLink()} className={cn('buttonCircleM', 'buttonBlack2')}>GO!</Link>
       </div>
     </Wrapper>
   </section>

--- a/src/components/Layout/Header/Top/index.js
+++ b/src/components/Layout/Header/Top/index.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { Link } from 'react-router';
 import { Wrapper } from 'common/base';
 import ProgressBar from 'common/ProgressBar';
+import getCallToActionLink from 'utils/callToActionUtils';
 import styles from './Top.module.css';
 
 const Top = () => (
-  <Link to="/share" className={styles.root}>
+  <Link to={getCallToActionLink()} className={styles.root}>
     <Wrapper size="l" className={styles.inner}>
       <div className={styles.heading}>\  好工作評論網募「資」中  /</div>
       <ProgressBar totalData={20} size="s" theme="black" />

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/CallToActionRow.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/CallToActionRow.js
@@ -1,12 +1,12 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 import cn from 'classnames';
-
+import getCallToActionLink from 'utils/callToActionUtils';
 import styles from './CallToActionRow.module.css';
 import headerStyles from '../../Layout/Header/Header.module.css';
 
 const GoButton = () => (
-  <Link to="/share" className={cn(styles.go, headerStyles.leaveDataBtn)}>
+  <Link to={getCallToActionLink()} className={cn(styles.go, headerStyles.leaveDataBtn)}>
     GO!
   </Link>
 );

--- a/src/utils/callToActionUtils.js
+++ b/src/utils/callToActionUtils.js
@@ -1,0 +1,4 @@
+export default function getCallToActionLink() {
+  const links = ['/share/interview', '/share/work-experiences'];
+  return links[Math.floor(Math.random() * links.length)];
+}


### PR DESCRIPTION
Close #321 

## 這個 PR 是？ <!-- 必填 -->

所有 call to action 用途的連結改為隨機到面試或工作經驗表單頁

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

1. 實作一個隨機挑選 /share/interview or /share/work-experience 連結的 util function c824e00
2. 將所有 call to action 用途的 component 換成用該 function 取得連結 b22abcc
3. 補上 小教室選單頁 call to action 用途的 component 換成用該 function 取得連結 133835a

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 嘗試重新整理或切換頁面數次，看 header 上方的募資條連結是否有變
- [ ] 嘗試重新整理或切換頁面數次，看 單篇小教室頁面 左方的 banner 連結是否有變
- [ ] 嘗試重新整理或切換頁面數次，看 經驗分享查詢頁 左方和上方的 banner 連結是否有變
- [ ] 嘗試重新整理或切換頁面數次，看 薪資表單查詢頁 插在表格中間的 banner 連結是否有變
- [ ] 嘗試重新整理或切換頁面數次，看 小教室選單頁 中 banner 連結是否有變