### PR TITLE
修正Campaign送出表單沒有送出campaign參數

### DIFF
--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -188,6 +188,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
     const { match: { params: { campaign_name: campaignName } } } = this.props;
     const campaignInfo = campaignEntries.get(campaignName);
     if (campaignInfo) {
+      this.setState({ campaignName });
       this.setCampaignInfo(campaignInfo.toJS());
     }
   }

--- a/src/components/ShareExperience/utils.js
+++ b/src/components/ShareExperience/utils.js
@@ -184,7 +184,7 @@ export const getCampaignExtendedForm = extraFields => state => ({
   ...getExtraForm(extraFields)(state),
 });
 export const getCampaignTimeAndSalaryForm = extraFields => state => ({
-  campaign: state.campaignName,
+  campaignName: state.campaignName,
   ...getTimeAndSalaryForm(state),
   ...getCampaignExtendedForm(extraFields)(state),
 });


### PR DESCRIPTION
Close #480

原本`TimeAndSalary`是從`state`拿到`campaign` (如下)，在集中campaignInfo到store的時候疏忽這邊了

https://github.com/goodjoblife/GoodJobShare/blob/2ce095936f6ac7c6427252dabf2faf5ff8da66c9/src/components/ShareExperience/utils.js#L186-L190

所以解法是在`setCampaignInfoFromEntries` (如下)時一併`setState({ campaignName })`即可

https://github.com/goodjoblife/GoodJobShare/blob/2ce095936f6ac7c6427252dabf2faf5ff8da66c9/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js#L187-L193