### PR TITLE
experiences blocks 中間塞 banner 

### DIFF
--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -58,6 +58,8 @@ const sortByMap = {
   popularity: '熱門',
 };
 
+const BANNER_LOCATION = 10;
+
 class ExperienceSearch extends Component {
   static fetchData({ location, store: { dispatch } }) {
     const { query } = location;
@@ -462,22 +464,36 @@ class ExperienceSearch extends Component {
                     尚未有「{data.searchQuery}」的經驗分享
                 </P>
               }
-
-              <Banner2 />
-
-              {
+              { // rendering experiences blocks and banner
                 loadingStatus === status.FETCHING
                 ? <Loader size="s" />
                 : (data.experiences || [])
-                  .map(o => (
-                    <ExperienceBlock
-                      key={o._id}
-                      to={`/experiences/${o._id}`}
-                      data={o}
-                      size="l"
-                      backable
-                    />
-                  ))
+                  .map((o, index) => {
+                    if (index === BANNER_LOCATION) {
+                      return (
+                        <div>
+                          <Banner2 />
+                          <ExperienceBlock
+                            key={o._id}
+                            to={`/experiences/${o._id}`}
+                            data={o}
+                            size="l"
+                            backable
+                          />
+                        </div>
+                      );
+                    }
+                    return (
+                      <ExperienceBlock
+                        key={o._id}
+                        to={`/experiences/${o._id}`}
+                        data={o}
+                        size="l"
+                        backable
+                      />
+                    );
+                  }
+                )
               }
 
               <Pagination

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -471,10 +471,9 @@ class ExperienceSearch extends Component {
                   .map((o, index) => {
                     if (index === BANNER_LOCATION) {
                       return (
-                        <div>
+                        <div key={o._id}>
                           <Banner2 />
                           <ExperienceBlock
-                            key={o._id}
                             to={`/experiences/${o._id}`}
                             data={o}
                             size="l"


### PR DESCRIPTION
part of #322  

## 這個 PR 是？ <!-- 必填 -->

在 experiences block 每頁的第 10 篇後面塞 banner，而不是一開始就顯示在最上方。

## Screenshots  <!-- 選填，沒有就刪掉 -->

![wnbzckzolj](https://user-images.githubusercontent.com/3805975/33277613-07c329c0-d3d4-11e7-912c-1862e9c3ffb5.gif)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 查看經驗分享列表，用任意參數搜尋排序都可以。如果資料大於 10 筆，banner 應該要出現在第 10 筆後面。

## TODO
- [x] 修改 s3 上的 image 
![artboard 3](https://user-images.githubusercontent.com/3805975/33277837-ad33f362-d3d4-11e7-883d-544e231109c4.png)
