### PR TITLE
hotfix: 解決大量 call API 的 bug 

### DIFF
--- a/src/components/TimeAndSalary/common/WorkingHourBlock.js
+++ b/src/components/TimeAndSalary/common/WorkingHourBlock.js
@@ -96,7 +96,7 @@ class WorkingHourBlock extends Component {
             [styles.expanded]: this.state.isExpanded,
           })}
         >
-          {this.renderBlockContent()}
+          { this.state.isExpanded ? this.renderBlockContent() : null}
         </div>
       </section>
     );


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

bug 的來源是 workingHourBlock ([示意圖](https://user-images.githubusercontent.com/3805975/39526800-770f1a48-4e52-11e8-8dc0-5cc215c2c228.png) ) 在未展開的狀態下，還是會 render content，裡面包含了 PermissionBlock 。這一堆 PermissionBlock 會同時間瞬間去檢查三種數字的 fetching status，全部都認為還沒 fetch，就全部都打 API 了。

我嘗試過讓 PermissionBlock 檢查 fetching status 是不是 unfetched，然後在準備要打 API 之"前"，先 dispatch action 把 fetching status 設成 fetching，想說這樣還沒打 API 之前就能先改 fetching status，就不會爆出一堆 query。

但這招沒有奏效，unfetched 還沒變成 isfetching 之前，所有的 PermissionBlock 就已經全部檢查完狀態，全部都打 API 了

所以，目前唯一解法是不要瞬間 render 大量 PermissionBlock。
瞬間 render 大量 PermissionBlock 也很不合理啦，所以就只改一行了

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 無痕模式下進  http://localhost:3001/time-and-salary/job-title/設計/salary-dashboard ，重新整理後，不應該要再打一堆 request 了
- [ ] 或者是 facebook 先登出，非登入狀態下進  http://localhost:3001/time-and-salary/job-title/設計/salary-dashboard ，重新整理後，不應該要再打一堆 request 了
