### PR TITLE
Rewrite ExperienceSearch

### DIFF
--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -8,25 +8,13 @@ import statusConstant from '../constants/status';
 
 
 export const SET_SEARCH_BY = 'SET_SEARCH_BY';
-export const SET_WORKINGS = 'SET_WORKINGS';
-export const SET_KEYWORD = 'SET_KEYWORD';
 export const SET_KEYWORDS = 'SET_KEYWORDS';
 export const SET_SORT_AND_EXPERIENCES = 'SET_SORT_AND_EXPERIENCES';
 export const SET_LOADING_STATUS = 'SET_LOADING_STATUS';
 
-export const setKeyword = keyword => ({
-  type: SET_KEYWORD,
-  keyword,
-});
-
 export const setSortAndExperiences = payload => ({
   type: SET_SORT_AND_EXPERIENCES,
   payload,
-});
-
-export const setWorkings = workings => ({
-  type: SET_WORKINGS,
-  workings,
 });
 
 const setLoadingStatus = (status, error = null) => ({
@@ -81,42 +69,18 @@ export const fetchExperiences = (page, limit, _sort, searchBy, searchQuery, sear
     });
 };
 
-export const fetchWorkings = (searchBy, searchQuery) => dispatch => {
-  const url = `/workings/search_by/${searchBy}/group_by/company?${searchBy}=${searchQuery}`;
-
-  return fetchUtil(url)('GET')
-    .then(result => {
-      if (result.error) {
-        dispatch(setWorkings([]));
-        return;
-      }
-      dispatch(setWorkings(result));
-    })
-    .catch(e => {
-      dispatch(setWorkings([]));
-      throw e;
-    });
-};
-
 const setKeywords = keywords => ({
   type: SET_KEYWORDS,
   keywords,
-});
-
-const setSearchBy = searchBy => ({
-  type: SET_SEARCH_BY,
-  searchBy,
 });
 
 export const getNewSearchBy = searchBy => dispatch => {
   const url = searchBy === 'company' ? '/company_keywords' : '/job_title_keywords';
   return fetchUtil(url)('GET')
     .then(result => {
-      dispatch(setSearchBy(searchBy));
       dispatch(setKeywords(result.keywords));
     })
     .catch(e => {
-      dispatch(setSearchBy(searchBy));
       dispatch(setKeywords([]));
       throw e;
     });

--- a/src/components/ExperienceSearch/Filter/index.js
+++ b/src/components/ExperienceSearch/Filter/index.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import R from 'ramda';
 import Checkbox from 'common/form/Checkbox';
 
 import styles from './Filter.module.css';
@@ -8,64 +9,114 @@ const SORT = {
   CREATED_AT: 'created_at',
   POPULARITY: 'popularity',
 };
+
 const SEARCH_TYPE = {
   INTERVIEW: 'interview',
   WORK: 'work',
-  SALARY: 'salary',
 };
 
-const Filter = ({
-  data,
-  fetchExperiencesWithSort,
-  setSearchType,
-  className,
-}) => (
-  <div className={className}>
-    <section>
-      <button
-        className={data.sort === SORT.CREATED_AT
-          ? `${styles.frontButton} ${styles.toggle}`
-          : styles.frontButton}
-        onClick={() => fetchExperiencesWithSort(SORT.CREATED_AT)}
-        value={SORT.CREATED_AT}
-      >
-        最新
-      </button>
-      <button
-        className={data.sort === SORT.POPULARITY
-          ? `${styles.rearButton} ${styles.toggle}`
-          : styles.rearButton}
-        onClick={() => fetchExperiencesWithSort(SORT.POPULARITY)}
-        value={SORT.POPULARITY}
-      >
-        熱門
-      </button>
-    </section>
-    <hr className={styles.splitter} />
-    <div className={styles.fliters}>
-      {
-        [
-          { label: '面試經驗', value: SEARCH_TYPE.INTERVIEW },
-          { label: '工作經驗', value: SEARCH_TYPE.WORK },
-          { label: '薪資工時', value: SEARCH_TYPE.SALARY },
-        ].map(o => (
-          <Checkbox
-            key={o.value} id={`searchType-${o.value}`}
-            label={o.label} value={o.value}
-            disabled={o.value === 'salary' && !data.searchQuery}
-            onChange={setSearchType}
-            checked={data.searchType.includes(o.value)}
-          />
-        ))
-      }
-    </div>
-  </div>
-);
+const OPTIONS = [
+  { label: '面試經驗', value: SEARCH_TYPE.INTERVIEW },
+  { label: '工作經驗', value: SEARCH_TYPE.WORK },
+];
+
+class Filter extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { sort, searchType } = props;
+    this.state = {
+      sort,
+      searchType,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { sort, searchType } = nextProps;
+    this.setState({
+      sort,
+      searchType,
+    });
+  }
+
+  render() {
+    const {
+      onSortClick,
+      onSeachTypeChange,
+      className,
+    } = this.props;
+
+    const { sort, searchType } = this.state;
+
+    // use classname module
+    return (
+      <div className={className}>
+        <section>
+          <button
+            className={sort === SORT.CREATED_AT ? `${styles.frontButton} ${styles.toggle}` : styles.frontButton}
+            onClick={() => {
+              const newSort = SORT.CREATED_AT;
+              this.setState({ sort: newSort });
+              onSortClick({ sort: newSort, searchType });
+            }}
+            value={SORT.CREATED_AT}
+          >
+            最新
+          </button>
+          <button
+            className={sort === SORT.POPULARITY ? `${styles.rearButton} ${styles.toggle}` : styles.rearButton}
+            onClick={() => {
+              const newSort = SORT.POPULARITY;
+              this.setState({ sort: newSort });
+              onSortClick({ sort: newSort, searchType });
+            }}
+            value={SORT.POPULARITY}
+          >
+            熱門
+          </button>
+        </section>
+        <hr className={styles.splitter} />
+        <div className={styles.fliters}>
+          {
+            OPTIONS.map(o => (
+              <Checkbox
+                key={o.value}
+                id={`searchType-${o.value}`}
+                label={o.label}
+                value={o.value}
+                onChange={e => {
+                  const value = e.target.value;
+                  const newSearchType = R.ifElse(
+                    R.contains(value),
+                    R.reject(R.equals(value)),
+                    R.append(value),
+                  )(searchType);
+                  this.setState({ searchType: newSearchType });
+                  onSeachTypeChange({ searchType: newSearchType, sort });
+                }}
+                checked={searchType.includes(o.value)}
+              />
+            ))
+          }
+        </div>
+      </div>
+    );
+  }
+}
+
 Filter.propTypes = {
   className: PropTypes.string,
-  data: PropTypes.object.isRequired,
-  fetchExperiencesWithSort: PropTypes.func.isRequired,
-  setSearchType: PropTypes.func.isRequired,
+  searchType: PropTypes.array.isRequired,
+  sort: PropTypes.string,
+  // ({ searchType, sort }) => ()
+  onSeachTypeChange: PropTypes.func,
+  // ({ searchType, sort }) => ()
+  onSortClick: PropTypes.func,
+};
+
+Filter.defaultProps = {
+  onSeachTypeChange: () => {},
+  onSortClick: () => {},
 };
 
 export default Filter;

--- a/src/components/ExperienceSearch/Searchbar.js
+++ b/src/components/ExperienceSearch/Searchbar.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
@@ -6,76 +6,115 @@ import Radio from 'common/form/Radio';
 import Magnifiner from 'common/icons/Magnifiner';
 import styles from './Searchbar.module.css';
 
-const SearchBar = ({
-  data,
-  setKeyword,
-  handleSearchBy,
-  handleKeyPress,
-  handleKeywordClick,
-  fetchExperiencesAndWorkings,
-  className,
-}) => (
-  <section className={cn(styles.searchbar, className)}>
-    <div className={styles.condition}>
-      {
-        [
-          { label: '公司', value: 'company' },
-          { label: '職稱', value: 'job_title' },
-        ].map(o => (
-          <Radio
-            key={o.value} id={`condition-${o.value}`}
-            label={o.label} value={o.value} inline
-            onChange={() => handleSearchBy(o.value)}
-            checked={data.searchBy === o.value}
+const OPTIONS = [
+  { label: '公司', value: 'company' },
+  { label: '職稱', value: 'job_title' },
+];
+
+class SearchBar extends PureComponent {
+  constructor(props) {
+    super(props);
+
+    const { searchBy, searchQuery } = props;
+    this.state = {
+      searchBy,
+      searchQuery,
+    };
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const {
+      searchBy,
+      searchQuery,
+    } = nextProps;
+
+    this.setState({
+      searchBy,
+      searchQuery,
+    });
+  }
+
+  render() {
+    const { keywords } = this.props;
+    const {
+      onKeywordClick,
+      onSearchByChange,
+      onSubmit,
+    } = this.props;
+    const { className } = this.props;
+    const { searchBy, searchQuery } = this.state;
+
+    return (
+      <section className={cn(styles.searchbar, className)}>
+        <div className={styles.condition}>
+          {
+            OPTIONS.map(o => (
+              <Radio
+                key={o.value}
+                id={`condition-${o.value}`}
+                label={o.label}
+                value={o.value}
+                inline
+                onChange={() => {
+                  const newSearchBy = o.value;
+                  this.setState({ searchBy: newSearchBy });
+                  onSearchByChange({ searchBy: newSearchBy, searchQuery });
+                }}
+                checked={searchBy === o.value}
+              />
+            ))
+          }
+        </div>
+        <div className={styles.search}>
+          <input
+            type="text"
+            onKeyPress={e => {
+              if (e.key === 'Enter') {
+                const newSearchQuery = e.target.value;
+                onSubmit({ searchBy, searchQuery: newSearchQuery });
+              }
+            }}
+            onChange={e => this.setState({ searchQuery: e.target.value })}
+            value={searchQuery}
+            placeholder={searchBy === 'company' ? 'ex: 台灣電機股份有限公司' : 'ex: 行銷企劃'}
           />
-        ))
-      }
-    </div>
-    <div className={styles.search}>
-      <input
-        type="text"
-        onKeyPress={handleKeyPress}
-        onChange={e => setKeyword(e.target.value)}
-        value={data.keyword}
-        placeholder={
-          data.searchBy === 'company'
-            ? 'ex: 台灣電機股份有限公司'
-            : 'ex: 行銷企劃'
-        }
-      />
-      <button
-        className={styles.searchBtn}
-        onClick={() => {
-          // cmpAlert.show();
-          const val = data.keyword;
-          fetchExperiencesAndWorkings(val);
-        }}
-      >
-        <Magnifiner />
-      </button>
-      <div className={styles.keywordGroup}>
-        {
-          (data.keywords || []).map(o => (
-            <span
-              key={o} className={styles.keyword}
-              onClick={() => handleKeywordClick(o)}
-            >
-              {o}
-            </span>
-          ))
-        }
-      </div>
-    </div>
-  </section>
-);
+          <button
+            className={styles.searchBtn}
+            onClick={() => {
+              onSubmit({ searchBy, searchQuery });
+            }}
+          >
+            <Magnifiner />
+          </button>
+          <div className={styles.keywordGroup}>
+            {
+              (keywords || []).map(keyword => (
+                <span
+                  key={keyword}
+                  className={styles.keyword}
+                  onClick={() => {
+                    onKeywordClick({ keyword, searchBy, searchQuery });
+                  }}
+                >
+                  {keyword}
+                </span>
+              ))
+            }
+          </div>
+        </div>
+      </section>
+    );
+  }
+}
+
 SearchBar.propTypes = {
   className: PropTypes.string,
-  data: PropTypes.object.isRequired,
-  handleSearchBy: PropTypes.func.isRequired,
-  handleKeyPress: PropTypes.func.isRequired,
-  handleKeywordClick: PropTypes.func.isRequired,
-  setKeyword: PropTypes.func.isRequired,
-  fetchExperiencesAndWorkings: PropTypes.func.isRequired,
+  keywords: PropTypes.array,
+  searchBy: PropTypes.string.isRequired,
+  searchQuery: PropTypes.string.isRequired,
+  onSearchByChange: PropTypes.func.isRequired,
+  onKeywordClick: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
 };
 
 export default SearchBar;

--- a/src/components/ExperienceSearch/helper.js
+++ b/src/components/ExperienceSearch/helper.js
@@ -33,6 +33,7 @@ const qsSelector = (key, defaultValue) => R.compose(
 export const searchQuerySelector = qsSelector('q', '');
 export const searchBySelector = qsSelector('s_by', 'job_title');
 export const sortBySelector = qsSelector('sort', 'created_at');
+export const sortSelector = qsSelector('sort', 'created_at');
 export const pageSelector = qsSelector('p', 1);
 export const searchTypeSelector = R.compose(
   qsSelector('type', 'interview,work'),
@@ -41,6 +42,9 @@ export const searchTypeSelector = R.compose(
 export const querySelector = query => ({
   get sortBy() {
     return sortBySelector(query);
+  },
+  get sort() {
+    return sortSelector(query);
   },
   get searchQuery() {
     return searchQuerySelector(query);

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -76,9 +76,7 @@ class ExperienceSearch extends Component {
   }
 
   static propTypes = {
-    // setKeyword: PropTypes.func.isRequired, // TODO: remove
     fetchExperiences: PropTypes.func.isRequired,
-    // fetchWorkings: PropTypes.func.isRequired, // TODO: remove
     getNewSearchBy: PropTypes.func.isRequired, // TODO: rename, eg: queryKeywords
     experienceSearch: ImmutablePropTypes.map.isRequired,
     location: PropTypes.shape({

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -11,7 +11,6 @@ import ReactPixel from 'react-facebook-pixel';
 
 import Loader from 'common/Loader';
 import { Section, Wrapper, Heading, P } from 'common/base';
-import Columns from 'common/Columns';
 
 import styles from './ExperienceSearch.module.css';
 import Searchbar from './Searchbar';
@@ -26,7 +25,6 @@ import {
   PAGE_COUNT,
 } from '../../constants/experienceSearch';
 import status from '../../constants/status';
-import TimeSalaryBlock from './TimeSalaryBlock';
 import Filter from './Filter';
 import { Banner1, Banner2 } from './Banners';
 
@@ -500,22 +498,6 @@ class ExperienceSearch extends Component {
                 currentPage={data.currentPage}
                 createPageLinkTo={this.createPageLinkTo}
               />
-
-              {(data.searchQuery && data.workings.length > 0) &&
-                <div>
-                  <hr className={styles.splitter} />
-                  <section className={styles.timeSalaryWrapper}>
-                    <Heading size="m" bold marginBottom>「{data.searchQuery}」的薪資工時</Heading>
-                    {data.salary &&
-                      <Columns
-                        Item={TimeSalaryBlock}
-                        items={(data.workings || []).map(o => ({ data: o }))}
-                        gutter="s"
-                      />
-                    }
-                  </section>
-                </div>
-              }
             </section>
           </div>
         </Wrapper>

--- a/src/components/ExperienceSearch/index.js
+++ b/src/components/ExperienceSearch/index.js
@@ -33,7 +33,6 @@ import Pagination from './Pagination';
 import getScale from '../../utils/numberUtils';
 
 import {
-  handleSearchType,
   toQsString,
   querySelector,
   pageKeysToQuery,
@@ -85,11 +84,6 @@ class ExperienceSearch extends Component {
       pathname: PropTypes.string,
     }),
     loadingStatus: PropTypes.string,
-  }
-
-  constructor(props) {
-    super(props);
-    this.fetchExperiencesWithSort = this.fetchExperiencesWithSort.bind(this);
   }
 
   componentDidMount() {
@@ -164,54 +158,28 @@ class ExperienceSearch extends Component {
     return url;
   }
 
-  setSearchType = e => {
-    const searchType = e.target.value;
-    const on = this.props.experienceSearch.get(searchType);
-    if (on) {
-      ReactGA.event({
-        category: GA_CATEGORY.SEARCH_EXPERIENCE,
-        action: `${GA_ACTION.TOGGLE_OFF}_${searchType}`,
-      });
-    } else {
-      ReactGA.event({
-        category: GA_CATEGORY.SEARCH_EXPERIENCE,
-        action: `${GA_ACTION.TOGGLE_ON}_${searchType}`,
-      });
-    }
-
-    const {
-      pathname,
-      query,
-    } = this.props.location;
+  handleSearchTypeChange = ({ searchType, sort }) => {
+    const { pathname, query } = this.props.location;
 
     const {
       searchBy,
       searchQuery,
-      sortBy: sort,
     } = querySelector(query);
 
-    let {
-      searchType: prevSearchType,
-    } = querySelector(query);
-
-    prevSearchType = R.split(',', prevSearchType);
-
-    const nextSearchType = handleSearchType(searchType)(prevSearchType);
+    const page = 1;
 
     const queryString = toQsString({
-      page: 1,
+      page,
       sort,
       searchBy,
       searchQuery,
-      searchType: nextSearchType,
+      searchType: R.join(',')(searchType),
     });
-
     const url = `${pathname}?${queryString}`;
-
     browserHistory.push(url);
   }
 
-  handleSearchbarKeywordClick = ({ keyword, searchQuery, searchBy }) => {
+  handleSearchbarKeywordClick = ({ keyword, searchBy }) => {
     const { pathname, query } = this.props.location;
     // pickup parameter from query
     const { sort, searchType } = querySelector(query);
@@ -228,7 +196,7 @@ class ExperienceSearch extends Component {
     const url = `${pathname}?${queryString}`;
     browserHistory.push(url);
 
-    this.searchTrack({ searchBy, searchQuery });
+    this.searchTrack({ searchBy, keyword });
   }
 
   handleSearchBy = ({ searchQuery, searchBy }) => {
@@ -292,7 +260,7 @@ class ExperienceSearch extends Component {
     });
   }
 
-  fetchExperiencesWithSort(sort) {
+  handleSortClick = ({ searchType, sort }) => {
     const {
       pathname,
       query,
@@ -300,19 +268,21 @@ class ExperienceSearch extends Component {
 
     const {
       searchBy,
-      searchType,
     } = querySelector(query);
+
+    // reset searchQuery
+    const searchQuery = '';
+    const page = 1;
 
     const queryString = toQsString({
       sort,
       searchBy,
-      searchQuery: '',
-      page: 1,
+      searchQuery,
+      page,
       searchType,
     });
 
     const url = `${pathname}?${queryString}`;
-
     browserHistory.push(url);
 
     if (sort === SORT.CREATED_AT) {
@@ -435,7 +405,7 @@ class ExperienceSearch extends Component {
     const experiences = data.experiences || [];
 
     const { query } = this.props.location;
-    const { searchQuery, searchBy } = querySelector(query);
+    const { searchQuery, searchBy, sort, searchType } = querySelector(query);
 
     return (
       <Section Tag="main" pageTop paddingBottom>
@@ -444,9 +414,10 @@ class ExperienceSearch extends Component {
           <div className={styles.container}>
             <aside className={styles.aside}>
               <Filter
-                data={data}
-                fetchExperiencesWithSort={this.fetchExperiencesWithSort}
-                setSearchType={this.setSearchType}
+                sort={sort}
+                searchType={searchType.split(',')}
+                onSeachTypeChange={this.handleSearchTypeChange}
+                onSortClick={this.handleSortClick}
                 className={styles.filter}
               />
               <Banner1 className={styles.banner} />

--- a/src/containers/ExperienceSearchPage.js
+++ b/src/containers/ExperienceSearchPage.js
@@ -6,17 +6,11 @@ import ExperienceSearch from '../components/ExperienceSearch';
 import * as ExperienceSearchActions from '../actions/experienceSearch';
 
 import {
-  searchBySelector,
-  sortSelector,
-  searchQuerySelector,
   loadingStatusSelector,
 } from '../selectors/experienceSearchSelector';
 
 const mapStateToProps = createStructuredSelector({
   experienceSearch: state => state.experienceSearch,
-  searchBy: searchBySelector,
-  searchQuery: searchQuerySelector,
-  sort: sortSelector,
   loadingStatus: loadingStatusSelector,
 });
 

--- a/src/reducers/experienceSearch.js
+++ b/src/reducers/experienceSearch.js
@@ -3,9 +3,6 @@ import { Map, fromJS } from 'immutable';
 import createReducer from 'utils/createReducer';
 import statusConstant from '../constants/status';
 import {
-  SET_SEARCH_BY,
-  SET_WORKINGS,
-  SET_KEYWORD,
   SET_KEYWORDS,
   SET_SORT_AND_EXPERIENCES,
   SET_LOADING_STATUS,
@@ -21,23 +18,12 @@ const preloadedState = Map({
   experiences: [],
   experienceCount: 0,
 
-  keyword: '', // input value 用
   keywords: [],
-  workings: [],
   loadingStatus: statusConstant.UNFETCHED,
   error: null,
 });
 
 const experienceSearch = createReducer(preloadedState, {
-  [SET_SEARCH_BY]: (state, action) =>
-    state.update('searchBy', () => action.searchBy),
-
-  [SET_KEYWORD]: (state, action) =>
-    state.update('keyword', () => action.keyword),
-
-  [SET_WORKINGS]: (state, action) =>
-    state.update('workings', () => fromJS(action.workings || [])),
-
   [SET_KEYWORDS]: (state, action) =>
     state.merge({
       keywords: fromJS(action.keywords),

--- a/src/selectors/experienceSearchSelector.js
+++ b/src/selectors/experienceSearchSelector.js
@@ -1,4 +1,2 @@
-export const searchBySelector = state => state.experienceSearch.get('searchBy');
-export const searchQuerySelector = state => state.experienceSearch.get('searchQuery');
-export const sortSelector = state => state.experienceSearch.get('sort');
 export const loadingStatusSelector = state => state.experienceSearch.get('loadingStatus');
+export const dummy = true;


### PR DESCRIPTION
將

![image](https://user-images.githubusercontent.com/1908007/37241980-b5723b88-249c-11e8-97ba-ba5a155a31a2.png)

![image](https://user-images.githubusercontent.com/1908007/37241986-c5c53864-249c-11e8-83fe-f2729bdd99f2.png)

兩個選項與 redux state 脫離

1. input/checkbox/radio 的狀態只要放在 Component 內就足夠了
2. 將事件的處理全部移到 `components/ExperienceSearch`，避免底層的 component 自己送 action