### PR TITLE
Feature/experienceSearch page helmet

### DIFF
--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -3,6 +3,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import Helmet from 'react-helmet';
 import { browserHistory } from 'react-router';
 import R from 'ramda';
+import qs from 'qs';
 
 import ReactGA from 'react-ga';
 
@@ -145,6 +146,27 @@ class ExperienceSearch extends Component {
 
       fetchExperiences(page, PAGE_COUNT, sort, searchBy, searchQuery, searchType);
     }
+  }
+
+  getCanonicalUrl = () => {
+    const {
+      searchType,
+      searchQuery,
+      searchBy,
+      sortBy,
+      page,
+    } = querySelector(this.props.location.query);
+
+    const params = {
+      type: searchType || 'interview,work',
+      q: searchQuery || '',
+      s_by: searchBy || 'job_title',
+      sort: sortBy || 'created_at',
+      p: page || 1,
+    };
+    const str = qs.stringify(params, { sort: (a, b) => a.localeCompare(b) });
+    const url = formatCanonicalPath(`${this.props.location.pathname}?${str}`);
+    return url;
   }
 
   setSearchType = e => {
@@ -348,7 +370,7 @@ class ExperienceSearch extends Component {
 
     const count = this.props.experienceSearch.get('experienceCount');
     const scale = getScale(count);
-    const url = formatCanonicalPath(this.props.location.pathname + this.props.location.search);
+    const url = this.getCanonicalUrl();
     const searchTypeName = searchType.split(',').sort().reduce((names, type) => {
       if (searchTypeMap[type]) { names.push(searchTypeMap[type]); }
       return names;

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -16,7 +16,8 @@ import ExperienceBlock from './ExperienceBlock';
 import {
   fetchExperiences as fetchExperiencesAction,
 } from '../../actions/experienceSearch';
-import { HELMET_DATA } from '../../constants/helmetData';
+import { formatTitle, formatCanonicalPath } from '../../utils/helmetHelper';
+import { imgHost, SITE_NAME } from '../../constants/helmetData';
 import {
   PAGE_COUNT,
 } from '../../constants/experienceSearch';
@@ -44,6 +45,16 @@ import { GA_CATEGORY, GA_ACTION } from '../../constants/gaConstants';
 const SORT = {
   CREATED_AT: 'created_at',
   POPULARITY: 'popularity',
+};
+
+const searchTypeMap = {
+  work: '工作經驗',
+  interview: '面試經驗',
+};
+
+const sortByMap = {
+  created_at: '最新',
+  popularity: '熱門',
 };
 
 class ExperienceSearch extends Component {
@@ -328,14 +339,49 @@ class ExperienceSearch extends Component {
   }
 
   renderHelmet = () => {
-    const scale = getScale(this.props.experienceSearch.get('experienceCount'));
-    const description = `馬上查詢超過 ${scale} 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！`;
-    const data = HELMET_DATA.EXPERIENCE_SEARCH;
-    data.meta.push(
-      { name: 'description', content: description },
-      { property: 'og:description', content: description },
+    const {
+      searchType,
+      searchQuery,
+      sortBy,
+      page,
+    } = querySelector(this.props.location.query);
+
+    const count = this.props.experienceSearch.get('experienceCount');
+    const scale = getScale(count);
+    const url = formatCanonicalPath(this.props.location.pathname + this.props.location.search);
+    const searchTypeName = searchType.split(',').sort().reduce((names, type) => {
+      if (searchTypeMap[type]) { names.push(searchTypeMap[type]); }
+      return names;
+    }, []).join('、');
+
+    // default helmet info
+    let title = '查詢面試、工作經驗';
+    let description = `馬上查詢超過 ${scale} 篇面試及工作經驗分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！`;
+
+    // if searchQuery is given and number of result > 0, then show job / company name
+    if (searchQuery && count > 0) {
+      const tmpStr = `${searchQuery}的${searchTypeName}分享`;
+      title = `${tmpStr}，第 ${page} 頁`;
+      description = `馬上查看共 ${count} 篇有關${tmpStr}，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！`;
+    } else if (sortBy) { // if searchQuery is not given, but sortBy is given, then show 最新/熱門
+      title = `${sortByMap[sortBy]}${searchTypeName}分享 - 第 ${page} 頁`;
+      description = `馬上查詢超過 ${scale} 篇${searchTypeName}分享，讓我們一起把面試準備的更好，也更瞭解公司內部的真實樣貌，找到更適合自己的好工作！`;
+    }
+    return (
+      <Helmet
+        title={title}
+        meta={[
+          { name: 'description', content: description },
+          { property: 'og:title', content: formatTitle(title, SITE_NAME) },
+          { property: 'og:description', content: description },
+          { property: 'og:url', content: url },
+          { property: 'og:image', content: `${imgHost}/og/experience-search.jpg` },
+        ]}
+        link={[
+          { rel: 'canonical', href: url },
+        ]}
+      />
     );
-    return <Helmet {...data} />;
   }
 
   render() {

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -26,7 +26,7 @@ The followings are some useful elements from Open Graph Protocol:
 
 */
 
-const imgHost = 'https://image.goodjob.life';
+export const imgHost = 'https://image.goodjob.life';
 export const SITE_NAME = 'GoodJob 好工作評論網';
 export const HELMET_DATA = {
   DEFAULT: {
@@ -87,15 +87,7 @@ export const HELMET_DATA = {
     ],
   },
   EXPERIENCE_SEARCH: {
-    title: '查詢面試、工作經驗',
-    meta: [
-      { property: 'og:title', content: formatTitle('查詢面試、工作經驗', SITE_NAME) },
-      { property: 'og:url', content: formatCanonicalPath('/experiences/search') },
-      { property: 'og:image', content: `${imgHost}/og/experience-search.jpg` },
-    ],
-    link: [
-      { rel: 'canonical', href: formatCanonicalPath('/experiences/search') },
-    ],
+    // information is dynamic
   },
   EXPERIENCE_DETAIL: {
     // information is dynamic


### PR DESCRIPTION
Close #353 

## 這個 PR 是？ 

優化 experienceSearch 這一頁的 helmet 資訊
1. 當 searchQuery 不是空字串、資料數大於 0： `title`、`description` 會出現 `searchQuery` `page`
2. 當 searchQuery 未給定，但 sortby 有給定：`title`、`description` 會出現 `sortBy` (最新/熱門） `page`
3. 其他情況：預設值

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

query string 說明：
sortBy: `created_at` / `popularity`
searchQuery : 搜尋的關鍵字
searchType: `work, interview` / `work` / `interview`
page: start from 1 

## 我應該如何手動測試？ <!-- 必填 -->

以下幾個頁面的 helmet information 要正確，進該頁面後，要重新整理看網頁原始碼，看 SSR 有沒有對
- [ ] 以公司搜尋聯發科 `/experiences/search?sort=popularity&s_by=company&q=%E8%81%AF%E7%99%BC%E7%A7%91&p=1&type=interview%2Cwork` 要出現聯發科、頁數
- [ ] 以職稱搜尋工程師 `http://localhost:3001/experiences/search?sort=popularity&s_by=job_title&q=%E5%B7%A5%E7%A8%8B%E5%B8%AB&p=1&type=interview%2Cwork` 要出現工程師、頁數
- [ ] 熱門 `http://localhost:3001/experiences/search?sort=popularity&s_by=job_title&q=&p=1&type=interview%2Cwork` 要出現 熱門、頁數
- [ ] 最新 `http://localhost:3001/experiences/search?sort=created_at&s_by=job_title&q=&p=1&type=interview%2Cwork` 要出現 最新、頁數
