### PR TITLE
Handle 3xx/4xx routes

### DIFF
--- a/src/components/CampaignTimeAndSalary/NotFound.js
+++ b/src/components/CampaignTimeAndSalary/NotFound.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
-import { Redirect } from 'react-router-dom';
 import CommonNotFound from 'common/NotFound';
+import Redirect from 'common/routing/Redirect';
 import { queryCampaignInfoList } from '../../actions/campaignInfo';
 import { isFetched } from '../../constants/status';
 
@@ -16,21 +16,17 @@ class NotFound extends Component {
   }
 
   render() {
-    const { staticContext, campaignName, campaignEntries, campaignEntriesStatus } = this.props;
+    const { campaignName, campaignEntries, campaignEntriesStatus } = this.props;
 
     if (isFetched(campaignEntriesStatus) && !campaignEntries.has(campaignName)) {
       return <CommonNotFound />;
     }
 
-    if (staticContext) {
-      staticContext.status = 301; // eslint-disable-line no-param-reassign
-    }
     return (<Redirect to={'/time-and-salary/campaigns/:campaign_name/latest'.replace(':campaign_name', campaignName)} />);
   }
 }
 
 NotFound.propTypes = {
-  staticContext: PropTypes.object,
   campaignName: PropTypes.string.isRequired,
   campaignEntries: ImmutablePropTypes.map.isRequired,
   campaignEntriesStatus: PropTypes.string.isRequired,

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -265,7 +265,7 @@ class ExperienceDetail extends Component {
     if (experienceError) {
       switch (experienceError.statusCode) {
         case 403:
-          return (<NotFound heading="本篇文章已經被原作者隱藏，目前無法查看" />);
+          return (<NotFound heading="本篇文章已經被原作者隱藏，目前無法查看" status={403} />);
         case 404:
           return (<NotFound />);
         default:

--- a/src/components/TimeAndSalary/NotFound.js
+++ b/src/components/TimeAndSalary/NotFound.js
@@ -1,16 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { Redirect } from 'react-router-dom';
+import Redirect from 'common/routing/Redirect';
 
-const NotFound = ({ staticContext }) => {
-  if (staticContext) {
-    staticContext.status = 301; // eslint-disable-line no-param-reassign
-  }
-  return (<Redirect to="/time-and-salary/latest" />);
-};
-
-NotFound.propTypes = {
-  staticContext: PropTypes.object,
-};
+const NotFound = () => (
+  <Redirect to="/time-and-salary/latest" />
+);
 
 export default NotFound;

--- a/src/components/common/NotFound/index.js
+++ b/src/components/common/NotFound/index.js
@@ -1,33 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Route, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { Wrapper, Heading } from 'common/base';
+import NotFoundStatus from 'common/routing/NotFound';
 import styles from './NotFound.module.css';
 
-const NotFoundBase = ({ heading }) => (
-  <Wrapper size="l" className={styles.wrapper}>
-    <div className={styles.inner}>
-      <Heading size="l" className={styles.heading}>
-        {heading || '不好意思，頁面不存在'}
-      </Heading>
-      <Link to="/" className={styles.link}>回首頁</Link>
-    </div>
-  </Wrapper>
+const NotFound = ({ status, heading }) => (
+  <NotFoundStatus status={status}>
+    <Wrapper size="l" className={styles.wrapper}>
+      <div className={styles.inner}>
+        <Heading size="l" className={styles.heading}>
+          {heading || '不好意思，頁面不存在'}
+        </Heading>
+        <Link to="/" className={styles.link}>回首頁</Link>
+      </div>
+    </Wrapper>
+  </NotFoundStatus>
 );
 
-NotFoundBase.propTypes = {
+NotFound.propTypes = {
+  status: PropTypes.number.isRequired,
   heading: PropTypes.string,
 };
 
-const NotFound = props => (
-  <Route
-    render={({ staticContext }) => {
-      if (staticContext) {
-        staticContext.status = 404; // eslint-disable-line no-param-reassign
-      }
-      return (<NotFoundBase {...props} />);
-    }}
-  />
-);
+NotFound.defaultProps = {
+  status: 404,
+  heading: null,
+};
 
 export default NotFound;

--- a/src/components/common/routing/NotFound.js
+++ b/src/components/common/routing/NotFound.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Status from './Status';
+
+const NotFound = ({ status, children }) => (
+  <Status status={status}>
+    { children }
+  </Status>
+);
+
+NotFound.propTypes = {
+  status: PropTypes.number.isRequired,
+  children: PropTypes.node,
+};
+
+NotFound.defaultProps = {
+  status: 404,
+  children: null,
+};
+
+export default NotFound;

--- a/src/components/common/routing/Redirect.js
+++ b/src/components/common/routing/Redirect.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Redirect as RouterRedirect } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import Status from './Status';
+
+// Add http status code 301 when SSR
+const Redirect = ({ status, ...props }) => (
+  <Status status={status}>
+    <RouterRedirect {...props} />
+  </Status>
+);
+
+Redirect.propTypes = {
+  status: PropTypes.number,
+};
+
+Redirect.defaultProps = {
+  status: 301,
+};
+
+export default Redirect;

--- a/src/components/common/routing/Status.js
+++ b/src/components/common/routing/Status.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import PropTypes from 'prop-types';
+
+// Add http status code when SSR
+const Status = ({ status, children }) => (
+  <Route
+    render={({ staticContext }) => {
+      if (staticContext) {
+        staticContext.status = status; // eslint-disable-line no-param-reassign
+      }
+      return children;
+    }}
+  />
+);
+
+Status.propTypes = {
+  status: PropTypes.number.isRequired,
+  children: PropTypes.node,
+};
+
+Status.defaultProps = {
+  children: null,
+};
+
+export default Status;

--- a/src/routes.js
+++ b/src/routes.js
@@ -80,6 +80,9 @@ const routes = [
         exact: true,
         component: WorkExperiencesForm,
       },
+      {
+        component: NotFound,
+      },
     ],
   },
   {

--- a/src/server.js
+++ b/src/server.js
@@ -77,6 +77,15 @@ server.get('/*', wrap(
       <Html assets={assets} component={finalComponent} store={store} />
     );
 
+    if (context.url) {
+      if (context.status === 301) {
+        res.redirect(301, context.url);
+        return;
+      }
+      res.redirect(context.url);
+      return;
+    }
+
     if (context.status) {
       res.status(context.status);
     }


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

確定所有的 Redirect / NotFound 會在 Server 端正確的傳出 http status code, http header

## 我應該如何手動測試？ <!-- 必填 -->

404 類 應該要看到 status code 404：

<img width="391" alt="default" src="https://user-images.githubusercontent.com/1908007/40193476-f797bdc6-5a39-11e8-8d8a-88e648cf8582.png">

```sh
curl -i http://localhost:3001/share/123
```

```sh
curl -i http://localhost:3001/time-and-salary/campaigns/123
```

```sh
curl -i http://localhost:3001/labor-rights/123
```

```sh
curl -i http://localhost:3001/experiences/123
```

301 類 應該要看到 status code 301, header 有 `Location`：

<img width="377" alt="default" src="https://user-images.githubusercontent.com/1908007/40193535-1de0f646-5a3a-11e8-9559-1e13203aad90.png">

```sh
curl -i http://localhost:3001/time-and-salary
```

```sh
curl -i http://localhost:3001/time-and-salary/campaigns/software-engineer
```
