### PR TITLE
TimeAndSalary enhance

### DIFF
--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -4,6 +4,7 @@ import Loading from 'common/Loader';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import $ from 'jquery';
 import cn from 'classnames';
+import { Link } from 'react-router';
 
 import Select from 'common/form/Select';
 import Table from 'common/table/Table';
@@ -68,12 +69,16 @@ const selectOptions = R.pipe(
 
 const getName = val => (
   <div>
-    {val.name}
+    <Link to={`/time-and-salary/company/${encodeURIComponent(val.name)}/work-time-dashboard`}>
+      {val.name}
+    </Link>
   </div>
 );
 const getTitle = (val, row) => (
   <div>
-    {val}
+    <Link to={`/time-and-salary/job-title/${encodeURIComponent(val)}/work-time-dashboard`}>
+      {val}
+    </Link>
     {' '}
     <span className={`pM ${commonStyles.sector}`}>
       {row.sector}

--- a/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
@@ -102,7 +102,7 @@ export default class TimeAndSalaryCompany extends Component {
           </div>
         </div>
         {raw.map((o, i) => (
-          <WorkingHourBlock key={o.company.id || i} data={o} groupSortBy={groupSortBy} />
+          <WorkingHourBlock key={o.company.id || i} data={o} groupSortBy={groupSortBy} isExpanded={(i === 0) && (raw.length === 1)} />
         ))}
       </section>
     );

--- a/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
@@ -100,7 +100,7 @@ export default class TimeAndSalaryJobTitle extends Component {
           </div>
         </div>
         {raw.map((o, i) => (
-          <WorkingHourBlock key={o.company.id || i} data={o} groupSortBy={groupSortBy} />
+          <WorkingHourBlock key={o.company.id || i} data={o} groupSortBy={groupSortBy} isExpanded={(i === 0) && (raw.length === 1)} />
         ))}
       </section>
     );

--- a/src/components/TimeAndSalary/common/WorkingHourBlock.js
+++ b/src/components/TimeAndSalary/common/WorkingHourBlock.js
@@ -11,12 +11,17 @@ class WorkingHourBlock extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
     groupSortBy: PropTypes.string.isRequired,
+    isExpanded: PropTypes.bool,
   }
 
-  constructor() {
-    super();
+  static defaultProps = {
+    isExpanded: false,
+  }
+
+  constructor(props) {
+    super(props);
     this.state = {
-      isExpanded: false,
+      isExpanded: props.isExpanded,
     };
   }
 


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

1. 幫 Board 的職稱與公司加上連結
2. 以公司或職稱搜尋：當資料只有一筆，自動展開

## 截圖

1. http://localhost:3001/time-and-salary/latest

  ![image](https://user-images.githubusercontent.com/1908007/33321638-5669ad26-d481-11e7-8563-62dab3a9779b.png)

2. 造訪 http://localhost:3001/time-and-salary/company/%E4%B8%AD%E8%8F%AF%E9%9B%BB%E4%BF%A1%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/work-time-dashboard 時，自動展開細節

![image](https://user-images.githubusercontent.com/1908007/33321658-6ac3cd6a-d481-11e7-950d-20cb06df98b4.png)


## 我應該如何手動測試？ <!-- 必填 -->

- [x] 直接跑 `npm run start`, 看截圖相關的網頁