### PR TITLE
fix: show error message on Modal when error happen

### DIFF
--- a/src/components/ShareExperience/common/FailFeedback.js
+++ b/src/components/ShareExperience/common/FailFeedback.js
@@ -3,16 +3,17 @@ import PropTypes from 'prop-types';
 
 import Feedback from 'common/Feedback';
 
-const FailFeedback = ({ buttonClick }) => (
+const FailFeedback = ({ info, buttonClick }) => (
   <Feedback
     buttonClick={buttonClick}
     heading="Oops 有些錯誤發生"
-    info="請查看你的網路連線再試一次，如果你還沒填寫完，請先別關閉瀏覽器！"
+    info={info || '請查看你的網路連線再試一次，如果你還沒填寫完，請先別關閉瀏覽器！'}
     buttonText="好，我知道了"
   />
 );
 
 FailFeedback.propTypes = {
+  info: PropTypes.string,
   buttonClick: PropTypes.func,
 };
 

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -31,8 +31,9 @@ const getWorkingsSuccessFeedback = count => (
   />
 );
 
-const getFailFeedback = buttonClick => (
+const getFailFeedback = (info, buttonClick) => (
   <FailFeedback
+    info={info}
     buttonClick={buttonClick}
   />
 );
@@ -83,11 +84,12 @@ class SubmitArea extends React.PureComponent {
           }
           return this.handleFeedback(getSuccessFeedback(id));
         })
-        .catch(() => {
+        .catch(error => {
           this.handleIsOpen(true);
           this.handleHasClose(false);
           return this.handleFeedback(getFailFeedback(
-            () => this.handleIsOpen(false)
+            error.message,
+            () => this.handleIsOpen(false),
           ));
         });
     }


### PR DESCRIPTION
Close #500 

## 這個 PR 是？ <!-- 必填 -->

填寫表單如果 API 出現錯誤，把錯誤訊息顯示在 modal 上，才不會不知道到底為什麼出錯。

## Screenshots  <!-- 選填，沒有就刪掉 -->

![2018-05-09 12 45 45](https://user-images.githubusercontent.com/3805975/39770703-59951e70-5322-11e8-99d3-8a678ac6328d.png)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 最簡單的測試方式是，先留五筆薪資工時資訊，留第六筆，要看到「您已經上傳5次，已達最高上限」的訊息。
