### PR TITLE
Refactor: In form, do logic handle in only one function

### DIFF
--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -141,8 +141,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
     }
   }
 
-  onSubmit(opt) {
-    const { handleIsOpen, handleHasClose, handleFeedback } = opt;
+  onSubmit() {
     const valid = basicFormCheck(getBasicForm(this.state));
     const valid2 = salaryFormCheck(getSalaryForm(this.state));
     const valid3 = timeFormCheck(getTimeForm(this.state));
@@ -160,17 +159,6 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
 
       return p.then(response => {
         const count = response.queries_count;
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <SuccessFeedback
-            info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
-            buttonText="查看最新工時、薪資"
-            buttonClick={() => {
-              window.location.replace(`/time-and-salary/campaigns/${campaignName}/latest`);
-            }}
-          />
-        );
 
         ReactGA.event({
           category: GA_CATEGORY.SHARE_TIME_SALARY,
@@ -181,20 +169,32 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
           currency: 'TWD',
           content_category: PIXEL_CONTENT_CATEGORY.UPLOAD_TIME_AND_SALARY,
         });
-      }, error => {
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <FailFeedback
-            info={error.message}
-            buttonClick={() => handleIsOpen(false)}
-          />
-        );
 
+        return (
+          () => (
+            <SuccessFeedback
+              info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
+              buttonText="查看最新工時、薪資"
+              buttonClick={() => {
+                window.location.replace(`/time-and-salary/campaigns/${campaignName}/latest`);
+              }}
+            />
+          )
+        );
+      }, error => {
         ReactGA.event({
           category: GA_CATEGORY.SHARE_TIME_SALARY,
           action: GA_ACTION.UPLOAD_FAIL,
         });
+
+        return (
+          ({ buttonClickCallback }) => (
+            <FailFeedback
+              info={error.message}
+              buttonClick={buttonClickCallback}
+            />
+          )
+        );
       });
     }
     this.handleState('submitted')(true);
@@ -207,7 +207,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
         smooth: true,
       });
     }
-    return null;
+    return Promise.reject();
   }
 
   setCampaignInfoFromEntries(campaignEntries) {

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -139,8 +139,7 @@ class InterviewForm extends React.Component {
     });
   }
 
-  onSubmit(opt) {
-    const { handleIsOpen, handleHasClose, handleFeedback } = opt;
+  onSubmit() {
     const valid = interviewFormCheck(getInterviewForm(this.state));
 
     if (valid) {
@@ -148,15 +147,6 @@ class InterviewForm extends React.Component {
       const p = postInterviewExperience(portInterviewFormToRequestFormat(getInterviewForm(this.state)));
       return p.then(response => {
         const experienceId = response.experience._id;
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <SuccessFeedback
-            buttonClick={() => (
-              window.location.replace(`/experiences/${experienceId}`)
-            )}
-          />
-        );
 
         ReactGA.event({
           category: GA_CATEGORY.SHARE_INTERVIEW,
@@ -167,20 +157,29 @@ class InterviewForm extends React.Component {
           currency: 'TWD',
           content_category: PIXEL_CONTENT_CATEGORY.UPLOAD_INTERVIEW_EXPERIENCE,
         });
-      }, error => {
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <FailFeedback
-            info={error.message}
-            buttonClick={() => handleIsOpen(false)}
-          />
+        return (
+          () => (
+            <SuccessFeedback
+              buttonClick={() => (
+                window.location.replace(`/experiences/${experienceId}`)
+              )}
+            />
+          )
         );
-
+      }, error => {
         ReactGA.event({
           category: GA_CATEGORY.SHARE_INTERVIEW,
           action: GA_ACTION.UPLOAD_FAIL,
         });
+
+        return (
+          ({ buttonClickCallback }) => (
+            <FailFeedback
+              info={error.message}
+              buttonClick={buttonClickCallback}
+            />
+          )
+        );
       });
     }
     this.handleState('submitted')(true);
@@ -193,7 +192,7 @@ class InterviewForm extends React.Component {
         smooth: true,
       });
     }
-    return null;
+    return Promise.reject();
   }
 
   getTopInvalidElement = () => {

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -36,6 +36,9 @@ import {
   LS_INTERVIEW_FORM_KEY,
 } from '../../../constants/localStorageKey';
 
+import SuccessFeedback from '../common/SuccessFeedback';
+import FailFeedback from '../common/FailFeedback';
+
 const createSection = id => (subtitle, placeholder = '', titlePlaceholder = '段落標題，例：面試方式') => {
   const section = {
     id,
@@ -136,12 +139,25 @@ class InterviewForm extends React.Component {
     });
   }
 
-  onSubmit() {
+  onSubmit(opt) {
+    const { handleIsOpen, handleHasClose, handleFeedback } = opt;
     const valid = interviewFormCheck(getInterviewForm(this.state));
 
     if (valid) {
+      localStorage.removeItem(LS_INTERVIEW_FORM_KEY);
       const p = postInterviewExperience(portInterviewFormToRequestFormat(getInterviewForm(this.state)));
-      p.then(() => {
+      return p.then(response => {
+        const experienceId = response.experience._id;
+        handleIsOpen(true);
+        handleHasClose(false);
+        handleFeedback(
+          <SuccessFeedback
+            buttonClick={() => (
+              window.location.replace(`/experiences/${experienceId}`)
+            )}
+          />
+        );
+
         ReactGA.event({
           category: GA_CATEGORY.SHARE_INTERVIEW,
           action: GA_ACTION.UPLOAD_SUCCESS,
@@ -151,14 +167,21 @@ class InterviewForm extends React.Component {
           currency: 'TWD',
           content_category: PIXEL_CONTENT_CATEGORY.UPLOAD_INTERVIEW_EXPERIENCE,
         });
-      }).catch(() => {
+      }, error => {
+        handleIsOpen(true);
+        handleHasClose(false);
+        handleFeedback(
+          <FailFeedback
+            info={error.message}
+            buttonClick={() => handleIsOpen(false)}
+          />
+        );
+
         ReactGA.event({
           category: GA_CATEGORY.SHARE_INTERVIEW,
           action: GA_ACTION.UPLOAD_FAIL,
         });
       });
-      localStorage.removeItem(LS_INTERVIEW_FORM_KEY);
-      return p;
     }
     this.handleState('submitted')(true);
     const topInvalidElement = this.getTopInvalidElement();

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -102,8 +102,7 @@ class TimeSalaryForm extends React.PureComponent {
     });
   }
 
-  onSubmit(opt) {
-    const { handleIsOpen, handleHasClose, handleFeedback } = opt;
+  onSubmit() {
     const valid = basicFormCheck(getBasicForm(this.state));
     const valid2 = salaryFormCheck(getSalaryForm(this.state));
     const valid3 = timeFormCheck(getTimeForm(this.state));
@@ -117,17 +116,6 @@ class TimeSalaryForm extends React.PureComponent {
 
       return p.then(response => {
         const count = response.queries_count;
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <SuccessFeedback
-            info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
-            buttonText="查看最新工時、薪資"
-            buttonClick={() => {
-              window.location.replace('/time-and-salary/latest');
-            }}
-          />
-        );
 
         ReactGA.event({
           category: GA_CATEGORY.SHARE_TIME_SALARY,
@@ -138,20 +126,32 @@ class TimeSalaryForm extends React.PureComponent {
           currency: 'TWD',
           content_category: PIXEL_CONTENT_CATEGORY.UPLOAD_TIME_AND_SALARY,
         });
-      }, error => {
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <FailFeedback
-            info={error.message}
-            buttonClick={() => handleIsOpen(false)}
-          />
-        );
 
+        return (
+          () => (
+            <SuccessFeedback
+              info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
+              buttonText="查看最新工時、薪資"
+              buttonClick={() => {
+                window.location.replace('/time-and-salary/latest');
+              }}
+            />
+          )
+        );
+      }, error => {
         ReactGA.event({
           category: GA_CATEGORY.SHARE_TIME_SALARY,
           action: GA_ACTION.UPLOAD_FAIL,
         });
+
+        return (
+          ({ buttonClickCallback }) => (
+            <FailFeedback
+              info={error.message}
+              buttonClick={buttonClickCallback}
+            />
+          )
+        );
       });
     }
     this.handleState('submitted')(true);
@@ -164,7 +164,7 @@ class TimeSalaryForm extends React.PureComponent {
         smooth: true,
       });
     }
-    return null;
+    return Promise.reject();
   }
 
   getTopInvalidElement = () => {

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -43,6 +43,9 @@ import {
   LS_TIME_SALARY_FORM_KEY,
 } from '../../../constants/localStorageKey';
 
+import SuccessFeedback from '../common/SuccessFeedback';
+import FailFeedback from '../common/FailFeedback';
+
 const defaultForm = {
   company: '',
   companyId: '',
@@ -99,17 +102,33 @@ class TimeSalaryForm extends React.PureComponent {
     });
   }
 
-  onSubmit() {
+  onSubmit(opt) {
+    const { handleIsOpen, handleHasClose, handleFeedback } = opt;
     const valid = basicFormCheck(getBasicForm(this.state));
     const valid2 = salaryFormCheck(getSalaryForm(this.state));
     const valid3 = timeFormCheck(getTimeForm(this.state));
 
     if (valid && (valid2 || valid3)) {
+      localStorage.removeItem(LS_TIME_SALARY_FORM_KEY);
+
       const p = postWorkings(
         portTimeSalaryFormToRequestFormat(getTimeAndSalaryForm(this.state))
       );
 
-      p.then(() => {
+      return p.then(response => {
+        const count = response.queries_count;
+        handleIsOpen(true);
+        handleHasClose(false);
+        handleFeedback(
+          <SuccessFeedback
+            info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
+            buttonText="查看最新工時、薪資"
+            buttonClick={() => {
+              window.location.replace('/time-and-salary/latest');
+            }}
+          />
+        );
+
         ReactGA.event({
           category: GA_CATEGORY.SHARE_TIME_SALARY,
           action: GA_ACTION.UPLOAD_SUCCESS,
@@ -119,15 +138,21 @@ class TimeSalaryForm extends React.PureComponent {
           currency: 'TWD',
           content_category: PIXEL_CONTENT_CATEGORY.UPLOAD_TIME_AND_SALARY,
         });
-      }).catch(() => {
+      }, error => {
+        handleIsOpen(true);
+        handleHasClose(false);
+        handleFeedback(
+          <FailFeedback
+            info={error.message}
+            buttonClick={() => handleIsOpen(false)}
+          />
+        );
+
         ReactGA.event({
           category: GA_CATEGORY.SHARE_TIME_SALARY,
           action: GA_ACTION.UPLOAD_FAIL,
         });
       });
-      localStorage.removeItem(LS_TIME_SALARY_FORM_KEY);
-
-      return p;
     }
     this.handleState('submitted')(true);
     const topInvalidElement = this.getTopInvalidElement();
@@ -277,7 +302,7 @@ class TimeSalaryForm extends React.PureComponent {
           />
         </IconHeadingBlock>
 
-        <SubmitArea onSubmit={this.onSubmit} type="workings" />
+        <SubmitArea onSubmit={this.onSubmit} />
       </div>
     );
   }

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -130,8 +130,7 @@ class WorkExperiencesForm extends React.Component {
     });
   }
 
-  onSubmit(opt) {
-    const { handleIsOpen, handleHasClose, handleFeedback } = opt;
+  onSubmit() {
     const valid = workExperiencesFormCheck(propsWorkExperiencesForm(this.state));
 
     if (valid) {
@@ -139,15 +138,6 @@ class WorkExperiencesForm extends React.Component {
       const p = postWorkExperience(workExperiencesToBody(this.state));
       return p.then(response => {
         const experienceId = response.experience._id;
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <SuccessFeedback
-            buttonClick={() => (
-              window.location.replace(`/experiences/${experienceId}`)
-            )}
-          />
-        );
 
         ReactGA.event({
           category: GA_CATEGORY.SHARE_WORK,
@@ -158,20 +148,30 @@ class WorkExperiencesForm extends React.Component {
           currency: 'TWD',
           content_category: PIXEL_CONTENT_CATEGORY.UPLOAD_WORK_EXPERIENCE,
         });
-      }, error => {
-        handleIsOpen(true);
-        handleHasClose(false);
-        handleFeedback(
-          <FailFeedback
-            info={error.message}
-            buttonClick={() => handleIsOpen(false)}
-          />
-        );
 
+        return (
+          () => (
+            <SuccessFeedback
+              buttonClick={() => (
+                window.location.replace(`/experiences/${experienceId}`)
+              )}
+            />
+          )
+        );
+      }, error => {
         ReactGA.event({
           category: GA_CATEGORY.SHARE_WORK,
           action: GA_ACTION.UPLOAD_FAIL,
         });
+
+        return (
+          ({ buttonClickCallback }) => (
+            <FailFeedback
+              info={error.message}
+              buttonClick={buttonClickCallback}
+            />
+          )
+        );
       });
     }
     this.handleState('submitted')(true);
@@ -184,7 +184,7 @@ class WorkExperiencesForm extends React.Component {
         smooth: true,
       });
     }
-    return null;
+    return Promise.reject();
   }
 
   getTopInvalidElement = () => {

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -180,7 +180,7 @@ class SubmitArea extends React.PureComponent {
 }
 
 SubmitArea.propTypes = {
-  onSubmit: PropTypes.func,
+  onSubmit: PropTypes.func, // () => Promise<({ buttonClickCallback?: () => void }) => Component>
   auth: ImmutablePropTypes.map,
   login: PropTypes.func.isRequired,
   FB: PropTypes.object,

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -7,37 +7,9 @@ import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
 import Modal from 'common/Modal';
 
-import SuccessFeedback from './SuccessFeedback';
-import FailFeedback from './FailFeedback';
 import FacebookFail from './FacebookFail';
 
 import authStatus from '../../../constants/authStatus';
-
-const getSuccessFeedback = id => (
-  <SuccessFeedback
-    buttonClick={() => (
-      window.location.replace(`/experiences/${id}`)
-    )}
-  />
-);
-
-const getWorkingsSuccessFeedback = (count, campaignName = null) => (
-  <SuccessFeedback
-    info={`您已經上傳 ${count} 次，還有 ${5 - (count || 0)} 次可以上傳。`}
-    buttonText="查看最新工時、薪資"
-    buttonClick={() => {
-      const url = campaignName ? `/time-and-salary/campaigns/${campaignName}/latest` : '/time-and-salary/latest';
-      window.location.replace(url);
-    }}
-  />
-);
-
-const getFailFeedback = (info, buttonClick) => (
-  <FailFeedback
-    info={info}
-    buttonClick={buttonClick}
-  />
-);
 
 const getFacebookFail = buttonClick => (
   <FacebookFail
@@ -66,36 +38,12 @@ class SubmitArea extends React.PureComponent {
 
 
   onSubmit() {
-    const p = this.props.onSubmit();
-    const { type, campaignName } = this.props;
-
-    if (p) {
-      return p
-        .then(r => {
-          if (type === 'workings') {
-            return r.queries_count;
-          }
-          return r.experience._id;
-        })
-        .then(id => {
-          this.handleIsOpen(true);
-          this.handleHasClose(false);
-          if (type === 'workings') {
-            return this.handleFeedback(getWorkingsSuccessFeedback(id, campaignName));
-          }
-          return this.handleFeedback(getSuccessFeedback(id));
-        })
-        .catch(error => {
-          this.handleIsOpen(true);
-          this.handleHasClose(false);
-          return this.handleFeedback(getFailFeedback(
-            error.message,
-            () => this.handleIsOpen(false),
-          ));
-        });
-    }
-
-    return Promise.resolve();
+    const opt = {
+      handleIsOpen: this.handleIsOpen.bind(this),
+      handleHasClose: this.handleHasClose.bind(this),
+      handleFeedback: this.handleFeedback.bind(this),
+    };
+    return this.props.onSubmit(opt);
   }
 
   onFacebookFail() {
@@ -229,8 +177,6 @@ class SubmitArea extends React.PureComponent {
 }
 
 SubmitArea.propTypes = {
-  type: PropTypes.string,
-  campaignName: PropTypes.string,
   onSubmit: PropTypes.func,
   auth: ImmutablePropTypes.map,
   login: PropTypes.func.isRequired,

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -38,12 +38,15 @@ class SubmitArea extends React.PureComponent {
 
 
   onSubmit() {
-    const opt = {
-      handleIsOpen: this.handleIsOpen.bind(this),
-      handleHasClose: this.handleHasClose.bind(this),
-      handleFeedback: this.handleFeedback.bind(this),
-    };
-    return this.props.onSubmit(opt);
+    return this.props.onSubmit()
+      .then(Feedback => {
+        this.handleIsOpen(true);
+        this.handleHasClose(false);
+        return this.handleFeedback(Feedback({
+          buttonClick: () => this.handleIsOpen(false),
+        }));
+      })
+      .catch(e => console.log(e));
   }
 
   onFacebookFail() {


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

這個 PR 想要解決 **送出表單流程** 由多點處理 程式邏輯 的問題

現象：

這是 `SubmitArea` 的 `onSubmit`，

https://github.com/goodjoblife/GoodJobShare/blob/768364a50714c2bdca0eb18b08a21f947e43074d/src/components/ShareExperience/common/SubmitArea.js#L69-L87

在 `SubmitArea` 裡面會負責處理各種 form 的 `onSubmit` (`this.props.onSubmit`) 狀態 (`p`)，並且根據狀態做 if/else 顯示 modal

會有幾個問題：

1. `p` 到底是什麼？(in this case, `null`, `Promise`)
2. `type` 有哪些？
3. 一堆跟 `SubmitArea` 不相關參數 (`type`, `campaign`, ...) 為了要產生 modal 而傳入

解法：

讓 `SubmitArea` 把 `handleFeedback` 傳入 form 的 `obSubmit` 參數，
由 form 的 `obSubmit` 去處理正確，錯誤的邏輯


## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

```
送表單流程：

檢查欄位 --N→ 提示錯誤的 form part(在 Form 的 onSubmit)
  |
  Y
  ↓
已登入 --N→ FB登入(在 SubmitArea 的 login) --N→ 跳出失敗 (在 SubmitArea 的 onFacebookFail)
  |           |
  Y           |
  |<----------
  ↓
送出表單(*1) --N→ 處理失敗(在 SubmitArea 的 obSubmit)
  |
跳出處理成功(在 SubmitArea 的 obSubmit)
```

*1:  由 `SubmitArea` 的 `obSubmit` 處理 form 的 `obSubmit` 的回傳值
