### PR TITLE
Refactor: PermissionBlock 圖示與文案& 灰階遮罩

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "react": "^16.2.0",
     "react-autocomplete": "^1.5.6",
     "react-dom": "^16.2.0",
+    "react-fontawesome": "^1.6.1",
     "react-ga": "^2.2.0",
     "react-helmet": "^5.2.0",
     "react-immutable-proptypes": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "webpack-merge": "^2.6.1"
   },
   "dependencies": {
+    "@fortawesome/fontawesome": "^1.1.3",
+    "@fortawesome/fontawesome-free-solid": "^5.0.6",
+    "@fortawesome/react-fontawesome": "^0.0.17",
     "classnames": "^2.2.5",
     "contentful": "^4.1.2",
     "eslint-import-resolver-webpack": "^0.8.1",
@@ -87,7 +90,6 @@
     "react": "^16.2.0",
     "react-autocomplete": "^1.5.6",
     "react-dom": "^16.2.0",
-    "react-fontawesome": "^1.6.1",
     "react-ga": "^2.2.0",
     "react-helmet": "^5.2.0",
     "react-immutable-proptypes": "^2.1.0",

--- a/src/components/ExperienceDetail/Article.js
+++ b/src/components/ExperienceDetail/Article.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 import { Heading, P } from 'common/base';
 import { Good, Bad, Glike } from 'common/icons';
+import GradientMask from 'common/GradientMask';
 import rateButtonStyles from 'common/button/RateButtonElement.module.css';
 import styles from './Article.module.css';
 import InfoBlock from './InfoBlock';
@@ -31,7 +32,9 @@ class Article extends React.Component {
                 const showLength = content.length - (currentTotalWords - MAX_WORDS_IF_HIDDEN);
                 const newContent = `${content.substring(0, showLength)}...`;
                 return (
-                  <SectionBlock key={idx} subtitle={subtitle} content={newContent} />
+                  <GradientMask>
+                    <SectionBlock key={idx} subtitle={subtitle} content={newContent} />
+                  </GradientMask>
                 );
               }
               return (

--- a/src/components/LaborRightsSingle/Body.js
+++ b/src/components/LaborRightsSingle/Body.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { StickyContainer, Sticky } from 'react-sticky';
 import cn from 'classnames';
 import { Section, Wrapper, Heading } from 'common/base';
+import GradientMask from 'common/GradientMask';
 import MarkdownParser from './MarkdownParser';
 import styles from './Body.module.css';
 import LeftBanner from '../ExperienceSearch/Banners/Banner1';
@@ -27,7 +28,9 @@ const Body = ({ title, seoText, description, content, permissionBlock }) => (
           </Sticky>
         </StickyContainer>
         <div className={styles.content}>
-          <MarkdownParser content={content} />
+          <GradientMask show={permissionBlock !== null}>
+            <MarkdownParser content={content} />
+          </GradientMask>
           {permissionBlock}
         </div>
       </div>

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css
@@ -54,6 +54,10 @@
   content: none !important;
 }
 
+.noPadding {
+  padding: 0 !important;
+}
+
 .permissionBlockBoard {
   margin: -12px -20px;
   padding: 50px 25px;

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -20,6 +20,7 @@ import CallToActionRow from './CallToActionRow';
 import BasicPermissionBlock from '../../../containers/PermissionBlock/BasicPermissionBlockContainer';
 
 import { queryTimeAndSalary } from '../../../actions/timeAndSalaryBoard';
+import GradientMask from '../../common/GradientMask';
 
 const pathnameMapping = {
   'work-time-dashboard': {
@@ -183,11 +184,18 @@ const injectPermissionBlock = rows => {
   const newRows = rows.slice(0, MAX_ROWS_IF_HIDDEN);
   newRows.push(
     <tr>
+      <td colSpan="7" className={styles.noPadding}>
+        <GradientMask />
+      </td>
+    </tr>
+  );
+  newRows.push(
+    <tr>
       <td colSpan="7" className={styles.noBefore}>
         <BasicPermissionBlock rootClassName={styles.permissionBlockBoard} />
       </td>
     </tr>
-    );
+  );
   return newRows;
 };
 

--- a/src/components/common/GradientMask/GradientMask.module.css
+++ b/src/components/common/GradientMask/GradientMask.module.css
@@ -1,0 +1,18 @@
+
+.container {
+  position: relative;
+}
+
+.show {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100px;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
+}
+
+.hidden {
+
+}

--- a/src/components/common/GradientMask/GradientMask.module.css
+++ b/src/components/common/GradientMask/GradientMask.module.css
@@ -1,9 +1,8 @@
-
 .container {
   position: relative;
 }
 
-.show {
+.mask {
   position: absolute;
   bottom: 0;
   left: 0;
@@ -11,8 +10,4 @@
   height: 100px;
   pointer-events: none;
   background-image: linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
-}
-
-.hidden {
-
 }

--- a/src/components/common/GradientMask/index.js
+++ b/src/components/common/GradientMask/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cn from 'classnames';
+
+import styles from './GradientMask.module.css';
+
+const GradientMask = ({ children, rootClassName, show = true }) => (
+  <div className={cn(styles.container, rootClassName)}>
+    {children}
+    <div className={show ? styles.show : styles.hidden} />
+  </div>
+);
+
+GradientMask.propTypes = {
+  children: PropTypes.element,
+  rootClassName: PropTypes.string,
+  show: PropTypes.bool,
+};
+
+GradientMask.defaultProps = {
+  children: null,
+  rootClassName: '',
+  show: true,
+};
+
+export default GradientMask;

--- a/src/components/common/GradientMask/index.js
+++ b/src/components/common/GradientMask/index.js
@@ -7,7 +7,7 @@ import styles from './GradientMask.module.css';
 const GradientMask = ({ children, rootClassName, show = true }) => (
   <div className={cn(styles.container, rootClassName)}>
     {children}
-    <div className={show ? styles.show : styles.hidden} />
+    <div className={cn({ [styles.mask]: show })} />
   </div>
 );
 

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
-import FontAwesome from 'react-fontawesome';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faLock from '@fortawesome/fontawesome-free-solid/faLock';
 
 import P from 'common/base/P';
 import { Heading } from 'common/base';
@@ -47,7 +48,7 @@ class BasicPermissionBlock extends React.Component {
       <div className={cn(styles.permissionBlock, rootClassName)}>
         <div className={styles.container}>
           <div className={styles.headingContainer}>
-            <FontAwesome className={styles.lockIcon} name="lock" />
+            <FontAwesomeIcon icon={faLock} className={styles.headingIcon} />
             <Heading size="sl" Tag="h3">你暫時沒有查看完整資訊的權限</Heading>
           </div>
           <P size="l" className={styles.ctaText}>

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -6,6 +6,7 @@ import FontAwesome from 'react-fontawesome';
 import P from 'common/base/P';
 import { Heading } from 'common/base';
 import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
+import getScale from '../../../utils/numberUtils';
 import styles from './PermissionBlock.module.css';
 
 class BasicPermissionBlock extends React.Component {
@@ -40,6 +41,8 @@ class BasicPermissionBlock extends React.Component {
 
   render() {
     const { rootClassName, experienceCount, timeAndSalaryCount, laborRightsCount } = this.props;
+    const experienceScale = getScale(experienceCount);
+    const timeAndSalaryScale = getScale(timeAndSalaryCount);
     return (
       <div className={cn(styles.permissionBlock, rootClassName)}>
         <div className={styles.container}>
@@ -48,10 +51,9 @@ class BasicPermissionBlock extends React.Component {
             <Heading size="sl" Tag="h3">你暫時沒有查看完整資訊的權限</Heading>
           </div>
           <P size="l" className={styles.ctaText}>
-            <strong>只要 40 秒</strong>，分享一筆你的 薪資<strong> 或 </strong>工時
-            <strong> 或 </strong>面試<strong> 或 </strong> 工作經驗，就能查看
-            <strong>{`全站 ${timeAndSalaryCount} 筆`}</strong>薪資工時資訊、
-            <strong>{`${experienceCount} 篇`}</strong>面試及工作經驗分享，以及
+            只需幾分鐘，<strong>分享你的職場資訊</strong>，不僅幫助其他人不再踩雷，更能
+            <strong>{`查看全站超過 ${timeAndSalaryScale} 筆`}</strong>薪資工時資訊、
+            <strong>{`${experienceScale}+ 篇`}</strong>面試及工作經驗分享，以及
             <strong>{` ${laborRightsCount} 篇`}</strong>勞動權益懶人包哦！
           </P>
           <br />

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
+import FontAwesome from 'react-fontawesome';
 
 import P from 'common/base/P';
+import { Heading } from 'common/base';
 import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
 import styles from './PermissionBlock.module.css';
 
@@ -41,6 +43,10 @@ class BasicPermissionBlock extends React.Component {
     return (
       <div className={cn(styles.permissionBlock, rootClassName)}>
         <div className={styles.container}>
+          <div className={styles.headingContainer}>
+            <FontAwesome className={styles.lockIcon} name="lock" />
+            <Heading size="sl" Tag="h3">你暫時沒有查看完整資訊的權限</Heading>
+          </div>
           <P size="l" className={styles.ctaText}>
             <strong>只要 40 秒</strong>，分享一筆你的 薪資<strong> 或 </strong>工時
             <strong> 或 </strong>面試<strong> 或 </strong> 工作經驗，就能查看

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
+import FontAwesome from 'react-fontawesome';
 
 import P from 'common/base/P';
+import { Heading } from 'common/base';
 import MarkdownParser from '../../LaborRightsSingle/MarkdownParser';
 import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
 import styles from './PermissionBlock.module.css';
@@ -43,6 +45,10 @@ class BasicPermissionBlock extends React.Component {
     return (
       <div className={cn(styles.permissionBlock, rootClassName)}>
         <div className={styles.container}>
+          <div className={styles.headingContainer}>
+            <FontAwesome className={styles.lockIcon} name="lock" />
+            <Heading size="sl" Tag="h3">你暫時沒有查看完整資訊的權限</Heading>
+          </div>
           <P size="l" className={styles.ctaText}>
             <strong>只要 40 秒</strong>，分享一筆你的 薪資<strong> 或 </strong>工時
             <strong> 或 </strong>面試<strong> 或 </strong> 工作經驗，就能

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
-import FontAwesome from 'react-fontawesome';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faLock from '@fortawesome/fontawesome-free-solid/faLock';
 
 import P from 'common/base/P';
 import { Heading } from 'common/base';
@@ -49,7 +50,7 @@ class BasicPermissionBlock extends React.Component {
       <div className={cn(styles.permissionBlock, rootClassName)}>
         <div className={styles.container}>
           <div className={styles.headingContainer}>
-            <FontAwesome className={styles.lockIcon} name="lock" />
+            <FontAwesomeIcon icon={faLock} className={styles.headingIcon} />
             <Heading size="sl" Tag="h3">你暫時沒有查看完整資訊的權限</Heading>
           </div>
           <P size="l" className={styles.ctaText}>

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -7,6 +7,7 @@ import P from 'common/base/P';
 import { Heading } from 'common/base';
 import MarkdownParser from '../../LaborRightsSingle/MarkdownParser';
 import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
+import getScale from '../../../utils/numberUtils';
 import styles from './PermissionBlock.module.css';
 
 class BasicPermissionBlock extends React.Component {
@@ -42,6 +43,8 @@ class BasicPermissionBlock extends React.Component {
 
   render() {
     const { rootClassName, experienceCount, timeAndSalaryCount, laborRightsCount, description } = this.props;
+    const experienceScale = getScale(experienceCount);
+    const timeAndSalaryScale = getScale(timeAndSalaryCount);
     return (
       <div className={cn(styles.permissionBlock, rootClassName)}>
         <div className={styles.container}>
@@ -50,17 +53,16 @@ class BasicPermissionBlock extends React.Component {
             <Heading size="sl" Tag="h3">你暫時沒有查看完整資訊的權限</Heading>
           </div>
           <P size="l" className={styles.ctaText}>
-            <strong>只要 40 秒</strong>，分享一筆你的 薪資<strong> 或 </strong>工時
-            <strong> 或 </strong>面試<strong> 或 </strong> 工作經驗，就能
-            <strong>查看完整</strong>的懶人包，內容包含：
+            只需幾分鐘，<strong>分享你的職場資訊</strong>，不僅幫助其他人不再踩雷，更能
+            <strong>查看完整的懶人包資訊</strong>，內容包含：
           </P>
           <div className={styles.descriptionContainer}>
             <MarkdownParser content={description} />
           </div>
           <P size="l" className={styles.ctaText}>
-            還可以查看
-            <strong>{`全站 ${timeAndSalaryCount} 筆`}</strong>薪資工時資訊、
-            <strong>{`${experienceCount} 篇`}</strong>面試及工作經驗分享，以及其他
+            除此之外，還可以
+            <strong>{`查看全站超過 ${timeAndSalaryScale} 筆`}</strong>薪資工時資訊、
+            <strong>{`${experienceScale}+ 篇`}</strong>面試及工作經驗分享，以及其他
             <strong>{` ${laborRightsCount - 1} 篇`}</strong>勞動權益懶人包哦！
           </P>
           <br />

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -32,9 +32,9 @@
   margin-bottom: 20px;
 }
 
-.lockIcon {
+.headingIcon {
   display: inline;
-  font-size: 36px;
+  font-size: 2em;
   margin-right: 15px;
 }
 

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -24,3 +24,20 @@
 .descriptionContainer {
   margin: 20px 10px;
 }
+
+.headingContainer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.lockIcon {
+  display: inline;
+  font-size: 36px;
+  margin-right: 15px;
+}
+
+.heading {
+  display: inline;
+}

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -65,6 +65,7 @@ export default class Html extends Component {
               a.appendChild(r);
             })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');` }}
           />
+          <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
         </head>
         <body>
           <div

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -65,7 +65,6 @@ export default class Html extends Component {
               a.appendChild(r);
             })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');` }}
           />
-          <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" />
         </head>
         <body>
           <div

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,28 @@
 # yarn lockfile v1
 
 
+"@fortawesome/fontawesome-common-types@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.1.2.tgz#d6aa075058f0c984d6e2ebcbc0052c1f7f9bea72"
+
+"@fortawesome/fontawesome-free-solid@^5.0.6":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-free-solid/-/fontawesome-free-solid-5.0.6.tgz#6bb5acdd081b03ab25b7684f7089b37ed3d20740"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.1.2"
+
+"@fortawesome/fontawesome@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome/-/fontawesome-1.1.3.tgz#7a4844345cbc7fb238f5f1788af73bd302ee9b80"
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.1.2"
+
+"@fortawesome/react-fontawesome@^0.0.17":
+  version "0.0.17"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.0.17.tgz#69abd135523187044f533cadc5458f829d43961f"
+  dependencies:
+    humps "^2.0.1"
+
 JSONStream@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.4.tgz#91657dfe6ff857483066132b4618b62e8f4887bd"
@@ -3185,6 +3207,10 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+humps@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -5587,12 +5613,6 @@ react-dom@^16.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
-
-react-fontawesome@^1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/react-fontawesome/-/react-fontawesome-1.6.1.tgz#eddce17e7dc731aa09fd4a186688a61793a16c5c"
-  dependencies:
-    prop-types "^15.5.6"
 
 react-ga@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,6 +5588,12 @@ react-dom@^16.2.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
+react-fontawesome@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/react-fontawesome/-/react-fontawesome-1.6.1.tgz#eddce17e7dc731aa09fd4a186688a61793a16c5c"
+  dependencies:
+    prop-types "^15.5.6"
+
 react-ga@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.2.0.tgz#45235de1356e4d988d9b82214d615a08489c9291"


### PR DESCRIPTION
Close #393 

## 這個 PR 是？ <!-- 必填 -->

1. 加上灰階遮罩，讓使用者更容易意識到東西被遮住
2. 加上鎖頭＆明確告訴使用者沒權限
3. 文案小幅修改，避免引導使用者只想用很短的時間寫內容

## Screenshots  <!-- 選填，沒有就刪掉 -->

單篇經驗分享：
![2018-02-20 11 25 15](https://user-images.githubusercontent.com/3805975/36432551-6dbfb2bc-1695-11e8-86f7-9736ce588ec7.png)

單筆薪資工時：
![2018-02-20 11 25 25](https://user-images.githubusercontent.com/3805975/36432552-6de7d80a-1695-11e8-959b-8c6a28bedb1e.png)

搜尋薪資工時：
![2018-02-20 11 25 38](https://user-images.githubusercontent.com/3805975/36432553-6e372e46-1695-11e8-9fc5-a5c3aeb39390.png)

小教室：
![2018-02-20 11 25 05](https://user-images.githubusercontent.com/3805975/36432550-6d935686-1695-11e8-8063-f336d7a8e420.png)

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

分 commit 看

## Questions:  <!-- 選填，沒有就刪掉 -->

- 我需要更新 Packages 嗎？ yes

## 我應該如何手動測試？ <!-- 必填 -->
兩個FB帳號
- [ ] A 帳號留 4 筆薪資工時、 1 筆經驗分享
- [ ] B 帳號不能留過任何資訊。在單篇經驗分享頁、薪資工時查詢頁、部分的小教室頁，應該要看到新的權限區塊和遮罩。  （薪資工時查詢頁在用職稱、公司搜尋的結果區塊不會有遮罩）
