### PR TITLE
bugfix #494, query api when unfetched

### DIFF
--- a/src/actions/experiences.js
+++ b/src/actions/experiences.js
@@ -1,6 +1,6 @@
 import R from 'ramda';
 import { getExperiences } from '../apis/experiencesApi';
-import fetchingStatus from '../constants/status';
+import fetchingStatus, { isUnfetched } from '../constants/status';
 
 export const SET_COUNT_DATA = '@@EXPERIENCES/SET_COUNT_DATA';
 
@@ -13,6 +13,7 @@ const setCountData = (count, status, error = null) => ({
 
 export const queryExperienceCount = () =>
   dispatch => {
+    dispatch(setCountData(0, fetchingStatus.FETCHING));
     const opt = {
       limit: 1,
       start: 0,
@@ -27,3 +28,11 @@ export const queryExperienceCount = () =>
         dispatch(setCountData(0, fetchingStatus.ERROR, error));
       });
   };
+
+export const queryExperienceCountIfUnfetched = () =>
+(dispatch, getState) => {
+  if (isUnfetched(getState().experiences.get('countStatus'))) {
+    return dispatch(queryExperienceCount());
+  }
+  return Promise.resolve();
+};

--- a/src/actions/timeAndSalary.js
+++ b/src/actions/timeAndSalary.js
@@ -13,6 +13,8 @@ const setCountData = (count, status, error = null) => ({
 
 export const queryTimeAndSalaryCount = () =>
   dispatch => {
+    dispatch(setCountData(0, fetchingStatus.FETCHING));
+
     const opt = {
       limit: 1,
     };

--- a/src/containers/PermissionBlock/BasicPermissionBlockContainer.js
+++ b/src/containers/PermissionBlock/BasicPermissionBlockContainer.js
@@ -2,9 +2,9 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import BasicPermissionBlock from '../../components/common/PermissionBlock/BasicPermissionBlock';
-import { queryTimeAndSalaryCount } from '../../actions/timeAndSalary';
-import { queryExperienceCount } from '../../actions/experiences';
-import { queryMenu } from '../../actions/laborRights';
+import { queryTimeAndSalaryCountIfUnfetched } from '../../actions/timeAndSalary';
+import { queryExperienceCountIfUnfetched } from '../../actions/experiences';
+import { queryMenuIfUnfetched } from '../../actions/laborRights';
 import {
   experienceCountSelector,
   hasFetchedexperienceCountSelector,
@@ -25,9 +25,9 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators({
-    queryExperienceCount,
-    queryTimeAndSalaryCount,
-    queryLaborRightsCount: queryMenu,
+    queryExperienceCount: queryExperienceCountIfUnfetched,
+    queryTimeAndSalaryCount: queryTimeAndSalaryCountIfUnfetched,
+    queryLaborRightsCount: queryMenuIfUnfetched,
   }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(BasicPermissionBlock);

--- a/src/containers/PermissionBlock/LaborRightsPermissionBlockContainer.js
+++ b/src/containers/PermissionBlock/LaborRightsPermissionBlockContainer.js
@@ -2,9 +2,9 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import LaborRightsPermissionBlock from '../../components/common/PermissionBlock/LaborRightsPermissionBlock';
-import { queryTimeAndSalaryCount } from '../../actions/timeAndSalary';
-import { queryExperienceCount } from '../../actions/experiences';
-import { queryMenu } from '../../actions/laborRights';
+import { queryTimeAndSalaryCountIfUnfetched } from '../../actions/timeAndSalary';
+import { queryExperienceCountIfUnfetched } from '../../actions/experiences';
+import { queryMenuIfUnfetched } from '../../actions/laborRights';
 import {
   experienceCountSelector,
   hasFetchedexperienceCountSelector,
@@ -25,9 +25,9 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch =>
   bindActionCreators({
-    queryExperienceCount,
-    queryTimeAndSalaryCount,
-    queryLaborRightsCount: queryMenu,
+    queryExperienceCount: queryExperienceCountIfUnfetched,
+    queryTimeAndSalaryCount: queryTimeAndSalaryCountIfUnfetched,
+    queryLaborRightsCount: queryMenuIfUnfetched,
   }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(LaborRightsPermissionBlock);


### PR DESCRIPTION
Close #494

## 這個 PR 是？ <!-- 必填 -->

當打 API 時，檢查是不是 `UNFETCHED`，並且 dispatch `FETCHING` 確保一次只有一個 query 發生

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

當 component 執行 `queryExperienceCountIfUnfetched` 時，

直到 `getExperiences(opt)` 前，都是非 async code (*)，所以 `dispatch(setCountData(0, fetchingStatus.FETCHING));` 可以確保下一個 query 被拒絕

(*) 目前驗證的結果是這樣

## 我應該如何手動測試？ <!-- 必填 -->

- [x] 檢查打開 #494 相關的頁面，是否仍然有大量的 query