### PR TITLE
Bugfix: Campaign handle 404

### DIFF
--- a/src/components/CampaignTimeAndSalary/CampaignTimeAndSalaryBoard/index.js
+++ b/src/components/CampaignTimeAndSalary/CampaignTimeAndSalaryBoard/index.js
@@ -9,13 +9,14 @@ import { Link } from 'react-router-dom';
 
 import { Star } from 'common/icons';
 import Select from 'common/form/Select';
+import CommonNotFound from 'common/NotFound';
 import InfoTimeModal from '../../TimeAndSalary/common/InfoTimeModal';
 import InfoSalaryModal from '../../TimeAndSalary/common/InfoSalaryModal';
 import AboutThisJobModal from '../../TimeAndSalary/common/AboutThisJobModal';
 import timeAndSalaryBoardStyles from '../../TimeAndSalary/TimeAndSalaryBoard/TimeAndSalaryBoard.module.css';
 import timeAndSalaryBannerStyles from '../../TimeAndSalary/Banner.module.css';
 import timeAndSalaryCommonStyles from '../../TimeAndSalary/views/view.module.css';
-import fetchingStatus from '../../../constants/status';
+import fetchingStatus, { isFetched } from '../../../constants/status';
 import { MAX_ROWS_IF_HIDDEN } from '../../../constants/hideContent';
 import BasicPermissionBlock from '../../../containers/PermissionBlock/BasicPermissionBlockContainer';
 import styles from '../CampaignTimeAndSalary.module.css';
@@ -213,8 +214,13 @@ export default class CampaignTimeAndSalaryBoard extends Component {
   render() {
     const { path, params: { campaign_name } } = this.props.match;
     const { title } = pathnameMapping[path];
-    const { campaignEntriesStatus, status, data, switchPath } = this.props;
+    const { campaignEntries, campaignEntriesStatus, status, data, switchPath } = this.props;
     const raw = data.toJS();
+
+    // 如果 campaign_name 不在清單中，代表 Not Found
+    if (isFetched(campaignEntriesStatus) && !campaignEntries.has(campaign_name)) {
+      return <CommonNotFound />;
+    }
 
     const isLoading = campaignEntriesStatus === fetchingStatus.FETCHIING || status === fetchingStatus.FETCHING;
 

--- a/src/components/CampaignTimeAndSalary/NotFound.js
+++ b/src/components/CampaignTimeAndSalary/NotFound.js
@@ -1,17 +1,45 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Redirect } from 'react-router-dom';
+import CommonNotFound from 'common/NotFound';
+import { queryCampaignInfoList } from '../../actions/campaignInfo';
+import { isFetched } from '../../constants/status';
 
-const NotFound = ({ staticContext, match: { params: { campaign_name } } }) => {
-  if (staticContext) {
-    staticContext.status = 301; // eslint-disable-line no-param-reassign
+class NotFound extends Component {
+  static fetchData({ store: { dispatch } }) {
+    return dispatch(queryCampaignInfoList());
   }
-  return (<Redirect to={'/time-and-salary/campaigns/:campaign_name/latest'.replace(':campaign_name', campaign_name)} />);
-};
+
+  componentDidMount() {
+    this.props.queryCampaignInfoList();
+  }
+
+  render() {
+    const { staticContext, match: { params: { campaign_name: campaignName } } } = this.props;
+    const { campaignEntries, campaignEntriesStatus } = this.props;
+
+    if (isFetched(campaignEntriesStatus) && !campaignEntries.has(campaignName)) {
+      return <CommonNotFound />;
+    }
+
+    if (staticContext) {
+      staticContext.status = 301; // eslint-disable-line no-param-reassign
+    }
+    return (<Redirect to={'/time-and-salary/campaigns/:campaign_name/latest'.replace(':campaign_name', campaignName)} />);
+  }
+}
 
 NotFound.propTypes = {
   staticContext: PropTypes.object,
-  match: PropTypes.object.isRequired,
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      campaign_name: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  campaignEntries: ImmutablePropTypes.map.isRequired,
+  campaignEntriesStatus: PropTypes.string.isRequired,
+  queryCampaignInfoList: PropTypes.func.isRequired,
 };
 
 export default NotFound;

--- a/src/components/CampaignTimeAndSalary/index.js
+++ b/src/components/CampaignTimeAndSalary/index.js
@@ -87,6 +87,10 @@ export default class TimeAndSalary extends Component {
     const path = this.props.location.pathname;
     const url = formatCanonicalPath(path);
     const campaignName = this.props.match.params.campaign_name;
+    if (!this.props.campaignEntries.has(campaignName)) {
+      // We will render a 404 Not Found
+      return null;
+    }
     const campaignInfo = this.props.campaignEntries.get(campaignName).toJS();
     const { title: campaignTitle, ogImgUrl } = campaignInfo;
 

--- a/src/components/CampaignTimeAndSalary/index.js
+++ b/src/components/CampaignTimeAndSalary/index.js
@@ -88,7 +88,7 @@ export default class TimeAndSalary extends Component {
     const url = formatCanonicalPath(path);
     const campaignName = this.props.match.params.campaign_name;
     if (!this.props.campaignEntries.has(campaignName)) {
-      // We will render a 404 Not Found
+      // We will render a 301 / 404
       return null;
     }
     const campaignInfo = this.props.campaignEntries.get(campaignName).toJS();

--- a/src/containers/CampaignTimeAndSalary/NotFound.js
+++ b/src/containers/CampaignTimeAndSalary/NotFound.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import NotFound from '../../components/CampaignTimeAndSalary/NotFound';
+import { queryCampaignInfoListIfNeeded } from '../../actions/campaignInfo';
+
+const mapStateToProps = state => ({
+  campaignEntries: state.campaignInfo.get('entries'),
+  campaignEntriesStatus: state.campaignInfo.get('entriesStatus'),
+  campaignEntriesError: state.campaignInfo.get('entriesError'),
+});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({
+    queryCampaignInfoList: queryCampaignInfoListIfNeeded,
+  }, dispatch);
+
+export default connect(mapStateToProps, mapDispatchToProps)(NotFound);

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,7 @@ import TimeAndSalaryJobTitle from './containers/TimeAndSalary/TimeAndSalaryJobTi
 import TimeAndSalaryNotFound from './components/TimeAndSalary/NotFound';
 import CampaignTimeAndSalary from './containers/CampaignTimeAndSalary';
 import CampaignTimeAndSalaryBoard from './containers/CampaignTimeAndSalary/CampaignTimeAndSalaryBoard';
-import CampaignTimeAndSalaryNotFound from './components/CampaignTimeAndSalary/NotFound';
+import CampaignTimeAndSalaryNotFound from './containers/CampaignTimeAndSalary/NotFound';
 import ExperienceSearchPage from './containers/ExperienceSearchPage';
 import ExperienceDetail from './containers/ExperienceDetail';
 import NotFound from './components/common/NotFound';


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

這個 PR 處理當 campaignName 不在 campaign 活動中時，應該要

1. 顯示 404
2. 小心處理 Helmet，因為 campaignInfo 可能是 undefined (`src/components/CampaignTimeAndSalary/index.js`) (PR 前：這個 bug 導致 https://www-stage.goodjob.life/time-and-salary/campaigns/TEST 出現 500)