### PR TITLE
前端加上權限機制

### DIFF
--- a/src/actions/dataCount.js
+++ b/src/actions/dataCount.js
@@ -1,0 +1,62 @@
+import { getExperiences } from '../apis/experiencesApi';
+import { fetchTimeAndSalary } from '../apis/timeAndSalaryApi';
+import fetchLaborRightsMetaList from '../apis/laborRightsApi';
+
+export const SET_EXPERIENCE_COUNT = '@@dataCount/SET_EXPERIENCE_COUNT';
+export const SET_TIME_AND_SALARY_COUNT = '@@dataCount/SET_TIME_AND_SALARY_COUNT';
+export const SET_LABOR_RIGHTS_COUNT = '@@dataCount/SET_LABOR_RIGHTS_COUNT';
+
+export const setExperienceCount = (count, hasFetched, err) => ({
+  type: SET_EXPERIENCE_COUNT,
+  count,
+  hasFetched,
+  err,
+});
+
+export const setTimeAndSalaryCount = (count, hasFetched, err) => ({
+  type: SET_TIME_AND_SALARY_COUNT,
+  count,
+  hasFetched,
+  err,
+});
+
+export const setLaborRightsCount = (count, hasFetched, err) => ({
+  type: SET_LABOR_RIGHTS_COUNT,
+  count,
+  hasFetched,
+  err,
+});
+
+export const queryExperienceCount = () =>
+dispatch => {
+  const query = {
+    limit: 1,
+    start: 0,
+    sort: 'created_at',
+  };
+
+  return getExperiences(query).then(data => {
+    const count = data.total;
+    dispatch(setExperienceCount(count, true, null));
+  }).catch(err => {
+    dispatch(setExperienceCount(0, false, err));
+  });
+};
+
+export const queryTimeAndSalaryCount = () =>
+dispatch =>
+  fetchTimeAndSalary().then(data => {
+    const count = data.total;
+    dispatch(setTimeAndSalaryCount(count, true, null));
+  }).catch(err => {
+    dispatch(setTimeAndSalaryCount(0, false, err));
+  });
+
+export const queryLaborRightsCount = () =>
+dispatch =>
+  fetchLaborRightsMetaList().then(data => {
+    const count = data.length;
+    dispatch(setLaborRightsCount(count, true, null));
+  }).catch(err => {
+    dispatch(setLaborRightsCount(0, false, err));
+  });

--- a/src/actions/me.js
+++ b/src/actions/me.js
@@ -7,6 +7,7 @@ export const SET_MY_WORKINGS = 'SET_MY_WORKINGS';
 export const SET_MY_WORKINGS_STATUS = 'SET_MY_WORKINGS_STATUS';
 export const SET_MY_REPLIES = 'SET_MY_REPLIES';
 export const SET_MY_REPLIES_STATUS = 'SET_MY_REPLIES_STATUS';
+export const SET_MY_PERMISSION = 'SET_MY_PERMISSION';
 
 const getIndex = (ary, id) => ary.map(e => e._id).indexOf(id);
 
@@ -29,6 +30,13 @@ export const setMyReplies = (myReplies, err) => ({
   myRepliesStatus: err ? status.ERROR : status.FETCHED,
   myRepliesError: err,
   myReplies,
+});
+
+export const setMyPermission = ({ permission, location }, err) => ({
+  type: SET_MY_PERMISSION,
+  permission,
+  location,
+  fetchPermissionError: err,
 });
 
 export const fetchMyExperiences = () => dispatch => {
@@ -167,3 +175,13 @@ export const setReplyStatus = o => (dispatch, getState) => {
     dispatch(setMyReplies(replies, null));
   });
 };
+
+export const fetchMyPermission = () => (dispatch, getState) =>
+  fetchUtil('/me/permissions/search')('GET').then(result => {
+    dispatch(setMyPermission({
+      permission: result.hasSearchPermission,
+      location: getState().routing.locationBeforeTransitions,
+    }, null));
+  }).catch(error => {
+    dispatch(setMyPermission({}, error));
+  });

--- a/src/apis/laborRightsApi.js
+++ b/src/apis/laborRightsApi.js
@@ -1,0 +1,8 @@
+import fetchUtil from 'utils/fetchUtil';
+
+import { CONTENTFUL_API_HOST } from '../config';
+
+const fetchLaborRightsMetaList = () =>
+  fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
+
+export default fetchLaborRightsMetaList;

--- a/src/components/ExperienceDetail/Article.js
+++ b/src/components/ExperienceDetail/Article.js
@@ -8,152 +8,193 @@ import InfoBlock from './InfoBlock';
 import SectionBlock from './SectionBlock';
 import QABlock from './QABlock';
 import { overallRatingDialogMap } from '../ShareExperience/common/optionMap';
+import { MAX_WORDS_IF_HIDDEN } from '../../constants/hideContent';
 
-const Article = ({ experience }) => (
-  <div className={styles.container}>
-    <aside className={styles.aside}>
-      {experience.type === 'interview' && (
-      <ul className={styles.infoList}>
-        <InfoBlock label="面試地區">
-          {experience.region}
-        </InfoBlock>
-        <InfoBlock label="應徵職稱">
-          {experience.job_title}
-        </InfoBlock>
-        {
-          experience.experience_in_year &&
-          <InfoBlock label="自身相關職務工作經驗">
-            {experience.experience_in_year} 年
-          </InfoBlock>
-        }
-        {
-          experience.education &&
-          <InfoBlock label="最高學歷">
-            {experience.education}
-          </InfoBlock>
-        }
-        {
-          experience.interview_time &&
-          <InfoBlock label="面試時間">
-            {`${experience.interview_time.year} 年 ${experience.interview_time.month} 月`}
-          </InfoBlock>
-        }
-        <InfoBlock label="面試結果">
-          {experience.interview_result}
-        </InfoBlock>
-        {
-          experience.salary &&
-          <InfoBlock label="待遇">
-            {`${experience.salary.amount} / ${Article.getTimeUnit(experience.salary.type)}`}
-          </InfoBlock>
-        }
-        <InfoBlock label="對公司的面試整體滿意度">
-          <div className={styles.ratingContainer}>
-            {[1, 2, 3, 4, 5].map(el => (
-              <Glike
-                key={el}
-                className={cn(rateButtonStyles.container, styles.autoCursor, {
-                  [rateButtonStyles.active]: (el <= experience.overall_rating),
-                })}
-              />
-            ))}
-            <div className={`${styles.ratingText} pS`}>
-              {overallRatingDialogMap[experience.overall_rating]}
-            </div>
-          </div>
-        </InfoBlock>
-        {
-          experience.interview_sensitive_questions && experience.interview_sensitive_questions.length
-          ? (<InfoBlock label="有以下特殊問題">
-            <ul>
-              {
-                experience.interview_sensitive_questions.map((o, idx) => (
-                  <li key={idx}>{o}</li>
-                ))
+class Article extends React.Component {
+
+  renderSections = () => {
+    const { experience, hideContent } = this.props;
+    let toHide = false;
+    let currentTotalWords = 0;
+
+    if (hideContent) {
+      return (
+        <div>
+          {experience.sections && (
+            experience.sections.map(({ subtitle, content }, idx) => {
+              if (toHide) { return null; }
+              currentTotalWords += content.length;
+              if (currentTotalWords > MAX_WORDS_IF_HIDDEN) {
+                toHide = true;
+                const showLength = content.length - (currentTotalWords - MAX_WORDS_IF_HIDDEN);
+                const newContent = `${content.substring(0, showLength)}...`;
+                return (
+                  <SectionBlock key={idx} subtitle={subtitle} content={newContent} />
+                );
               }
-            </ul>
-          </InfoBlock>)
-          : null
-        }
-      </ul>
-      )}
-
-      {experience.type === 'work' && (
-      <ul className={styles.infoList}>
-        <InfoBlock label="工作地區">
-          {experience.region}
-        </InfoBlock>
-        <InfoBlock label="職稱">
-          {experience.job_title}
-        </InfoBlock>
-        {
-          experience.experience_in_year &&
-          <InfoBlock label="自身相關職務工作經驗">
-            {experience.experience_in_year} 年
-          </InfoBlock>
-        }
-        {
-          experience.education &&
-          <InfoBlock label="最高學歷">
-            {experience.education}
-          </InfoBlock>
-        }
-        {
-          experience.week_work_time &&
-          <InfoBlock label="一週工時">
-            {experience.week_work_time}
-          </InfoBlock>
-        }
-        {
-          experience.salary &&
-          <InfoBlock label="待遇">
-            {`${experience.salary.amount} / ${Article.getTimeUnit(experience.salary.type)}`}
-          </InfoBlock>
-        }
-        {
-          experience.recommend_to_others &&
-          <InfoBlock label="是否推薦此工作">
-            {experience.recommend_to_others === 'yes' ?
-              <div className={styles.recommendIcon}><Good />推</div>
-              : <div className={styles.recommendIcon}><Bad /> 不推</div>
-            }
-          </InfoBlock>
-        }
-      </ul>
-      )}
-    </aside>
-    <section className={styles.main}>
-      <div className={styles.article}>
-        <Heading size="m" className={styles.heading}>{experience.title}</Heading>
+              return (
+                <SectionBlock key={idx} subtitle={subtitle} content={content} />
+              );
+            })
+          )}
+        </div>
+      );
+    }
+    return (
+      <div>
         {experience.sections && (
           experience.sections.map(({ subtitle, content }, idx) => (
-            <SectionBlock
-              key={idx}
-              subtitle={subtitle}
-              content={content}
-            />
+            <SectionBlock key={idx} subtitle={subtitle} content={content} />
           ))
         )}
       </div>
+    );
+  }
 
-      {(experience.type === 'interview' && experience.interview_qas
-        && experience.interview_qas.length) ?
-        (
-          <div className={styles.qaWrapper}>
-            <P size="l" bold>面試問答</P>
-            {experience.interview_qas.map(({ question, answer }, idx) => (
-              <QABlock key={idx} question={question} answer={answer} />
-            ))}
+  render() {
+    const { experience, hideContent } = this.props;
+    return (
+      <div className={styles.container}>
+        <aside className={styles.aside}>
+          {experience.type === 'interview' && (
+          <ul className={styles.infoList}>
+            <InfoBlock label="面試地區">
+              {experience.region}
+            </InfoBlock>
+            <InfoBlock label="應徵職稱">
+              {experience.job_title}
+            </InfoBlock>
+            {
+              experience.experience_in_year &&
+              <InfoBlock label="自身相關職務工作經驗">
+                {experience.experience_in_year} 年
+              </InfoBlock>
+            }
+            {
+              experience.education &&
+              <InfoBlock label="最高學歷">
+                {experience.education}
+              </InfoBlock>
+            }
+            {
+              experience.interview_time &&
+              <InfoBlock label="面試時間">
+                {`${experience.interview_time.year} 年 ${experience.interview_time.month} 月`}
+              </InfoBlock>
+            }
+            <InfoBlock label="面試結果">
+              {experience.interview_result}
+            </InfoBlock>
+            {
+              experience.salary &&
+              <InfoBlock label="待遇">
+                {`${experience.salary.amount} / ${Article.getTimeUnit(experience.salary.type)}`}
+              </InfoBlock>
+            }
+            <InfoBlock label="對公司的面試整體滿意度">
+              <div className={styles.ratingContainer}>
+                {[1, 2, 3, 4, 5].map(el => (
+                  <Glike
+                    key={el}
+                    className={cn(rateButtonStyles.container, styles.autoCursor, {
+                      [rateButtonStyles.active]: (el <= experience.overall_rating),
+                    })}
+                  />
+                ))}
+                <div className={`${styles.ratingText} pS`}>
+                  {overallRatingDialogMap[experience.overall_rating]}
+                </div>
+              </div>
+            </InfoBlock>
+            {
+              experience.interview_sensitive_questions && experience.interview_sensitive_questions.length
+              ? (<InfoBlock label="有以下特殊問題">
+                <ul>
+                  {
+                    experience.interview_sensitive_questions.map((o, idx) => (
+                      <li key={idx}>{o}</li>
+                    ))
+                  }
+                </ul>
+              </InfoBlock>)
+              : null
+            }
+          </ul>
+          )}
+
+          {experience.type === 'work' && (
+          <ul className={styles.infoList}>
+            <InfoBlock label="工作地區">
+              {experience.region}
+            </InfoBlock>
+            <InfoBlock label="職稱">
+              {experience.job_title}
+            </InfoBlock>
+            {
+              experience.experience_in_year &&
+              <InfoBlock label="自身相關職務工作經驗">
+                {experience.experience_in_year} 年
+              </InfoBlock>
+            }
+            {
+              experience.education &&
+              <InfoBlock label="最高學歷">
+                {experience.education}
+              </InfoBlock>
+            }
+            {
+              experience.week_work_time &&
+              <InfoBlock label="一週工時">
+                {experience.week_work_time}
+              </InfoBlock>
+            }
+            {
+              experience.salary &&
+              <InfoBlock label="待遇">
+                {`${experience.salary.amount} / ${Article.getTimeUnit(experience.salary.type)}`}
+              </InfoBlock>
+            }
+            {
+              experience.recommend_to_others &&
+              <InfoBlock label="是否推薦此工作">
+                {experience.recommend_to_others === 'yes' ?
+                  <div className={styles.recommendIcon}><Good />推</div>
+                  : <div className={styles.recommendIcon}><Bad /> 不推</div>
+                }
+              </InfoBlock>
+            }
+          </ul>
+          )}
+        </aside>
+        <section className={styles.main}>
+          <div className={styles.article}>
+            <Heading size="m" className={styles.heading}>{experience.title}</Heading>
+            {this.renderSections()}
           </div>
-        ) :
-        null
-      }
-    </section>
-  </div>
-);
+          {(experience.type === 'interview' &&
+            experience.interview_qas &&
+            experience.interview_qas.length &&
+            !hideContent
+          ) ?
+            (
+              <div className={styles.qaWrapper}>
+                <P size="l" bold>面試問答</P>
+                {experience.interview_qas.map(({ question, answer }, idx) => (
+                  <QABlock key={idx} question={question} answer={answer} />
+                ))}
+              </div>
+            ) :
+            null
+          }
+        </section>
+      </div>
+    );
+  }
+}
 
 Article.propTypes = {
   experience: PropTypes.object.isRequired,
+  hideContent: PropTypes.bool.isRequired,
 };
 
 Article.getTimeUnit = type => {

--- a/src/components/ExperienceDetail/Article.js
+++ b/src/components/ExperienceDetail/Article.js
@@ -187,7 +187,7 @@ class Article extends React.Component {
             ) :
             null
           }
-          {hideContent ? <BasicPermissionBlock /> : null}
+          {hideContent ? <BasicPermissionBlock rootClassName={styles.permissionBlockArticle} /> : null}
         </section>
       </div>
     );

--- a/src/components/ExperienceDetail/Article.js
+++ b/src/components/ExperienceDetail/Article.js
@@ -7,6 +7,7 @@ import styles from './Article.module.css';
 import InfoBlock from './InfoBlock';
 import SectionBlock from './SectionBlock';
 import QABlock from './QABlock';
+import BasicPermissionBlock from '../../containers/PermissionBlock/BasicPermissionBlockContainer';
 import { overallRatingDialogMap } from '../ShareExperience/common/optionMap';
 import { MAX_WORDS_IF_HIDDEN } from '../../constants/hideContent';
 
@@ -186,6 +187,7 @@ class Article extends React.Component {
             ) :
             null
           }
+          {hideContent ? <BasicPermissionBlock /> : null}
         </section>
       </div>
     );

--- a/src/components/ExperienceDetail/Article.module.css
+++ b/src/components/ExperienceDetail/Article.module.css
@@ -73,6 +73,8 @@ $paddingS: 16px;
 
 .main {
   flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .article {
@@ -101,5 +103,16 @@ $paddingS: 16px;
     width: 32px;
     height: 32px;
     margin-right: 8px;
+  }
+}
+
+.permissionBlockArticle {
+  flex-grow: 1;
+  margin-top: -40px;
+  padding: 50px 50px;
+
+  @media (max-width: 550px) {
+    margin-top: -15px;
+    padding: 50px 25px;
   }
 }

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -37,6 +37,7 @@ class ExperienceDetail extends Component {
     experienceDetail: ImmutablePropTypes.map.isRequired,
     fetchExperience: React.PropTypes.func.isRequired,
     fetchReplies: React.PropTypes.func.isRequired,
+    fetchMyPermission: React.PropTypes.func.isRequired,
     setTos: React.PropTypes.func.isRequired,
     likeExperience: React.PropTypes.func.isRequired,
     likeReply: React.PropTypes.func.isRequired,
@@ -52,6 +53,7 @@ class ExperienceDetail extends Component {
       }),
     }),
     authStatus: React.PropTypes.string,
+    canViewExperirenceDetail: React.PropTypes.bool.isRequired,
   }
 
   static fetchData({ store, params }) {
@@ -85,6 +87,7 @@ class ExperienceDetail extends Component {
       this.props.fetchExperience(this.props.params.id);
     }
     this.props.fetchReplies(this.props.params.id);
+    this.props.fetchMyPermission();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -92,6 +95,7 @@ class ExperienceDetail extends Component {
     if (nextProps.params.id !== this.props.params.id) {
       this.props.fetchExperience(nextProps.params.id);
       this.props.fetchReplies(nextProps.params.id);
+      this.props.fetchMyPermission();
     }
 
     if (nextProps.authStatus !== this.props.authStatus && nextProps.authStatus === authStatus.CONNECTED) {
@@ -202,7 +206,7 @@ class ExperienceDetail extends Component {
 
   render() {
     const {
-      experienceDetail, setTos, setComment, likeExperience, likeReply, params: { id },
+      experienceDetail, setTos, setComment, likeExperience, likeReply, params: { id }, canViewExperirenceDetail,
     } = this.props;
 
     const {
@@ -239,7 +243,7 @@ class ExperienceDetail extends Component {
             {
               data.experienceStatus === status.FETCHING
               ? <Loader />
-              : <Article experience={experience} />
+              : <Article experience={experience} hideContent={!canViewExperirenceDetail} />
             }
 
             { /* 按讚，分享，檢舉區塊  */}

--- a/src/components/LaborRightsSingle/Body.js
+++ b/src/components/LaborRightsSingle/Body.js
@@ -5,9 +5,8 @@ import { Section, Wrapper, Heading } from 'common/base';
 import MarkdownParser from './MarkdownParser';
 import styles from './Body.module.css';
 import LeftBanner from '../ExperienceSearch/Banners/Banner1';
-import LaborRightsPermissionBlock from '../../containers/PermissionBlock/LaborRightsPermissionBlockContainer';
 
-const Body = ({ title, seoText, description, content, hideContent }) => (
+const Body = ({ title, seoText, description, content, permissionBlock }) => (
   <Section Tag="main" pageTop>
     <Wrapper size="m">
       <Heading size="l" bold marginBottom>{title}</Heading>
@@ -28,12 +27,7 @@ const Body = ({ title, seoText, description, content, hideContent }) => (
         </StickyContainer>
         <div className={styles.content}>
           <MarkdownParser content={content} />
-          {hideContent ?
-            <LaborRightsPermissionBlock
-              rootClassName={styles.permissionBlockLaborRights}
-              description="- 123"
-            /> : null
-          }
+          {permissionBlock}
         </div>
       </div>
       {seoText && <div className={styles.seoText}>
@@ -48,12 +42,13 @@ Body.propTypes = {
   seoText: PropTypes.string,
   description: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
-  hideContent: PropTypes.bool.isRequired,
+  permissionBlock: PropTypes.element,
 };
 Body.defaultProps = {
   title: '',
   description: '',
   content: '',
+  permissionBlock: null,
 };
 
 export default Body;

--- a/src/components/LaborRightsSingle/Body.js
+++ b/src/components/LaborRightsSingle/Body.js
@@ -5,8 +5,9 @@ import { Section, Wrapper, Heading } from 'common/base';
 import MarkdownParser from './MarkdownParser';
 import styles from './Body.module.css';
 import LeftBanner from '../ExperienceSearch/Banners/Banner1';
+import LaborRightsPermissionBlock from '../../containers/PermissionBlock/LaborRightsPermissionBlockContainer';
 
-const Body = ({ title, seoText, description, content }) => (
+const Body = ({ title, seoText, description, content, hideContent }) => (
   <Section Tag="main" pageTop>
     <Wrapper size="m">
       <Heading size="l" bold marginBottom>{title}</Heading>
@@ -27,6 +28,12 @@ const Body = ({ title, seoText, description, content }) => (
         </StickyContainer>
         <div className={styles.content}>
           <MarkdownParser content={content} />
+          {hideContent ?
+            <LaborRightsPermissionBlock
+              rootClassName={styles.permissionBlockLaborRights}
+              description="- 123"
+            /> : null
+          }
         </div>
       </div>
       {seoText && <div className={styles.seoText}>
@@ -41,6 +48,7 @@ Body.propTypes = {
   seoText: PropTypes.string,
   description: PropTypes.string.isRequired,
   content: PropTypes.string.isRequired,
+  hideContent: PropTypes.bool.isRequired,
 };
 Body.defaultProps = {
   title: '',

--- a/src/components/LaborRightsSingle/Body.module.css
+++ b/src/components/LaborRightsSingle/Body.module.css
@@ -38,8 +38,3 @@
     }
   }
 }
-
-.permissionBlockLaborRights {
-  padding: 50px 25px;
-  margin-top: 25px;
-}

--- a/src/components/LaborRightsSingle/Body.module.css
+++ b/src/components/LaborRightsSingle/Body.module.css
@@ -38,3 +38,8 @@
     }
   }
 }
+
+.permissionBlockLaborRights {
+  padding: 50px 25px;
+  margin-top: 25px;
+}

--- a/src/components/LaborRightsSingle/LaborRightsSingle.module.css
+++ b/src/components/LaborRightsSingle/LaborRightsSingle.module.css
@@ -1,0 +1,4 @@
+.permissionBlockLaborRights {
+  padding: 50px 25px;
+  margin-top: 25px;
+}

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -59,7 +59,7 @@ class LaborRightsSingle extends React.Component {
 
     // hide some content if don't have permission
     let newContent = content;
-    if (!canViewLaborRightsSingle) {
+    if (!canViewLaborRightsSingle && content) {
       const endPos = nthIndexOf(content, MARKDOWN_DIVIDER, MAX_IMAGES_IF_HIDDEN);
       newContent = content.substr(0, endPos);
     }

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -8,16 +8,19 @@ import {
   formatCanonicalPath,
   formatUrl,
 } from 'utils/helmetHelper';
+import { nthIndexOf } from 'utils/stringUtil';
 import NotFound from 'common/NotFound';
 import CallToActionFolder from 'common/CallToAction/CallToActionFolder';
 import Body from './Body';
 import Footer from './Footer';
+import BasicPermissionBlock from '../../containers/PermissionBlock/BasicPermissionBlockContainer';
 
 import {
     fetchMetaListIfNeeded,
     fetchDataIfNeeded,
 } from '../../actions/laborRightsSingle';
 import status from '../../constants/status';
+import { MAX_IMAGES_IF_HIDDEN, MARKDOWN_DIVIDER } from '../../constants/hideContent';
 import { SITE_NAME } from '../../constants/helmetData';
 
 class LaborRightsSingle extends React.Component {
@@ -31,6 +34,7 @@ class LaborRightsSingle extends React.Component {
     this.props.fetchMetaListIfNeeded().then(() => {
       this.props.fetchDataIfNeeded(this.props.params.id);
     });
+    this.props.fetchMyPermission();
   }
 
   componentDidUpdate() {
@@ -52,6 +56,14 @@ class LaborRightsSingle extends React.Component {
       seoDescription,
       seoText,
     } = this.props.data ? this.props.data.toJS() : {};
+    const { canViewLaborRightsSingle } = this.props;
+
+    // hide some content if don't have permission
+    let newContent = content;
+    if (!canViewLaborRightsSingle) {
+      const endPos = nthIndexOf(content, MARKDOWN_DIVIDER, MAX_IMAGES_IF_HIDDEN);
+      newContent = content.substr(0, endPos);
+    }
     return (
       <main>
         <Helmet
@@ -79,11 +91,14 @@ class LaborRightsSingle extends React.Component {
                 title={title}
                 seoText={seoText}
                 description={description}
-                content={content}
+                content={newContent}
               />
-              <Section marginTop>
-                <CallToActionFolder />
-              </Section>
+              {!canViewLaborRightsSingle ? <BasicPermissionBlock /> : null}
+              {canViewLaborRightsSingle && (
+                <Section marginTop>
+                  <CallToActionFolder />
+                </Section>
+              )}
               <Footer
                 id={id}
                 prev={this.props.prev}
@@ -105,6 +120,8 @@ LaborRightsSingle.propTypes = {
   fetchDataIfNeeded: React.PropTypes.func.isRequired,
   status: React.PropTypes.string.isRequired,
   error: ImmutablePropTypes.map,
+  canViewLaborRightsSingle: React.PropTypes.bool.isRequired,
+  fetchMyPermission: React.PropTypes.func.isRequired,
 };
 
 export default LaborRightsSingle;

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -49,6 +49,7 @@ class LaborRightsSingle extends React.Component {
       description,
       content,
       coverUrl,
+      nPublicPages,
     } = this.props.data ? this.props.data.toJS() : {};
     const {
       seoTitle = title || '',
@@ -57,9 +58,10 @@ class LaborRightsSingle extends React.Component {
     } = this.props.data ? this.props.data.toJS() : {};
     const { canViewLaborRightsSingle } = this.props;
 
-    // hide some content if don't have permission
+    // hide some content if user dosen't have permission
+    // or when bPublicPages === -1, all pages are public
     let newContent = content;
-    if (!canViewLaborRightsSingle && content) {
+    if (!canViewLaborRightsSingle && nPublicPages > 0 && content) {
       const endPos = nthIndexOf(content, MARKDOWN_DIVIDER, MAX_IMAGES_IF_HIDDEN);
       newContent = content.substr(0, endPos);
     }
@@ -91,9 +93,9 @@ class LaborRightsSingle extends React.Component {
                 seoText={seoText}
                 description={description}
                 content={newContent}
-                hideContent={!canViewLaborRightsSingle}
+                hideContent={!canViewLaborRightsSingle && nPublicPages > 0}
               />
-              {canViewLaborRightsSingle && (
+              {(canViewLaborRightsSingle || nPublicPages < 0) && (
                 <Section marginTop>
                   <CallToActionFolder />
                 </Section>

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -13,6 +13,7 @@ import NotFound from 'common/NotFound';
 import CallToActionFolder from 'common/CallToAction/CallToActionFolder';
 import Body from './Body';
 import Footer from './Footer';
+import LaborRightsPermissionBlock from '../../containers/PermissionBlock/LaborRightsPermissionBlockContainer';
 
 import {
     fetchMetaListIfNeeded,
@@ -21,6 +22,8 @@ import {
 import status from '../../constants/status';
 import { MAX_IMAGES_IF_HIDDEN, MARKDOWN_DIVIDER } from '../../constants/hideContent';
 import { SITE_NAME } from '../../constants/helmetData';
+
+import styles from './LaborRightsSingle.module.css';
 
 class LaborRightsSingle extends React.Component {
   static fetchData({ store: { dispatch }, params: { id } }) {
@@ -50,6 +53,7 @@ class LaborRightsSingle extends React.Component {
       content,
       coverUrl,
       nPublicPages,
+      descriptionInPermissionBlock,
     } = this.props.data ? this.props.data.toJS() : {};
     const {
       seoTitle = title || '',
@@ -59,11 +63,18 @@ class LaborRightsSingle extends React.Component {
     const { canViewLaborRightsSingle } = this.props;
 
     // hide some content if user dosen't have permission
-    // or when bPublicPages === -1, all pages are public
+    // but when bPublicPages === -1, all pages are public
     let newContent = content;
+    let permissionBlock = null;
     if (!canViewLaborRightsSingle && nPublicPages > 0 && content) {
       const endPos = nthIndexOf(content, MARKDOWN_DIVIDER, MAX_IMAGES_IF_HIDDEN);
       newContent = content.substr(0, endPos);
+      permissionBlock = (
+        <LaborRightsPermissionBlock
+          rootClassName={styles.permissionBlockLaborRights}
+          description={descriptionInPermissionBlock || ''}
+        />
+      );
     }
     return (
       <main>
@@ -93,7 +104,7 @@ class LaborRightsSingle extends React.Component {
                 seoText={seoText}
                 description={description}
                 content={newContent}
-                hideContent={!canViewLaborRightsSingle && nPublicPages > 0}
+                permissionBlock={permissionBlock}
               />
               {(canViewLaborRightsSingle || nPublicPages < 0) && (
                 <Section marginTop>

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -13,7 +13,6 @@ import NotFound from 'common/NotFound';
 import CallToActionFolder from 'common/CallToAction/CallToActionFolder';
 import Body from './Body';
 import Footer from './Footer';
-import BasicPermissionBlock from '../../containers/PermissionBlock/BasicPermissionBlockContainer';
 
 import {
     fetchMetaListIfNeeded,
@@ -92,8 +91,8 @@ class LaborRightsSingle extends React.Component {
                 seoText={seoText}
                 description={description}
                 content={newContent}
+                hideContent={!canViewLaborRightsSingle}
               />
-              {!canViewLaborRightsSingle ? <BasicPermissionBlock /> : null}
               {canViewLaborRightsSingle && (
                 <Section marginTop>
                   <CallToActionFolder />

--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -47,6 +47,7 @@ class Header extends React.Component {
     if (prevProps.auth.get('status') !== this.props.auth.get('status') &&
       this.props.auth.get('status') === authStatus.CONNECTED) {
       const { getMe, FB } = this.props;
+      this.props.fetchMyPermission();
       getMe(FB).catch(() => {});
     }
   }
@@ -156,6 +157,7 @@ Header.propTypes = {
   auth: React.PropTypes.object,
   FB: React.PropTypes.object,
   location: React.PropTypes.object,
+  fetchMyPermission: React.PropTypes.func.isRequired,
 };
 
 const HeaderButton = ({ isNavOpen, toggle }) => (

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { browserHistory, Link } from 'react-router';
+import { Link } from 'react-router';
 
 import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
@@ -16,7 +16,7 @@ import authStatus from '../../../constants/authStatus';
 const getSuccessFeedback = id => (
   <SuccessFeedback
     buttonClick={() => (
-      browserHistory.push(`/experiences/${id}`)
+      window.location.replace(`/experiences/${id}`)
     )}
   />
 );
@@ -26,7 +26,7 @@ const getWorkingsSuccessFeedback = count => (
     info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
     buttonText="查看最新工時、薪資"
     buttonClick={() => (
-      browserHistory.push('/time-and-salary/latest')
+      window.location.replace('/time-and-salary/latest')
     )}
   />
 );

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -48,8 +48,8 @@
 
 .extremeRow {
   background-color: #f1f1f1;
+}
 
-  .noBefore::before {
-    content: none !important;
-  }
+.noBefore::before {
+  content: none !important;
 }

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -53,3 +53,10 @@
 .noBefore::before {
   content: none !important;
 }
+
+.permissionBlockBoard {
+  margin: -12px -20px;
+  padding: 50px 25px;
+
+  width: calc(100% + 40px);
+}

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -183,7 +183,7 @@ const injectPermissionBlock = rows => {
   newRows.push(
     <tr>
       <td colSpan="7" className={styles.noBefore}>
-        <BasicPermissionBlock />
+        <BasicPermissionBlock rootClassName={styles.permissionBlockBoard} />
       </td>
     </tr>
     );

--- a/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryCompany/index.js
@@ -48,11 +48,11 @@ export default class TimeAndSalaryCompany extends Component {
     params: PropTypes.object.isRequired,
     queryCompany: PropTypes.func,
     switchPath: PropTypes.func,
+    canViewTimeAndSalary: PropTypes.bool.isRequired,
+    fetchMyPermission: PropTypes.func.isRequired,
   }
 
   static fetchData({ routes, params, store: { dispatch } }) {
-    console.log(routes);
-    console.log(params);
     const { path } = R.last(routes);
     const { groupSortBy, order } = pathnameMapping[path];
     const company = params.keyword;
@@ -65,6 +65,7 @@ export default class TimeAndSalaryCompany extends Component {
     const { groupSortBy, order } = pathnameMapping[path];
     const company = this.props.params.keyword;
     this.props.queryCompany({ groupSortBy, order, company });
+    this.props.fetchMyPermission();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -73,11 +74,12 @@ export default class TimeAndSalaryCompany extends Component {
       const { groupSortBy, order } = pathnameMapping[path];
       const company = nextProps.params.keyword;
       this.props.queryCompany({ groupSortBy, order, company });
+      this.props.fetchMyPermission();
     }
   }
 
   render() {
-    const { route: { path }, switchPath } = this.props;
+    const { route: { path }, switchPath, canViewTimeAndSalary } = this.props;
     const { groupSortBy } = pathnameMapping[path];
     const company = this.props.params.keyword;
     const raw = this.props.data.toJS();
@@ -102,7 +104,13 @@ export default class TimeAndSalaryCompany extends Component {
           </div>
         </div>
         {raw.map((o, i) => (
-          <WorkingHourBlock key={o.company.id || i} data={o} groupSortBy={groupSortBy} isExpanded={(i === 0) && (raw.length === 1)} />
+          <WorkingHourBlock
+            key={o.company.id || i}
+            data={o}
+            groupSortBy={groupSortBy}
+            isExpanded={(i === 0) && (raw.length === 1)}
+            hideContent={!canViewTimeAndSalary}
+          />
         ))}
       </section>
     );

--- a/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryJobTitle/index.js
@@ -48,6 +48,8 @@ export default class TimeAndSalaryJobTitle extends Component {
     params: PropTypes.object.isRequired,
     queryJobTitle: PropTypes.func,
     switchPath: PropTypes.func,
+    canViewTimeAndSalary: PropTypes.bool.isRequired,
+    fetchMyPermission: PropTypes.func.isRequired,
   }
 
   static fetchData({ routes, params, store: { dispatch } }) {
@@ -63,6 +65,7 @@ export default class TimeAndSalaryJobTitle extends Component {
     const { groupSortBy, order } = pathnameMapping[path];
     const jobTitle = this.props.params.keyword;
     this.props.queryJobTitle({ groupSortBy, order, jobTitle });
+    this.props.fetchMyPermission();
   }
 
   componentWillReceiveProps(nextProps) {
@@ -71,11 +74,12 @@ export default class TimeAndSalaryJobTitle extends Component {
       const { groupSortBy, order } = pathnameMapping[path];
       const jobTitle = nextProps.params.keyword;
       this.props.queryJobTitle({ groupSortBy, order, jobTitle });
+      this.props.fetchMyPermission();
     }
   }
 
   render() {
-    const { route: { path }, switchPath } = this.props;
+    const { route: { path }, switchPath, canViewTimeAndSalary } = this.props;
     const { title, groupSortBy } = pathnameMapping[path];
     const jobTitle = this.props.params.keyword;
     const raw = this.props.data.toJS();
@@ -100,7 +104,13 @@ export default class TimeAndSalaryJobTitle extends Component {
           </div>
         </div>
         {raw.map((o, i) => (
-          <WorkingHourBlock key={o.company.id || i} data={o} groupSortBy={groupSortBy} isExpanded={(i === 0) && (raw.length === 1)} />
+          <WorkingHourBlock
+            key={o.company.id || i}
+            data={o}
+            groupSortBy={groupSortBy}
+            isExpanded={(i === 0) && (raw.length === 1)}
+            hideContent={!canViewTimeAndSalary}
+          />
         ))}
       </section>
     );

--- a/src/components/TimeAndSalary/common/WorkingHourBlock.js
+++ b/src/components/TimeAndSalary/common/WorkingHourBlock.js
@@ -6,12 +6,14 @@ import OvertimeBlock from './OvertimeBlock';
 import WorkingHourTable from './WorkingHourTable';
 
 import styles from './WorkingHourBlock.module.css';
+import BasicPermissionBlock from '../../../containers/PermissionBlock/BasicPermissionBlockContainer';
 
 class WorkingHourBlock extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
     groupSortBy: PropTypes.string.isRequired,
     isExpanded: PropTypes.bool,
+    hideContent: PropTypes.bool.isRequired,
   }
 
   static defaultProps = {
@@ -25,12 +27,44 @@ class WorkingHourBlock extends Component {
     };
   }
 
+  renderBlockContent = () => {
+    const { data, hideContent } = this.props;
+    if (hideContent) {
+      return (
+        <div className={styles.overtimeBlock}>
+          <div className={styles.overtimeBlockInner}>
+            <BasicPermissionBlock />
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div>
+        <div className={styles.overtimeBlock}>
+          <div className={styles.overtimeBlockInner}>
+            <OvertimeBlock
+              type="salary"
+              heading="加班有無加班費"
+              data={data}
+            />
+            <OvertimeBlock
+              type="dayoff"
+              heading="加班有無補休"
+              data={data}
+            />
+          </div>
+          <div className={styles.overtimeBlockUnit}>單位：資料筆數</div>
+        </div>
+        <WorkingHourTable data={data.time_and_salary} />
+      </div>
+    );
+  }
+
   render() {
     const { data, groupSortBy } = this.props;
     const { average, company } = data;
     const avgVal = average[groupSortBy];
     const avgUnit = groupSortBy === 'week_work_time' ? '小時' : '元';
-
     return (
       <section className={styles.container}>
         <button
@@ -61,24 +95,7 @@ class WorkingHourBlock extends Component {
             [styles.expanded]: this.state.isExpanded,
           })}
         >
-
-          <div className={styles.overtimeBlock}>
-            <div className={styles.overtimeBlockInner}>
-              <OvertimeBlock
-                type="salary"
-                heading="加班有無加班費"
-                data={data}
-              />
-              <OvertimeBlock
-                type="dayoff"
-                heading="加班有無補休"
-                data={data}
-              />
-            </div>
-            <div className={styles.overtimeBlockUnit}>單位：資料筆數</div>
-          </div>
-
-          <WorkingHourTable data={data.time_and_salary} />
+          {this.renderBlockContent()}
         </div>
       </section>
     );

--- a/src/components/TimeAndSalary/common/WorkingHourBlock.js
+++ b/src/components/TimeAndSalary/common/WorkingHourBlock.js
@@ -33,7 +33,7 @@ class WorkingHourBlock extends Component {
       return (
         <div className={styles.overtimeBlock}>
           <div className={styles.overtimeBlockInner}>
-            <BasicPermissionBlock />
+            <BasicPermissionBlock rootClassName={styles.permissionBlockWorkingHour} />
           </div>
         </div>
       );

--- a/src/components/TimeAndSalary/common/WorkingHourBlock.module.css
+++ b/src/components/TimeAndSalary/common/WorkingHourBlock.module.css
@@ -173,3 +173,15 @@
 .averageBlockValue {
 
 }
+
+.permissionBlockWorkingHour {
+  margin: -24px;
+  padding: 50px 25px;
+
+  width: calc(100% + 48px);
+
+  @media (max-width: 1024px) {
+    margin: -16px;
+    width: calc(100% + 32px);
+  }
+}

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -1,0 +1,42 @@
+import React, { PropTypes } from 'react';
+
+import styles from './PermissionBlock.module.css';
+
+class BasicPermissionBlock extends React.Component {
+  static propTypes = {
+    experienceCount: PropTypes.number.isRequired,
+    timeAndSalaryCount: PropTypes.number.isRequired,
+    laborRightsCount: PropTypes.number.isRequired,
+    hasFetchedExperienceCount: PropTypes.bool.isRequired,
+    hasFetchedTimeAndSalaryCount: PropTypes.bool.isRequired,
+    hasFetchedLaborRightsCount: PropTypes.bool.isRequired,
+    queryExperienceCount: PropTypes.func.isRequired,
+    queryTimeAndSalaryCount: PropTypes.func.isRequired,
+    queryLaborRightsCount: PropTypes.func.isRequired,
+  }
+
+  componentDidMount() {
+    if (this.props.hasFetchedExperienceCount === false) {
+      this.props.queryExperienceCount();
+    }
+    if (this.props.hasFetchedTimeAndSalaryCount === false) {
+      this.props.queryTimeAndSalaryCount();
+    }
+    if (this.props.hasFetchedLaborRightsCount === false) {
+      this.props.queryLaborRightsCount();
+    }
+  }
+
+  render() {
+    const { experienceCount, timeAndSalaryCount, laborRightsCount } = this.props;
+    return (
+      <div className={styles['permission-block']}>
+        <span>{`只要 40 秒，分享一筆你的 薪資 或 工時 或 面試 或 工作經驗，就能查看全站超過 ${timeAndSalaryCount} 筆薪資工時資訊、${experienceCount} 篇面試及工作經驗分享，以及 ${laborRightsCount} 篇的勞動權益懶人包哦！`}</span>
+        <span>若你已經分享過資訊，登入即可查看全文！</span>
+        <button> CTA button </button>
+      </div>
+    );
+  }
+}
+
+export default BasicPermissionBlock;

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 import cn from 'classnames';
-import { Link } from 'react-router';
 
 import P from 'common/base/P';
+import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
 import styles from './PermissionBlock.module.css';
 
 class BasicPermissionBlock extends React.Component {
@@ -50,7 +50,7 @@ class BasicPermissionBlock extends React.Component {
           <br />
           <P size="l"><strong>若你已經分享過資訊，登入即可查看全文！</strong></P>
           <div className={styles.ctaButtonContainer}>
-            <Link to={'/share'} className={cn('buttonCircleM', 'buttonBlack2')}>立即登入並分享</Link>
+            <CallToLoginShareButton to="/share" notLoginText="立即登入並分享" isLoginText="立即分享" />
           </div>
         </div>
       </div>

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -1,9 +1,13 @@
 import React, { PropTypes } from 'react';
+import cn from 'classnames';
+import { Link } from 'react-router';
 
+import P from 'common/base/P';
 import styles from './PermissionBlock.module.css';
 
 class BasicPermissionBlock extends React.Component {
   static propTypes = {
+    rootClassName: PropTypes.string,
     experienceCount: PropTypes.number.isRequired,
     timeAndSalaryCount: PropTypes.number.isRequired,
     laborRightsCount: PropTypes.number.isRequired,
@@ -13,6 +17,10 @@ class BasicPermissionBlock extends React.Component {
     queryExperienceCount: PropTypes.func.isRequired,
     queryTimeAndSalaryCount: PropTypes.func.isRequired,
     queryLaborRightsCount: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    rootClassName: '',
   }
 
   componentDidMount() {
@@ -28,12 +36,23 @@ class BasicPermissionBlock extends React.Component {
   }
 
   render() {
-    const { experienceCount, timeAndSalaryCount, laborRightsCount } = this.props;
+    const { rootClassName, experienceCount, timeAndSalaryCount, laborRightsCount } = this.props;
     return (
-      <div className={styles['permission-block']}>
-        <span>{`只要 40 秒，分享一筆你的 薪資 或 工時 或 面試 或 工作經驗，就能查看全站超過 ${timeAndSalaryCount} 筆薪資工時資訊、${experienceCount} 篇面試及工作經驗分享，以及 ${laborRightsCount} 篇的勞動權益懶人包哦！`}</span>
-        <span>若你已經分享過資訊，登入即可查看全文！</span>
-        <button> CTA button </button>
+      <div className={cn(styles.permissionBlock, rootClassName)}>
+        <div className={styles.container}>
+          <P size="l" className={styles.ctaText}>
+            <strong>只要 40 秒</strong>，分享一筆你的 薪資<strong> 或 </strong>工時
+            <strong> 或 </strong>面試<strong> 或 </strong> 工作經驗，就能查看
+            <strong>{`全站 ${timeAndSalaryCount} 筆`}</strong>薪資工時資訊、
+            <strong>{`${experienceCount} 篇`}</strong>面試及工作經驗分享，以及
+            <strong>{` ${laborRightsCount} 篇`}</strong>勞動權益懶人包哦！
+          </P>
+          <br />
+          <P size="l"><strong>若你已經分享過資訊，登入即可查看全文！</strong></P>
+          <div className={styles.ctaButtonContainer}>
+            <Link to={'/share'} className={cn('buttonCircleM', 'buttonBlack2')}>立即登入並分享</Link>
+          </div>
+        </div>
       </div>
     );
   }

--- a/src/components/common/PermissionBlock/CallToLoginShareButton.js
+++ b/src/components/common/PermissionBlock/CallToLoginShareButton.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cn from 'classnames';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import { Link } from 'react-router';
+
+import authStatus from '../../../constants/authStatus';
+import FacebookFail from '../../ShareExperience/common/FacebookFail';
+
+const isLogin = auth =>
+  auth.get('status') === authStatus.CONNECTED;
+
+const getFacebookFail = buttonClick => (
+  <FacebookFail
+    buttonClick={buttonClick}
+  />
+);
+
+class CallToLoginShareButton extends React.PureComponent {
+
+  onFacebookFail = () => {
+    this.handleIsOpen(true);
+    this.handleHasClose(true);
+    return this.handleFeedback(getFacebookFail(this.login));
+  }
+
+  handleFeedback = feedback => {
+    this.setState(() => ({
+      feedback,
+    }));
+  }
+
+  login = () => this.props.login(this.props.FB)
+    .then(status => {
+      if (status === authStatus.CONNECTED) {
+        window.location.reload();
+      } else {
+        throw Error('can not login');
+      }
+    })
+    .catch(e => {
+      console.log(e);
+      this.onFacebookFail();
+    });
+
+  render() {
+    const { notLoginText, isLoginText, to, auth } = this.props;
+    return (
+      <div
+        style={{
+          textAlign: 'center',
+        }}
+      >
+        {
+          isLogin(auth) ?
+            <Link
+              className={cn('buttonCircleM', 'buttonBlack2')}
+              to={to}
+            >
+              {isLoginText}
+            </Link> :
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+              }}
+            >
+              <button
+                className={cn('buttonCircleM', 'buttonBlack2')}
+                onClick={this.login}
+              >
+                <pre>{notLoginText}</pre>
+              </button>
+            </div>
+        }
+      </div>
+    );
+  }
+}
+
+CallToLoginShareButton.propTypes = {
+  notLoginText: PropTypes.string.isRequired,
+  isLoginText: PropTypes.string.isRequired,
+  to: PropTypes.string.isRequired,
+  auth: ImmutablePropTypes.map,
+  login: PropTypes.func.isRequired,
+  FB: PropTypes.object,
+};
+
+export default CallToLoginShareButton;

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -1,0 +1,70 @@
+import React, { PropTypes } from 'react';
+import cn from 'classnames';
+import { Link } from 'react-router';
+
+import P from 'common/base/P';
+import MarkdownParser from '../../LaborRightsSingle/MarkdownParser';
+import styles from './PermissionBlock.module.css';
+
+class BasicPermissionBlock extends React.Component {
+  static propTypes = {
+    rootClassName: PropTypes.string,
+    experienceCount: PropTypes.number.isRequired,
+    timeAndSalaryCount: PropTypes.number.isRequired,
+    laborRightsCount: PropTypes.number.isRequired,
+    description: PropTypes.string.isRequired,
+    hasFetchedExperienceCount: PropTypes.bool.isRequired,
+    hasFetchedTimeAndSalaryCount: PropTypes.bool.isRequired,
+    hasFetchedLaborRightsCount: PropTypes.bool.isRequired,
+    queryExperienceCount: PropTypes.func.isRequired,
+    queryTimeAndSalaryCount: PropTypes.func.isRequired,
+    queryLaborRightsCount: PropTypes.func.isRequired,
+  }
+
+  static defaultProps = {
+    rootClassName: '',
+  }
+
+  componentDidMount() {
+    if (this.props.hasFetchedExperienceCount === false) {
+      this.props.queryExperienceCount();
+    }
+    if (this.props.hasFetchedTimeAndSalaryCount === false) {
+      this.props.queryTimeAndSalaryCount();
+    }
+    if (this.props.hasFetchedLaborRightsCount === false) {
+      this.props.queryLaborRightsCount();
+    }
+  }
+
+  render() {
+    const { rootClassName, experienceCount, timeAndSalaryCount, laborRightsCount, description } = this.props;
+    return (
+      <div className={cn(styles.permissionBlock, rootClassName)}>
+        <div className={styles.container}>
+          <P size="l" className={styles.ctaText}>
+            <strong>只要 40 秒</strong>，分享一筆你的 薪資<strong> 或 </strong>工時
+            <strong> 或 </strong>面試<strong> 或 </strong> 工作經驗，就能
+            <strong>查看完整</strong>的懶人包，內容包含：
+          </P>
+          <div className={styles.descriptionContainer}>
+            <MarkdownParser content={description} />
+          </div>
+          <P size="l" className={styles.ctaText}>
+            還可以查看
+            <strong>{`全站 ${timeAndSalaryCount} 筆`}</strong>薪資工時資訊、
+            <strong>{`${experienceCount} 篇`}</strong>面試及工作經驗分享，以及其他
+            <strong>{` ${laborRightsCount - 1} 篇`}</strong>勞動權益懶人包哦！
+          </P>
+          <br />
+          <P size="l"><strong>若你已經分享過資訊，登入即可查看全文！</strong></P>
+          <div className={styles.ctaButtonContainer}>
+            <Link to={'/share'} className={cn('buttonCircleM', 'buttonBlack2')}>立即登入並分享</Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default BasicPermissionBlock;

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -1,9 +1,9 @@
 import React, { PropTypes } from 'react';
 import cn from 'classnames';
-import { Link } from 'react-router';
 
 import P from 'common/base/P';
 import MarkdownParser from '../../LaborRightsSingle/MarkdownParser';
+import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
 import styles from './PermissionBlock.module.css';
 
 class BasicPermissionBlock extends React.Component {
@@ -59,7 +59,7 @@ class BasicPermissionBlock extends React.Component {
           <br />
           <P size="l"><strong>若你已經分享過資訊，登入即可查看全文！</strong></P>
           <div className={styles.ctaButtonContainer}>
-            <Link to={'/share'} className={cn('buttonCircleM', 'buttonBlack2')}>立即登入並分享</Link>
+            <CallToLoginShareButton to="/share" notLoginText="立即登入並分享" isLoginText="立即分享" />
           </div>
         </div>
       </div>

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -1,0 +1,16 @@
+
+
+.permission-block {
+  /*
+  flex-grow: 1;
+  margin-top: -20px;
+  margin-left: -30px;
+  margin-right: -30px;
+  margin-bottom: 30px;
+  */
+  border: 1px solid #FCD406;
+  border-radius: 5px;
+  background-color: #FFFBE8;
+  box-shadow: 0 0 5px 0 rgba(0,0,0,0.21);
+}
+

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -1,16 +1,23 @@
 
 
-.permission-block {
-  /*
-  flex-grow: 1;
-  margin-top: -20px;
-  margin-left: -30px;
-  margin-right: -30px;
-  margin-bottom: 30px;
-  */
+.permissionBlock {
   border: 1px solid #FCD406;
   border-radius: 5px;
   background-color: #FFFBE8;
   box-shadow: 0 0 5px 0 rgba(0,0,0,0.21);
+}
+
+.container {
+  max-width: 500px;
+  margin: auto;
+}
+
+.ctaText {
+  font-weight: 300;
+}
+
+.ctaButtonContainer {
+  text-align: center;
+  margin-top: 30px;
 }
 

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -21,3 +21,6 @@
   margin-top: 30px;
 }
 
+.descriptionContainer {
+  margin: 20px 10px;
+}

--- a/src/constants/hideContent.js
+++ b/src/constants/hideContent.js
@@ -1,0 +1,3 @@
+export const MAX_WORDS_IF_HIDDEN = 50;
+export const MAX_IMAGES_IF_HIDDEN = 2;
+export const MAX_ROWS_IF_HIDDEN = 3;

--- a/src/constants/hideContent.js
+++ b/src/constants/hideContent.js
@@ -1,3 +1,4 @@
 export const MAX_WORDS_IF_HIDDEN = 50;
-export const MAX_IMAGES_IF_HIDDEN = 2;
+export const MAX_IMAGES_IF_HIDDEN = 3;
 export const MAX_ROWS_IF_HIDDEN = 3;
+export const MARKDOWN_DIVIDER = '---';

--- a/src/containers/ExperienceDetailPage.js
+++ b/src/containers/ExperienceDetailPage.js
@@ -3,17 +3,26 @@ import { connect } from 'react-redux';
 
 import ExperienceDetail from '../components/ExperienceDetail';
 import * as ExperienceDetailActions from '../actions/experienceDetail';
+import { fetchMyPermission } from '../actions/me';
 
 import {
   statusSelector,
 } from '../selectors/authSelector';
 
+import {
+  canViewExperirenceDetailSelector,
+} from '../selectors/meSelector';
+
 const mapStateToProps = state => ({
   experienceDetail: state.experienceDetail,
   authStatus: statusSelector(state),
+  canViewExperirenceDetail: canViewExperirenceDetailSelector(state),
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(ExperienceDetailActions, dispatch);
+  bindActionCreators({
+    ...ExperienceDetailActions,
+    fetchMyPermission,
+  }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(ExperienceDetail);

--- a/src/containers/LaborRightsSingle.js
+++ b/src/containers/LaborRightsSingle.js
@@ -1,8 +1,14 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as actionCreators from '../actions/laborRightsSingle';
+import { fetchMyPermission } from '../actions/me';
 import status from '../constants/status';
 import LaborRightsSingle from '../components/LaborRightsSingle';
+
+import {
+  canViewLaborRightsSingleSelector,
+} from '../selectors/meSelector';
+
 
 export default connect(
   (state, { params: { id } }) => {
@@ -32,7 +38,11 @@ export default connect(
       next: nextData,
       status: dataStatus,
       error: dataError,
+      canViewLaborRightsSingle: canViewLaborRightsSingleSelector(state),
     };
   },
-  dispatch => bindActionCreators(actionCreators, dispatch),
+  dispatch => bindActionCreators({
+    ...actionCreators,
+    fetchMyPermission,
+  }, dispatch),
 )(LaborRightsSingle);

--- a/src/containers/Layout/Header/index.js
+++ b/src/containers/Layout/Header/index.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import withFB from 'common/withFB';
 import Header from '../../../components/Layout/Header';
 import { login, logout, getLoginStatus, getMe } from '../../../actions/auth';
+import { fetchMyPermission } from '../../../actions/me';
 
 
 const mapStateToProps = state => ({
@@ -12,6 +13,6 @@ const mapStateToProps = state => ({
 
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ login, logout, getLoginStatus, getMe }, dispatch);
+  bindActionCreators({ login, logout, getLoginStatus, getMe, fetchMyPermission }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(withFB(Header));

--- a/src/containers/PermissionBlock/BasicPermissionBlockContainer.js
+++ b/src/containers/PermissionBlock/BasicPermissionBlockContainer.js
@@ -1,0 +1,23 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import BasicPermissionBlock from '../../components/common/PermissionBlock/BasicPermissionBlock';
+import { queryExperienceCount, queryTimeAndSalaryCount, queryLaborRightsCount } from '../../actions/dataCount';
+
+const mapStateToProps = state => ({
+  experienceCount: state.dataCount.get('experienceCount'),
+  timeAndSalaryCount: state.dataCount.get('timeAndSalaryCount'),
+  laborRightsCount: state.dataCount.get('laborRightsCount'),
+  hasFetchedExperienceCount: state.dataCount.get('hasFetchedExperienceCount'),
+  hasFetchedTimeAndSalaryCount: state.dataCount.get('hasFetchedTimeAndSalaryCount'),
+  hasFetchedLaborRightsCount: state.dataCount.get('hasFetchedLaborRightsCount'),
+});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({
+    queryExperienceCount,
+    queryTimeAndSalaryCount,
+    queryLaborRightsCount,
+  }, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(BasicPermissionBlock);

--- a/src/containers/PermissionBlock/CallToLoginShareButtonContainer.js
+++ b/src/containers/PermissionBlock/CallToLoginShareButtonContainer.js
@@ -1,0 +1,18 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import withFB from 'common/withFB';
+import CallToLoginShareButton from 'common/PermissionBlock/CallToLoginShareButton';
+import { login } from '../../actions/auth';
+
+
+const mapStateToProps = state => ({
+  auth: state.auth,
+});
+
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login }, dispatch);
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(withFB(CallToLoginShareButton));

--- a/src/containers/PermissionBlock/LaborRightsPermissionBlockContainer.js
+++ b/src/containers/PermissionBlock/LaborRightsPermissionBlockContainer.js
@@ -1,0 +1,23 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+
+import LaborRightsPermissionBlock from '../../components/common/PermissionBlock/LaborRightsPermissionBlock';
+import { queryExperienceCount, queryTimeAndSalaryCount, queryLaborRightsCount } from '../../actions/dataCount';
+
+const mapStateToProps = state => ({
+  experienceCount: state.dataCount.get('experienceCount'),
+  timeAndSalaryCount: state.dataCount.get('timeAndSalaryCount'),
+  laborRightsCount: state.dataCount.get('laborRightsCount'),
+  hasFetchedExperienceCount: state.dataCount.get('hasFetchedExperienceCount'),
+  hasFetchedTimeAndSalaryCount: state.dataCount.get('hasFetchedTimeAndSalaryCount'),
+  hasFetchedLaborRightsCount: state.dataCount.get('hasFetchedLaborRightsCount'),
+});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({
+    queryExperienceCount,
+    queryTimeAndSalaryCount,
+    queryLaborRightsCount,
+  }, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(LaborRightsPermissionBlock);

--- a/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryBoard.js
@@ -2,15 +2,27 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryBoard from '../../components/TimeAndSalary/TimeAndSalaryBoard';
 import { queryTimeAndSalary, switchPath, resetBoardExtremeData, queryExtremeTimeAndSalary } from '../../actions/timeAndSalaryBoard';
+import { fetchMyPermission } from '../../actions/me';
+import {
+  canViewTimeAndSalarySelector,
+} from '../../selectors/meSelector';
+
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryBoard.get('data'),
   status: state.timeAndSalaryBoard.get('status'),
   extremeStatus: state.timeAndSalaryBoard.get('extremeStatus'),
   extremeData: state.timeAndSalaryBoard.get('extremeData'),
+  canViewTimeAndSalary: canViewTimeAndSalarySelector(state),
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryTimeAndSalary, switchPath, resetBoardExtremeData, queryExtremeTimeAndSalary }, dispatch);
+  bindActionCreators({
+    queryTimeAndSalary,
+    switchPath,
+    resetBoardExtremeData,
+    queryExtremeTimeAndSalary,
+    fetchMyPermission,
+  }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryBoard);

--- a/src/containers/TimeAndSalary/TimeAndSalaryCompany.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryCompany.js
@@ -2,13 +2,16 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryCompany from '../../components/TimeAndSalary/TimeAndSalaryCompany';
 import { queryCompany, switchPath } from '../../actions/timeAndSalaryCompany';
+import { fetchMyPermission } from '../../actions/me';
+import { canViewTimeAndSalarySelector } from '../../selectors/meSelector';
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryCompany.get('data'),
   status: state.timeAndSalaryCompany.get('status'),
+  canViewTimeAndSalary: canViewTimeAndSalarySelector(state),
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryCompany, switchPath }, dispatch);
+  bindActionCreators({ queryCompany, switchPath, fetchMyPermission }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryCompany);

--- a/src/containers/TimeAndSalary/TimeAndSalaryJobTitle.js
+++ b/src/containers/TimeAndSalary/TimeAndSalaryJobTitle.js
@@ -2,13 +2,16 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import TimeAndSalaryJobTitle from '../../components/TimeAndSalary/TimeAndSalaryJobTitle';
 import { queryJobTitle, switchPath } from '../../actions/timeAndSalaryJobTitle';
+import { fetchMyPermission } from '../../actions/me';
+import { canViewTimeAndSalarySelector } from '../../selectors/meSelector';
 
 const mapStateToProps = state => ({
   data: state.timeAndSalaryJobTitle.get('data'),
   status: state.timeAndSalaryJobTitle.get('status'),
+  canViewTimeAndSalary: canViewTimeAndSalarySelector(state),
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ queryJobTitle, switchPath }, dispatch);
+  bindActionCreators({ queryJobTitle, switchPath, fetchMyPermission }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(TimeAndSalaryJobTitle);

--- a/src/reducers/dataCount.js
+++ b/src/reducers/dataCount.js
@@ -1,0 +1,40 @@
+import { fromJS } from 'immutable';
+import createReducer from 'utils/createReducer';
+
+import {
+  SET_EXPERIENCE_COUNT,
+  SET_TIME_AND_SALARY_COUNT,
+  SET_LABOR_RIGHTS_COUNT,
+} from '../actions/dataCount';
+
+const preloadedState = fromJS({
+  experienceCount: 0,
+  timeAndSalaryCount: 0,
+  laborRightsCount: 0,
+  hasFetchedExperienceCount: false,
+  hasFetchedTimeAndSalaryCount: false,
+  hasFetchedLaborRightsCount: false,
+  getExperienceError: null,
+  getTimeAndSalaryError: null,
+  getLaborRightsError: null,
+});
+
+export default createReducer(preloadedState, {
+  [SET_EXPERIENCE_COUNT]: (state, { count, hasFetched, err }) =>
+    state
+      .set('experienceCount', count)
+      .set('hasFetchedExperienceCount', hasFetched)
+      .set('getExperienceError', err),
+
+  [SET_TIME_AND_SALARY_COUNT]: (state, { count, hasFetched, err }) =>
+    state
+      .set('timeAndSalaryCount', count)
+      .set('hasFetchedTimeAndSalaryCount', hasFetched)
+      .set('getTimeAndSalaryError', err),
+
+  [SET_LABOR_RIGHTS_COUNT]: (state, { count, hasFetched, err }) =>
+    state
+      .set('laborRightsCount', count)
+      .set('hasFetchedLaborRightsCount', hasFetched)
+      .set('getLaborRightsError', err),
+});

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -2,6 +2,7 @@ import { combineReducers } from 'redux';
 import { routerReducer as routing } from 'react-router-redux';
 
 import auth from './auth';
+import dataCount from './dataCount';
 import experienceDetail from './experienceDetail';
 import experienceSearch from './experienceSearch';
 import laborRightsSingle from './laborRightsSingle';
@@ -14,6 +15,7 @@ import progressBarState from './progressBarState';
 
 const rootReducer = combineReducers({
   auth,
+  dataCount,
   experienceSearch,
   experienceDetail,
   laborRightsSingle,

--- a/src/reducers/me.js
+++ b/src/reducers/me.js
@@ -9,6 +9,7 @@ import {
   SET_MY_WORKINGS_STATUS,
   SET_MY_REPLIES,
   SET_MY_REPLIES_STATUS,
+  SET_MY_PERMISSION,
 } from '../actions/me';
 
 const preloadedState = fromJS({
@@ -21,6 +22,9 @@ const preloadedState = fromJS({
   myRepliesStatus: status.UNFETCHED,
   myRepliesError: null,
   myReplies: {},
+  canViewLaborRightsSingle: true,
+  canViewExperirenceDetail: true,
+  canViewTimeAndSalary: true,
 });
 
 const me = createReducer(preloadedState, {
@@ -53,6 +57,38 @@ const me = createReducer(preloadedState, {
 
   [SET_MY_REPLIES_STATUS]: (state, action) =>
     state.update('myReplies', () => action.status),
+
+  [SET_MY_PERMISSION]: (state, action) => {
+    let newState = state;
+    if (typeof Storage !== 'undefined') {
+      // check current pathname
+      const pathname = action.location.pathname;
+      const laborRightsSingleRegex = /\/labor-rights\/.+/;
+      const experienceDetailRegex = /\/experiences\/.+/;
+      const timeAndSalaryRegex = /\/time-and-salary\/.+/;
+
+      // 根據路徑，去更新相關的觀看權限 state
+      if (laborRightsSingleRegex.test(pathname)) {
+        // 假如是小教室頁，直接更新觀看權限 state
+        newState = state.update('canViewLaborRightsSingle', () => action.permission);
+      } else if (experienceDetailRegex.test(pathname)) {
+        // 假如是單篇經驗分享頁，localStorage 沒值的話，不更新觀看權限 state。因此不會做阻擋，但是馬上就更新 localStorage。
+        const hasViewedExperirenceDetail = localStorage.getItem('hasViewedExperirenceDetail');
+        if (hasViewedExperirenceDetail !== null) {
+          newState = state.update('canViewExperirenceDetail', () => action.permission);
+        }
+        localStorage.setItem('hasViewedExperirenceDetail', true);
+      } else if (timeAndSalaryRegex.test(pathname)) {
+        // 假如是薪資工時查詢頁，localStorage 沒值的話，不更新觀看權限 state。因此不會做阻擋，但是馬上就更新 localStorage。
+        const hasViewedTimeAndSalary = localStorage.getItem('hasViewedTimeAndSalary');
+        if (hasViewedTimeAndSalary !== null) {
+          newState = state.update('canViewTimeAndSalary', () => action.permission);
+        }
+        localStorage.setItem('hasViewedTimeAndSalary', true);
+      }
+    }
+    return newState;
+  },
 });
 
 export default me;

--- a/src/selectors/meSelector.js
+++ b/src/selectors/meSelector.js
@@ -1,0 +1,3 @@
+export const canViewExperirenceDetailSelector = state => state.me.get('canViewExperirenceDetail');
+export const canViewLaborRightsSingleSelector = state => state.me.get('canViewLaborRightsSingle');
+export const canViewTimeAndSalarySelector = state => state.me.get('canViewTimeAndSalary');

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -51,9 +51,9 @@ const checkStatus = handle401 => response => {
   return response.json();
 };
 
-const fetchUtil = endpoint => (method, body) =>
+const fetchUtil = (endpoint, apiHost = API_HOST) => (method, body) =>
   fetch(
-    `${API_HOST}${endpoint}`,
+    `${apiHost}${endpoint}`,
     optionsBuilder(body)(method)
   )
     .then(checkStatus());

--- a/src/utils/stringUtil.js
+++ b/src/utils/stringUtil.js
@@ -7,3 +7,15 @@ export const toCamelcase = str =>
 export const makeId = (length = 5) => (
   Math.random().toString(36).substring(2, length)
 );
+
+// find the n-th occurrence of substr in str.
+// when n = 1, it will be equal to indexOf
+export const nthIndexOf = (str, substr, n) => {
+  if (!str || !substr) { return -1; }
+  let pos = 0;
+  for (let i = 0; i < n; i += 1) {
+    pos = str.indexOf(substr, pos === 0 ? 0 : pos + substr.length);
+    if (pos < 0) { return pos; }
+  }
+  return pos;
+};


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

前端加上權限機制。詳細機制如下：

使用者打開某頁面 -> SSR 會先正常 render 所有內容，送到 client 端 -> client 端打 `GET /me/permission/search` 得到 true（有權限）或 false（無權限），並根據 local storage ，選擇顯示或擋住部分資訊。

#### 打 `GET /me/permission/search` 的時間點：
1. 進到 `/experiences/:id` 打API。API 回來後，先判定是否遮住資訊，再 localStorage.setItem("hasViewedExperirenceDetail", true);
2. 進到 `/time-and-salary` 底下任一路徑打API。API 回來後，先判定是否遮住資訊，再 localStorage.setItem("hasViewedTimeAndSalary", true);
3. 進到 `/labor-rights/:id` 打API
4. 使用者經由 header 按鈕，成功登入後

#### 判定遮住資訊的方式
1. 在 `/experiences/:id` 頁面，permission = false，且 localStorage.getItem(''hasViewedExperirenceDetail") !== null
2. 在 `/time-and-salary` 底下任一路徑，permission = false，且 localStorage.getItem(''hasViewedExperirenceDetail") !== null
3. 在 `/labor-rights/:id` ， permission = false 

也就是，單篇經驗分享＆薪資工時都至少可以看一頁，但小教室是直接擋。

#### 遮住的資訊
1. `/experiences/:id`: sections 裡面的 content 總和超過 50 字的部分都會被隱藏。
2. `/time-and-salary`: 單筆薪資工時表格，只顯示前三筆。以公司或職稱搜尋的結果，整個 block 遮住。
3. `/labor-rights/:id`: 目前是前三張圖片可以看。 

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/470

## Screenshots  <!-- 選填，沒有就刪掉 -->

<!-- 可以的話，請提供畫面截圖，如果是 GIF 的話更好 -->

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

invision: https://projects.invisionapp.com/d/main#/console/10208710/276361686/preview

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

分 commit 一個一個看

## Questions:  <!-- 選填，沒有就刪掉 -->

- 我需要更新 Packages 嗎？ No 
- 有哪些文件需要被更新嗎？ No 

## 我應該如何手動測試？ <!-- 必填 -->

這邊測試會有點複雜，建議起一個完全空的 DB，以及兩個 facebook 帳號做測試
- [ ] 先用 A 帳號留下四筆新工時、一筆面試經驗、一筆工作經驗。經驗分享要超過 50 字。
- [ ] 先清掉 localStorage，A 帳號處於登出狀態時，到 `/experiences/:id` 頁，第一次應該要可以看
- [ ] 跑到其他頁再點另一篇經驗分享，應該就要被擋住
- [ ] 此時登入網站，應該就要看得到那篇經驗分享內容
- [ ] 登出，進到 `/time-and-salary/latest` 頁面，第一次要看得到資訊
- [ ] 隨意下關鍵字或調整排序，資料應該就要被擋住
- [ ] 此時登入網站，應該就要看得到所有薪資工時資料
- [ ] 登出，進到 `/labor-rights/:id`，第一次就要被擋住
- [ ] 此時登入網站，應該就要看得到整篇小教室

接著是 B 帳號的測試（務必確定 B 帳號是沒留過任何資料的）
- [ ] 登入狀態，到 `/experiences/:id` 頁，第一次要看得到
- [ ] 跑到其他頁再點另一篇經驗分享，應該就要被擋住
- [ ] 進到 `/time-and-salary/latest` 頁面，第一次要看得到資訊
- [ ] 隨意下關鍵字或調整排序，資料應該就要被擋住
- [ ] 進到 `/labor-rights/:id`，第一次就要被擋住
- [ ] 此時留下任意一種資訊，所有資料應該都要可以看
