### PR TITLE
Refactor 權限機制

### DIFF
--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -23,7 +23,7 @@ import {
   queryEntry,
 } from '../../actions/laborRights';
 import fetchingStatus from '../../constants/status';
-import { MAX_IMAGES_IF_HIDDEN, MARKDOWN_DIVIDER } from '../../constants/hideContent';
+import { MARKDOWN_DIVIDER } from '../../constants/hideContent';
 import { SITE_NAME } from '../../constants/helmetData';
 import PIXEL_CONTENT_CATEGORY from '../../constants/pixelConstants';
 
@@ -84,7 +84,7 @@ class LaborRightsSingle extends React.Component {
     let newContent = content;
     let permissionBlock = null;
     if (!canViewLaborRightsSingle && nPublicPages > 0 && content) {
-      const endPos = nthIndexOf(content, MARKDOWN_DIVIDER, MAX_IMAGES_IF_HIDDEN);
+      const endPos = nthIndexOf(content, MARKDOWN_DIVIDER, nPublicPages);
       newContent = content.substr(0, endPos);
       permissionBlock = (
         <LaborRightsPermissionBlock

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -60,7 +60,7 @@ class BasicPermissionBlock extends React.Component {
           <br />
           <P size="l"><strong>若你已經分享過資訊，登入即可查看全文！</strong></P>
           <div className={styles.ctaButtonContainer}>
-            <CallToLoginShareButton to="/share" notLoginText="立即登入並分享" isLoginText="立即分享" />
+            <CallToLoginShareButton to="/share/time-and-salary" notLoginText="立即登入並分享" isLoginText="立即分享" />
           </div>
         </div>
       </div>

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -69,7 +69,7 @@ class BasicPermissionBlock extends React.Component {
           <br />
           <P size="l"><strong>若你已經分享過資訊，登入即可查看全文！</strong></P>
           <div className={styles.ctaButtonContainer}>
-            <CallToLoginShareButton to="/share" notLoginText="立即登入並分享" isLoginText="立即分享" />
+            <CallToLoginShareButton to="/share/time-and-salary" notLoginText="立即登入並分享" isLoginText="立即分享" />
           </div>
         </div>
       </div>

--- a/src/constants/hideContent.js
+++ b/src/constants/hideContent.js
@@ -1,4 +1,4 @@
 export const MAX_WORDS_IF_HIDDEN = 50;
 export const MAX_IMAGES_IF_HIDDEN = 3;
-export const MAX_ROWS_IF_HIDDEN = 3;
+export const MAX_ROWS_IF_HIDDEN = 8;
 export const MARKDOWN_DIVIDER = '---';


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

1. 權限機制的連結直接導到薪資工時表單頁
2. 薪資工時沒權限能看的列數提高到 8 列
3. 小教室沒權限能看的張數，應該是要 contentful （之前是用 constant 寫死，是bug）

## Screenshots  <!-- 選填，沒有就刪掉 -->
![2018-03-14 12 53 29](https://user-images.githubusercontent.com/3805975/37357238-d52d4368-2722-11e8-9f51-9757f58e9524.png)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 沒有權限的情況下進薪資工時查詢頁兩次，應該要看到八個 rows，
- [ ] 點擊權限區塊的立即分享，會進到薪資工時表單頁
