### PR TITLE
[WIP] Update/add meta data for Campaign form and search page 

### DIFF
--- a/src/apis/campaignInfoApi.js
+++ b/src/apis/campaignInfoApi.js
@@ -21,6 +21,7 @@ export const fetchCampaignList = () => Promise.resolve([
     formEnding: `## 合作單位
 ![台灣電子電機資訊產業工會 ](http://www.tueeit.org.tw/_/rsrc/1362329924603/config/customLogo.gif?revision=14)`,
     metaDescription: '科技業工程師，高薪的背後是否隱藏著高工時的代價，被訂單追趕而無止盡加班，導致自身健康與家庭出現問題，我們經常不得而知。因此，我們與台灣電子電機資訊產業工會合作，共同發起 「科技業工程師 真實工時 x 薪資分紅」大調查，想邀請各位科技業的工程師們分享自己的真實工時以及薪資福利多寡，讓職場變得更加透明，讓高工時的工作無所遁形。',
+    ogImgUrl: 'https://image.goodjob.life/campaign/software-engineer-campaign.png',
     defaultJobTitle: '',
     defaultContent: `1. 是否經常加班？ 加班的原因為何？
 

--- a/src/apis/campaignInfoApi.js
+++ b/src/apis/campaignInfoApi.js
@@ -20,6 +20,7 @@ export const fetchCampaignList = () => Promise.resolve([
     是的，永久匿名。`,
     formEnding: `## 合作單位
 ![台灣電子電機資訊產業工會 ](http://www.tueeit.org.tw/_/rsrc/1362329924603/config/customLogo.gif?revision=14)`,
+    metaDescription: '科技業工程師，高薪的背後是否隱藏著高工時的代價，被訂單追趕而無止盡加班，導致自身健康與家庭出現問題，我們經常不得而知。因此，我們與台灣電子電機資訊產業工會合作，共同發起 「科技業工程師 真實工時 x 薪資分紅」大調查，想邀請各位科技業的工程師們分享自己的真實工時以及薪資福利多寡，讓職場變得更加透明，讓高工時的工作無所遁形。',
     defaultJobTitle: '',
     defaultContent: `1. 是否經常加班？ 加班的原因為何？
 

--- a/src/components/CampaignTimeAndSalary/index.js
+++ b/src/components/CampaignTimeAndSalary/index.js
@@ -45,6 +45,11 @@ export default class TimeAndSalary extends Component {
     location: PropTypes.shape({
       pathname: PropTypes.string,
     }),
+    match: PropTypes.shape({
+      params: PropTypes.shape({
+        campaign_name: PropTypes.string,
+      }),
+    }).isRequired,
   }
 
   constructor(props) {
@@ -81,10 +86,13 @@ export default class TimeAndSalary extends Component {
   renderHelmet = () => {
     const path = this.props.location.pathname;
     const url = formatCanonicalPath(path);
+    const campaignName = this.props.match.params.campaign_name;
+    const campaignInfo = this.props.campaignEntries.get(campaignName).toJS();
+    const { title: campaignTitle } = campaignInfo;
 
     // default title and description
-    let title = '查看薪資、工時資訊';
-    const description = '馬上查看薪資、工時資訊以及加班狀況，協助您找到更好的工作！';
+    let title = `${campaignTitle}的最新薪資、工時資訊`;
+    const description = `馬上查看${title}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
 
     // 根據 route 去更新 title  e.g. 工時排行榜（由高到低）
     let name = '';
@@ -93,7 +101,7 @@ export default class TimeAndSalary extends Component {
         name = pathnameMapping[key];
       }
     });
-    if (name) { title = name; }
+    if (name) { title = `${campaignTitle}的${name}`; }
 
     return (
       <Helmet
@@ -103,6 +111,7 @@ export default class TimeAndSalary extends Component {
           { property: 'og:title', content: formatTitle(title, SITE_NAME) },
           { property: 'og:description', content: description },
           { property: 'og:url', content: url },
+          // TODO
           { property: 'og:image', content: `${imgHost}/og/time-and-salary.jpg` },
         ]}
         link={[

--- a/src/components/CampaignTimeAndSalary/index.js
+++ b/src/components/CampaignTimeAndSalary/index.js
@@ -15,7 +15,7 @@ import InfoSalaryModal from '../TimeAndSalary/common/InfoSalaryModal';
 import styles from './CampaignTimeAndSalary.module.css';
 
 import { formatTitle, formatCanonicalPath } from '../../utils/helmetHelper';
-import { imgHost, SITE_NAME } from '../../constants/helmetData';
+import { SITE_NAME } from '../../constants/helmetData';
 import { queryCampaignInfoList } from '../../actions/campaignTimeAndSalaryBoard';
 
 const pathnameMapping = {
@@ -88,7 +88,7 @@ export default class TimeAndSalary extends Component {
     const url = formatCanonicalPath(path);
     const campaignName = this.props.match.params.campaign_name;
     const campaignInfo = this.props.campaignEntries.get(campaignName).toJS();
-    const { title: campaignTitle } = campaignInfo;
+    const { title: campaignTitle, ogImgUrl } = campaignInfo;
 
     // default title and description
     let title = `${campaignTitle}的最新薪資、工時資訊`;
@@ -111,8 +111,7 @@ export default class TimeAndSalary extends Component {
           { property: 'og:title', content: formatTitle(title, SITE_NAME) },
           { property: 'og:description', content: description },
           { property: 'og:url', content: url },
-          // TODO
-          { property: 'og:image', content: `${imgHost}/og/time-and-salary.jpg` },
+          { property: 'og:image', content: ogImgUrl },
         ]}
         link={[
           { rel: 'canonical', href: url },

--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -257,7 +257,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
     if (this.props.campaignEntriesStatus === fetchingStatus.FETCHED) {
       const campaignName = this.props.match.params.campaign_name;
       const campaignInfo = this.props.campaignEntries.get(campaignName).toJS();
-      const { formTitle, metaDescription } = campaignInfo;
+      const { formTitle, metaDescription, ogImgUrl } = campaignInfo;
       const helmetData = {
         title: formTitle,
         meta: [
@@ -265,7 +265,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
           { property: 'og:title', content: formatTitle(formTitle, SITE_NAME) },
           { property: 'og:description', content: metaDescription },
           { property: 'og:url', content: formatCanonicalPath(`/share/time-and-salary/campaign/${campaignName}`) },
-          // TODO: og:image
+          { property: 'og:image', content: ogImgUrl },
         ],
         link: [
           { rel: 'canonical', href: formatCanonicalPath(`/share/time-and-salary/campaign/${campaignName}`) },

--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -45,7 +45,9 @@ import {
   portTimeSalaryFormToRequestFormat,
 } from '../utils';
 
-import { HELMET_DATA } from '../../../constants/helmetData';
+import { HELMET_DATA, SITE_NAME } from '../../../constants/helmetData';
+import { formatTitle, formatCanonicalPath } from '../../../utils/helmetHelper';
+
 import {
   INVALID,
   TIME_SALARY_BASIC_ORDER,
@@ -251,6 +253,30 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
     };
   }
 
+  renderHelmet = () => {
+    if (this.props.campaignEntriesStatus === fetchingStatus.FETCHED) {
+      const campaignName = this.props.match.params.campaign_name;
+      const campaignInfo = this.props.campaignEntries.get(campaignName).toJS();
+      const { formTitle, metaDescription } = campaignInfo;
+      const helmetData = {
+        title: formTitle,
+        meta: [
+          { name: 'description', content: metaDescription },
+          { property: 'og:title', content: formatTitle(formTitle, SITE_NAME) },
+          { property: 'og:description', content: metaDescription },
+          { property: 'og:url', content: formatCanonicalPath(`/share/time-and-salary/campaign/${campaignName}`) },
+          // TODO: og:image
+        ],
+        link: [
+          { rel: 'canonical', href: formatCanonicalPath(`/share/time-and-salary/campaign/${campaignName}`) },
+        ],
+      };
+      return <Helmet {...helmetData} />;
+    }
+    return <Helmet {...HELMET_DATA.SHARE_TIME_SALARY} />;
+  }
+
+
   render() {
     const {
       campaignEntriesStatus,
@@ -301,7 +327,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
 
     return (
       <div>
-        <Helmet {...HELMET_DATA.SHARE_TIME_SALARY} />
+        {this.renderHelmet()}
         <Heading size="l" marginBottomS center>
           {formTitle}
         </Heading>


### PR DESCRIPTION
Close #472 

## 這個 PR 是？ <!-- 必填 -->

增加 Campaign 表單頁面、查詢頁面所需的 meta information

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

分 commit 看

a291452 新增一個欄位放 description，因為用原本的 formIntroduction 會有 markdown 的符號有點怪，也太長
3849f25 搜尋頁小修改一下 meta 資訊
a836564 表單頁加上 meta 資訊

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進搜尋頁 http://localhost:3001/time-and-salary/campaigns/software-engineer/latest 看 title, description 資訊是否正確載入
- [ ] 進表單頁 http://localhost:3001/share/time-and-salary/campaigns/software-engineer 看 title, description 資訊是否正確載入

## TODO
- [ ] Campaign 會有專用的 og:image ， @wutingy  我想問一下你是不是已經給我了，有的話哪邊可以找到？