### PR TITLE
Seperate GA tracking ID from production online and stage/dev environment

### DIFF
--- a/.circleci/docker-compose-dev.yml
+++ b/.circleci/docker-compose-dev.yml
@@ -9,5 +9,6 @@ services:
         - API_HOST=https://api-dev.goodjob.life
         - CONTENTFUL_API_HOST=https://content-stage.goodjob.life
         - FACEBOOK_APP_ID=1844389232511081
+        - GA_ID=UA-79990667-2
     ports:
       - 39000:3001

--- a/.circleci/docker-compose-production.yml
+++ b/.circleci/docker-compose-production.yml
@@ -9,5 +9,6 @@ services:
         - API_HOST=https://api.goodjob.life
         - CONTENTFUL_API_HOST=https://content.goodjob.life
         - FACEBOOK_APP_ID=1750216878594984
+        - GA_ID=UA-79990667-1
     ports:
       - 42000:3001

--- a/.circleci/docker-compose-stage.yml
+++ b/.circleci/docker-compose-stage.yml
@@ -9,5 +9,6 @@ services:
         - API_HOST=https://api.goodjob.life
         - CONTENTFUL_API_HOST=https://content-stage.goodjob.life
         - FACEBOOK_APP_ID=1750216878594984
+        - GA_ID=UA-79990667-2
     ports:
       - 39000:3001

--- a/src/config/config.dev.js
+++ b/src/config/config.dev.js
@@ -2,4 +2,5 @@ module.exports = {
   API_HOST: process.env.API_HOST || 'https://api-dev.goodjob.life',
   CONTENTFUL_API_HOST: process.env.CONTENTFUL_API_HOST || 'https://content-stage.goodjob.life',
   FACEBOOK_APP_ID: process.env.FACEBOOK_APP_ID || '1750608541889151',
+  GA_ID: process.env.GA_ID || 'UA-79990667-2',
 };

--- a/src/config/config.prod.js
+++ b/src/config/config.prod.js
@@ -2,4 +2,5 @@ module.exports = {
   API_HOST: process.env.API_HOST || 'https://api.goodjob.life',
   CONTENTFUL_API_HOST: process.env.CONTENTFUL_API_HOST || 'https://content.goodjob.life',
   FACEBOOK_APP_ID: process.env.FACEBOOK_APP_ID || '1750216878594984',
+  GA_ID: process.env.GA_ID || 'UA-79990667-1',
 };

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -13,7 +13,7 @@ class Root extends Component {
   }
 
   initGA = () => {
-    ReactGA.initialize('UA-79990667-1');
+    ReactGA.initialize(process.env.GA_ID);
   }
 
   logPageView = () => {

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -8,6 +8,7 @@ const {
   API_HOST,
   CONTENTFUL_API_HOST,
   FACEBOOK_APP_ID,
+  GA_ID,
 } = require('./src/config');
 
 module.exports = {
@@ -35,6 +36,7 @@ module.exports = {
         API_HOST: JSON.stringify(API_HOST),
         CONTENTFUL_API_HOST: JSON.stringify(CONTENTFUL_API_HOST),
         FACEBOOK_APP_ID: JSON.stringify(FACEBOOK_APP_ID),
+        GA_ID: JSON.stringify(GA_ID),
       },
       __SERVER__: false,
     }),


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

將開發用的 GA ID 改成別的，避免測試的時候造成錯誤的資訊

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

`src/config/config.*.js` --> 會根據 NODE_ENV 是 production or dev 決定要用的 GA_ID

`docker-compose-*.yml` --> 這個會從 process.env.GA_ID 覆蓋 config 的決定（以 https://www-stage.goodjob.life 來說，還是希望 GA_ID 與 https://www.goodjob.life 分開）

## 我應該如何手動測試？ <!-- 必填 -->

- [x] 測試幾個 GA request，確定送出去的 GA_ID 是 `UA-79990667-2`