### PR TITLE
TimeAndSalaryBoard 在換route時清空極端資料

### DIFF
--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -44,6 +44,7 @@ export const queryTimeAndSalary = ({ sortBy, order }) =>
   (dispatch, getState) => {
     if (sortBy !== sortBySelector(getState()) || order !== orderSelector(getState())) {
       dispatch(resetBoard({ sortBy, order }));
+      dispatch(resetBoardExtremeData()); // eslint-disable-line no-use-before-define
     }
 
     if (statusSelector(getState()) === fetchingStatus.FETCHING) {


### PR DESCRIPTION
Close #439 

這個issue是因為沒有重置extremeData，以至於extremeData可能會與目前的route不符，而extremeData與一般的data有重覆時，會造成duplicated key，使React沒有辦法順利的去掉extremeData的row。

本PR將resetExtremeData加上，可修復該issue。