### PR TITLE
薪資工時查詢頁的 helmet 資訊

### DIFF
--- a/src/components/TimeAndSalary/index.js
+++ b/src/components/TimeAndSalary/index.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import Helmet from 'react-helmet';
 
 import Wrapper from 'common/base/Wrapper';
 import styles from './styles.module.css';
@@ -9,9 +10,27 @@ import MobileInfoButtons from './MobileInfoButtons';
 import InfoTimeModal from './common/InfoTimeModal';
 import InfoSalaryModal from './common/InfoSalaryModal';
 
+import { formatTitle, formatCanonicalPath } from '../../utils/helmetHelper';
+import { imgHost, SITE_NAME } from '../../constants/helmetData';
+
+const pathnameMapping = [
+  ['work-time-dashboard', '工時排行榜（由高到低）'],
+  ['sort/work-time-asc', '工時排行榜（由低到高）'],
+  ['salary-dashboard', '估算時薪排行榜（由高到低）'],
+  ['sort/salary-asc', '估算時薪排行榜（由低到高）'],
+  ['latest', '最新薪資、工時資訊'],
+  ['sort/time-asc', '最舊薪資、工時資訊'],
+];
+
 export default class TimeAndSalary extends Component {
   static propTypes = {
     children: PropTypes.node,
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }),
+    params: PropTypes.shape({
+      keyword: PropTypes.string,
+    }),
   }
 
   constructor(props) {
@@ -41,10 +60,43 @@ export default class TimeAndSalary extends Component {
     this.setState(state);
   }
 
+  renderHelmet = () => {
+    const path = this.props.location.pathname;
+    let title = '';
+    for (let i = 0; i < pathnameMapping.length; i += 1) {
+      if (path.indexOf(pathnameMapping[i][0]) >= 0) {
+        title = pathnameMapping[i][1];
+        break;
+      }
+    }
+    const keyword = this.props.params.keyword;
+    if (keyword) {
+      title = `${keyword}的${title}`;
+    }
+    const description = `馬上查看${keyword}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
+    const url = formatCanonicalPath(path);
+    return (
+      <Helmet
+        title={title}
+        meta={[
+          { name: 'description', content: description },
+          { property: 'og:title', content: formatTitle(title, SITE_NAME) },
+          { property: 'og:description', content: description },
+          { property: 'og:url', content: url },
+          { property: 'og:image', content: `${imgHost}/og/time-and-salary.jpg` },
+        ]}
+        link={[
+          { rel: 'canonical', href: url },
+        ]}
+      />
+    );
+  }
+
   render() {
     const { children } = this.props;
     return (
       <div className={styles.container}>
+        {this.renderHelmet()}
         <Banner />
         <Wrapper size="m" className={styles.showSearchbarWrapper}>
           <CallToShareData />

--- a/src/components/TimeAndSalary/index.js
+++ b/src/components/TimeAndSalary/index.js
@@ -13,14 +13,14 @@ import InfoSalaryModal from './common/InfoSalaryModal';
 import { formatTitle, formatCanonicalPath } from '../../utils/helmetHelper';
 import { imgHost, SITE_NAME } from '../../constants/helmetData';
 
-const pathnameMapping = [
-  ['work-time-dashboard', '工時排行榜（由高到低）'],
-  ['sort/work-time-asc', '工時排行榜（由低到高）'],
-  ['salary-dashboard', '估算時薪排行榜（由高到低）'],
-  ['sort/salary-asc', '估算時薪排行榜（由低到高）'],
-  ['latest', '最新薪資、工時資訊'],
-  ['sort/time-asc', '最舊薪資、工時資訊'],
-];
+const pathnameMapping = {
+  'work-time-dashboard': '工時排行榜（由高到低）',
+  'sort/work-time-asc': '工時排行榜（由低到高）',
+  'salary-dashboard': '估算時薪排行榜（由高到低）',
+  'sort/salary-asc': '估算時薪排行榜（由低到高）',
+  latest: '最新薪資、工時資訊',
+  'sort/time-asc': '最舊薪資、工時資訊',
+};
 
 export default class TimeAndSalary extends Component {
   static propTypes = {
@@ -62,19 +62,32 @@ export default class TimeAndSalary extends Component {
 
   renderHelmet = () => {
     const path = this.props.location.pathname;
-    let title = '';
-    for (let i = 0; i < pathnameMapping.length; i += 1) {
-      if (path.indexOf(pathnameMapping[i][0]) >= 0) {
-        title = pathnameMapping[i][1];
-        break;
+    const url = formatCanonicalPath(path);
+
+    // default title and description
+    let title = '查看薪資、工時資訊';
+    let description = '馬上查看薪資、工時資訊以及加班狀況，協助您找到更好的工作！';
+
+    // 根據 route 去更新 title  e.g. 工時排行榜（由高到低）
+    let name = '';
+    Object.keys(pathnameMapping).forEach(key => {
+      if (path.indexOf(key) >= 0) {
+        name = pathnameMapping[key];
       }
-    }
+    });
+    if (name) { title = name; }
+
+    // 假如 keyword 不是 null, undefined 或 ''。則把 keywords 更新到 title & description
     const keyword = this.props.params.keyword;
     if (keyword) {
-      title = `${keyword}的${title}`;
+      if (name) {
+        title = `${keyword}的${name}`;
+      } else {
+        title = `${keyword}的薪資、工時資訊`;
+      }
+      description = `馬上查看${keyword}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
     }
-    const description = `馬上查看${keyword}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
-    const url = formatCanonicalPath(path);
+
     return (
       <Helmet
         title={title}

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -26,7 +26,7 @@ The followings are some useful elements from Open Graph Protocol:
 
 */
 
-const imgHost = 'https://image.goodjob.life';
+export const imgHost = 'https://image.goodjob.life';
 export const SITE_NAME = 'GoodJob 好工作評論網';
 export const HELMET_DATA = {
   DEFAULT: {


### PR DESCRIPTION
Close #362 

## 這個 PR 是？ <!-- 必填 -->

產生薪資工時查詢頁的 helmet 資訊

## 我應該如何手動測試？ <!-- 必填 -->

#### 標題的部分：
1.
路徑包含 `work-time-dashboard` => `工時排行榜（由高到低）`
路徑包含 `sort/work-time-asc` => `工時排行榜（由低到高）`
路徑包含 `salary-dashboard` => `估算時薪排行榜（由高到低）`
路徑包含 `sort/salary-asc` => `估算時薪排行榜（由低到高）`
路徑包含 `latest` => `最新薪資、工時資訊`
路徑包含 `sort/time-asc`=>  `最舊薪資、工時資訊`

2.
路徑包含 /company/:company => 前方再加上 company 名稱
路徑包含 /job-title/:company => 前方再加上 job-title 名稱

e.g. `軟體工程師的工時排行榜（由高到低）`

#### 描述的部分：加上 company or job-title 名稱

- [ ] 測試每一個頁面是否產生相對應的 title、description