### PR TITLE
改善選單切換速度

### DIFF
--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -64,9 +64,18 @@ export const fetchExperiences = (page, limit, _sort, searchBy, searchQuery, sear
     workings: '',
     currentPage: Number(page),
     searchType,
+    searchBy,
   };
 
   dispatch(setLoadintStatus(status.FETCHING));
+  dispatch(setSortAndExperiences({
+    ...objCond,
+    error: null,
+    experiences: [],
+    experienceCount: 0,
+    hasMore: false,
+    loadingStatus: status.FETCHING,
+  }));
 
   return getExperiencesApi(query)
     .then(result => {

--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -4,7 +4,7 @@ import {
   getExperiences as getExperiencesApi,
 } from '../apis/experiencesApi';
 
-import status from '../constants/status';
+import statusConstant from '../constants/status';
 
 
 export const SET_SEARCH_BY = 'SET_SEARCH_BY';
@@ -39,10 +39,11 @@ export const setCurrentPage = currentPage => ({
   },
 });
 
-const setLoadintStatus = loadingStatus => ({
+const setLoadingStatus = (status, error = null) => ({
   type: SET_LOADING_STATUS,
   payload: {
-    loadingStatus,
+    status,
+    error,
   },
 });
 
@@ -67,14 +68,12 @@ export const fetchExperiences = (page, limit, _sort, searchBy, searchQuery, sear
     searchBy,
   };
 
-  dispatch(setLoadintStatus(status.FETCHING));
+  dispatch(setLoadingStatus(statusConstant.FETCHING));
   dispatch(setSortAndExperiences({
     ...objCond,
-    error: null,
     experiences: [],
     experienceCount: 0,
     hasMore: false,
-    loadingStatus: status.FETCHING,
   }));
 
   return getExperiencesApi(query)
@@ -83,27 +82,17 @@ export const fetchExperiences = (page, limit, _sort, searchBy, searchQuery, sear
 
       const payload = {
         ...objCond,
-        error: null,
         experiences: (
           result.experiences
         ),
         experienceCount: result.total,
         hasMore,
-        loadingStatus: status.FETCHED,
       };
+      dispatch(setLoadingStatus(statusConstant.FETCHED));
       dispatch(setSortAndExperiences(payload));
     })
     .catch(error => {
-      const payload = {
-        ...objCond,
-        error,
-        experiences: [],
-        experienceCount: 0,
-        hasMore,
-        loadingStatus: status.ERROR,
-      };
-
-      dispatch(setSortAndExperiences(payload));
+      dispatch(setLoadingStatus(statusConstant.ERROR, error));
       throw error;
     });
 };

--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -8,13 +8,10 @@ import statusConstant from '../constants/status';
 
 
 export const SET_SEARCH_BY = 'SET_SEARCH_BY';
-export const SET_EXPERIENCES = 'SET_EXPERIENCES';
 export const SET_WORKINGS = 'SET_WORKINGS';
 export const SET_KEYWORD = 'SET_KEYWORD';
 export const SET_KEYWORDS = 'SET_KEYWORDS';
 export const SET_SORT_AND_EXPERIENCES = 'SET_SORT_AND_EXPERIENCES';
-export const SET_KEYWORDS_AND_EXPERIENCES = 'SET_KEYWORDS_AND_EXPERIENCES';
-export const SET_CURRENT_PAGE = 'SET_CURRENT_PAGE';
 export const SET_LOADING_STATUS = 'SET_LOADING_STATUS';
 
 export const setKeyword = keyword => ({
@@ -30,13 +27,6 @@ export const setSortAndExperiences = payload => ({
 export const setWorkings = workings => ({
   type: SET_WORKINGS,
   workings,
-});
-
-export const setCurrentPage = currentPage => ({
-  type: SET_CURRENT_PAGE,
-  payload: {
-    currentPage,
-  },
 });
 
 const setLoadingStatus = (status, error = null) => ({
@@ -57,12 +47,10 @@ export const fetchExperiences = (page, limit, _sort, searchBy, searchQuery, sear
     searchQuery,
     searchType,
   };
-  let hasMore = false;
 
   const objCond = {
     sort: _sort,
     searchQuery,
-    workings: '',
     currentPage: Number(page),
     searchType,
     searchBy,
@@ -73,20 +61,16 @@ export const fetchExperiences = (page, limit, _sort, searchBy, searchQuery, sear
     ...objCond,
     experiences: [],
     experienceCount: 0,
-    hasMore: false,
   }));
 
   return getExperiencesApi(query)
     .then(result => {
-      hasMore = (start + limit) < result.total;
-
       const payload = {
         ...objCond,
         experiences: (
           result.experiences
         ),
         experienceCount: result.total,
-        hasMore,
       };
       dispatch(setLoadingStatus(statusConstant.FETCHED));
       dispatch(setSortAndExperiences(payload));

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -456,7 +456,7 @@ class ExperienceSearch extends Component {
                 onSelect={this.fetchMoreExperiences}
               />
 
-              {(data.searchQuery && data.experienceCount === 0) &&
+              {(data.searchQuery && data.experienceCount === 0 && loadingStatus !== status.FETCHING) &&
                 <P
                   size="l" bold
                   className={styles.searchNoResult}

--- a/src/reducers/experienceSearch.js
+++ b/src/reducers/experienceSearch.js
@@ -4,13 +4,10 @@ import createReducer from 'utils/createReducer';
 import statusConstant from '../constants/status';
 import {
   SET_SEARCH_BY,
-  SET_EXPERIENCES,
   SET_WORKINGS,
   SET_KEYWORD,
   SET_KEYWORDS,
-  SET_KEYWORDS_AND_EXPERIENCES,
   SET_SORT_AND_EXPERIENCES,
-  SET_CURRENT_PAGE,
   SET_LOADING_STATUS,
 } from '../actions/experienceSearch';
 
@@ -24,12 +21,8 @@ const preloadedState = Map({
   experiences: [],
   experienceCount: 0,
 
-  industry: 'all',
   keyword: '', // input value 用
   keywords: [],
-  prevCond: 'sort',
-  preValue: '',
-  hasMore: false,
   workings: [],
   loadingStatus: statusConstant.UNFETCHED,
   error: null,
@@ -41,12 +34,6 @@ const experienceSearch = createReducer(preloadedState, {
 
   [SET_KEYWORD]: (state, action) =>
     state.update('keyword', () => action.keyword),
-
-  [SET_EXPERIENCES]: (state, action) =>
-    state.merge({
-      experiences: fromJS(action.experiences || []),
-      experienceCount: action.experienceCount,
-    }),
 
   [SET_WORKINGS]: (state, action) =>
     state.update('workings', () => fromJS(action.workings || [])),
@@ -61,28 +48,12 @@ const experienceSearch = createReducer(preloadedState, {
       sort: action.payload.sort,
       keyword: action.payload.searchQuery,
       searchQuery: action.payload.searchQuery,
-      workings: action.payload.workings,
       salary: action.payload.salary,
       experienceCount: action.payload.experienceCount,
       experiences: fromJS(action.payload.experiences || []),
-      hasMore: action.payload.hasMore,
-      prevCond: action.payload.prevCond,
-      prevValue: action.payload.prevValue,
       currentPage: action.payload.currentPage,
       searchType: action.payload.searchType,
       searchBy: action.payload.searchBy,
-    }),
-
-  [SET_KEYWORDS_AND_EXPERIENCES]: (state, action) =>
-    state.merge({
-      keyword: fromJS(action.keywords || []),
-      experienceCount: action.experienceCount,
-      experiences: fromJS(action.experiences || []),
-    }),
-
-  [SET_CURRENT_PAGE]: (state, action) =>
-    state.merge({
-      currentPage: action.payload.currentPage,
     }),
 
   [SET_LOADING_STATUS]: (state, { payload: { status, error } }) =>

--- a/src/reducers/experienceSearch.js
+++ b/src/reducers/experienceSearch.js
@@ -1,7 +1,7 @@
 import { Map, fromJS } from 'immutable';
 
 import createReducer from 'utils/createReducer';
-import status from '../constants/status';
+import statusConstant from '../constants/status';
 import {
   SET_SEARCH_BY,
   SET_EXPERIENCES,
@@ -16,20 +16,22 @@ import {
 
 const preloadedState = Map({
   sort: 'created_at',
-  searchType: ['interview', 'work'],
-  industry: 'all',
-  searchBy: 'job_title',
-  searchQuery: '', // query & result 用
-  keyword: '', // input value 用
-  keywords: [],
+  searchType: ['interview', 'work'], // 過濾 面試、工作經驗 --> 正確是 type
+  searchBy: 'job_title', // 搜尋類別（公司、職稱）
+  searchQuery: '', // 搜尋類別的關鍵字
+  currentPage: 1,
+
   experiences: [],
   experienceCount: 0,
+
+  industry: 'all',
+  keyword: '', // input value 用
+  keywords: [],
   prevCond: 'sort',
   preValue: '',
-  currentPage: 1,
   hasMore: false,
   workings: [],
-  loadingStatus: status.UNFETCHED,
+  loadingStatus: statusConstant.UNFETCHED,
   error: null,
 });
 
@@ -56,8 +58,6 @@ const experienceSearch = createReducer(preloadedState, {
 
   [SET_SORT_AND_EXPERIENCES]: (state, action) =>
     state.merge({
-      loadingStatus: action.payload.loadingStatus,
-      error: action.payload.error,
       sort: action.payload.sort,
       keyword: action.payload.searchQuery,
       searchQuery: action.payload.searchQuery,
@@ -85,9 +85,10 @@ const experienceSearch = createReducer(preloadedState, {
       currentPage: action.payload.currentPage,
     }),
 
-  [SET_LOADING_STATUS]: (state, action) =>
+  [SET_LOADING_STATUS]: (state, { payload: { status, error } }) =>
     state.merge({
-      loadingStatus: action.payload.loadingStatus,
+      loadingStatus: status,
+      error,
     }),
 });
 

--- a/src/reducers/experienceSearch.js
+++ b/src/reducers/experienceSearch.js
@@ -70,6 +70,7 @@ const experienceSearch = createReducer(preloadedState, {
       prevValue: action.payload.prevValue,
       currentPage: action.payload.currentPage,
       searchType: action.payload.searchType,
+      searchBy: action.payload.searchBy,
     }),
 
   [SET_KEYWORDS_AND_EXPERIENCES]: (state, action) =>


### PR DESCRIPTION
Close #378

## 這個 PR 是？ <!-- 必填 -->

改善 378 提到的選單切換過慢的問題，在 fetch experiences 前多 dispatch state 改變選單

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

1. e9c4bc1 先 dispatch FETCHING 狀態，且將 experiences data 清空
2. 1f817b2 是確保 fetch 結束後，才顯示 `尚未有「xxx」的經驗分享`

## 我應該如何手動測試？ <!-- 必填 -->

- [x] 打開 /experiences/search 試試看選單切換是不是比較即時 