### PR TITLE
Hotfix #356, 解決意外修改到原本的資料

### DIFF
--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -86,16 +86,18 @@ export const HELMET_DATA = {
       { rel: 'canonical', href: formatCanonicalPath('/share/work-experiences') },
     ],
   },
-  EXPERIENCE_SEARCH: {
-    title: '查詢面試、工作經驗',
-    meta: [
-      { property: 'og:title', content: formatTitle('查詢面試、工作經驗', SITE_NAME) },
-      { property: 'og:url', content: formatCanonicalPath('/experiences/search') },
-      { property: 'og:image', content: `${imgHost}/og/experience-search.jpg` },
-    ],
-    link: [
-      { rel: 'canonical', href: formatCanonicalPath('/experiences/search') },
-    ],
+  get EXPERIENCE_SEARCH() {
+    return {
+      title: '查詢面試、工作經驗',
+      meta: [
+        { property: 'og:title', content: formatTitle('查詢面試、工作經驗', SITE_NAME) },
+        { property: 'og:url', content: formatCanonicalPath('/experiences/search') },
+        { property: 'og:image', content: `${imgHost}/og/experience-search.jpg` },
+      ],
+      link: [
+        { rel: 'canonical', href: formatCanonicalPath('/experiences/search') },
+      ],
+    };
   },
   EXPERIENCE_DETAIL: {
     // information is dynamic


### PR DESCRIPTION
Close #356

## 這個 PR 是？ <!-- 必填 -->

#356 的 issue 指出，push 會導致原本的資料被修改（data.meta 會越來越多東西）

透過 getter 讓取得物件時， 會回傳新的物件

## 我應該如何手動測試？ <!-- 必填 -->

在 `src/components/ExperienceSearch/index.js` 的 `renderHelmet()` 可以放上 `console.log(data)`

在 PR 前可以看到

```
{ title: '查詢面試、工作經驗',                     
  meta:                  
   [ { property: 'og:title', content: '查詢面試、工作經驗 | GoodJob 好工作評論網' },                   
     { property: 'og:url',                         
       content: 'https://www.goodjob.life/experiences/search' },                                       
     { property: 'og:image',                       
       content: 'https://image.goodjob.life/og/experience-search.jpg' },                               
     { name: 'description',                        
       content: '馬上查詢超過 90 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！' },               
     { property: 'og:description',                 
       content: '馬上查詢超過 90 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！' },               
     { name: 'description',                        
       content: '馬上查詢超過 90 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！' },               
     { property: 'og:description',                 
       content: '馬上查詢超過 90 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！' } ],             
  link:                  
   [ { rel: 'canonical', 
       href: 'https://www.goodjob.life/experiences/search' } ] }
```

PR 後，meta 不會一直增長