### PR TITLE
薪資提示字

### DIFF
--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -45,7 +45,7 @@ import {
   portTimeSalaryFormToRequestFormat,
 } from '../utils';
 
-import { salaryHint } from '../../../utils/formUtils';
+import salaryHint from '../../../utils/formUtils';
 
 import { HELMET_DATA, SITE_NAME } from '../../../constants/helmetData';
 import { formatTitle, formatCanonicalPath } from '../../../utils/helmetHelper';

--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -45,6 +45,8 @@ import {
   portTimeSalaryFormToRequestFormat,
 } from '../utils';
 
+import { salaryHint } from '../../../utils/formUtils';
+
 import { HELMET_DATA, SITE_NAME } from '../../../constants/helmetData';
 import { formatTitle, formatCanonicalPath } from '../../../utils/helmetHelper';
 
@@ -106,6 +108,9 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
     this.state = {
       ...defaultForm,
       submitted: false,
+      // for handling salary hint
+      salaryHint: null,
+      showSalaryWarning: false,
     };
     this.basicElValidationStatus = {};
     this.extElValidationStatus = {};
@@ -268,12 +273,33 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
     this.extElValidationStatus[elementId] = status;
   }
 
+  handleSalaryHint = (key, value) => {
+    let salaryAmount;
+    let salaryType;
+    if (key === 'salaryType') {
+      salaryAmount = this.state.salaryAmount;
+      salaryType = value;
+    } else if (key === 'salaryAmount') {
+      salaryAmount = value;
+      salaryType = this.state.salaryType;
+    }
+    const { showWarning, hint } = salaryHint(salaryType, salaryAmount);
+    this.setState({
+      showSalaryWarning: showWarning,
+      salaryHint: hint,
+    });
+  }
+
   handleState(key) {
     return value => {
       const updateState = {
         [key]: value,
       };
       this.setState(updateState);
+      // handle salary hint
+      if (['salaryType', 'salaryAmount'].indexOf(key) >= 0) {
+        this.handleSalaryHint(key, value);
+      }
     };
   }
 
@@ -397,6 +423,8 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
             experienceInYear={experienceInYear}
             submitted={submitted}
             changeValidationStatus={this.changeExtElValidationStatus}
+            showWarning={this.state.showSalaryWarning}
+            hint={this.state.salaryHint}
           />
 
           <TimeInfo

--- a/src/components/ShareExperience/TimeSalaryForm/SalaryInfo.js
+++ b/src/components/ShareExperience/TimeSalaryForm/SalaryInfo.js
@@ -29,6 +29,13 @@ import {
 import styles from './TimeSalaryForm.module.css';
 
 class SalaryInfo extends React.PureComponent {
+  renderHint = () => {
+    if (this.props.showWarning) {
+      return (<div className={cn([styles.warning__wording, styles.salaryHint])}>{this.props.hint}，確定嗎？</div>);
+    }
+    return <div className={cn(styles.salaryHint)}>{this.props.hint}</div>;
+  }
+
   render() {
     const {
       handleState,
@@ -108,6 +115,7 @@ class SalaryInfo extends React.PureComponent {
                   <span className={styles.unit}> 元</span>
                 </div>
               </div>
+              {this.renderHint()}
               {isSalarySetWarning && (
                 <div>
                   <p
@@ -175,6 +183,8 @@ SalaryInfo.propTypes = {
   ]),
   submitted: PropTypes.bool,
   changeValidationStatus: PropTypes.func,
+  showWarning: PropTypes.bool,
+  hint: PropTypes.string,
 };
 
 export default SalaryInfo;

--- a/src/components/ShareExperience/TimeSalaryForm/SalaryInfo.js
+++ b/src/components/ShareExperience/TimeSalaryForm/SalaryInfo.js
@@ -30,7 +30,9 @@ import styles from './TimeSalaryForm.module.css';
 
 class SalaryInfo extends React.PureComponent {
   renderHint = () => {
-    if (this.props.showWarning) {
+    if (this.props.hint === null) {
+      return null;
+    } else if (this.props.showWarning) {
       return (<div className={cn([styles.warning__wording, styles.salaryHint])}>{this.props.hint}，確定嗎？</div>);
     }
     return <div className={cn(styles.salaryHint)}>{this.props.hint}</div>;
@@ -185,6 +187,11 @@ SalaryInfo.propTypes = {
   changeValidationStatus: PropTypes.func,
   showWarning: PropTypes.bool,
   hint: PropTypes.string,
+};
+
+SalaryInfo.defaultProps = {
+  showWarning: false,
+  hint: null,
 };
 
 export default SalaryInfo;

--- a/src/components/ShareExperience/TimeSalaryForm/SalaryInfo.js
+++ b/src/components/ShareExperience/TimeSalaryForm/SalaryInfo.js
@@ -104,20 +104,22 @@ class SalaryInfo extends React.PureComponent {
                   }}
                 />
                 <div style={{ width: '15px' }} />
-                <div className={styles.inputUnit}>
-                  <ScrollElement name={SALARY_AMOUNT} />
-                  <TextInput
-                    value={salaryAmount}
-                    placeholder="22000"
-                    onChange={e => {
-                      changeSalaryAmountStatus(e.target.value);
-                      return handleState('salaryAmount')(e.target.value);
-                    }}
-                  />
-                  <span className={styles.unit}> 元</span>
+                <div>
+                  <div className={styles.inputUnit}>
+                    <ScrollElement name={SALARY_AMOUNT} />
+                    <TextInput
+                      value={salaryAmount}
+                      placeholder="22000"
+                      onChange={e => {
+                        changeSalaryAmountStatus(e.target.value);
+                        return handleState('salaryAmount')(e.target.value);
+                      }}
+                    />
+                    <span className={styles.unit}> 元</span>
+                  </div>
+                  {this.renderHint()}
                 </div>
               </div>
-              {this.renderHint()}
               {isSalarySetWarning && (
                 <div>
                   <p

--- a/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
+++ b/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
@@ -202,3 +202,9 @@
 		clear: both;
 	}
 }
+
+.salaryHint {
+  font-size: 0.9em;
+  margin-top: 10px;
+  text-align: center;
+}

--- a/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
+++ b/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
@@ -176,7 +176,6 @@
 		right: 0;
 		top: 0;
 		display: block;
-		height: 100%;
 		width: 50px;
 		border-left: 1px solid main-gray;
 		line-height: 42px;
@@ -206,5 +205,5 @@
 .salaryHint {
   font-size: 0.9em;
   margin-top: 10px;
-  text-align: center;
+  text-align: right;
 }

--- a/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
+++ b/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
@@ -206,4 +206,5 @@
   font-size: 0.9em;
   margin-top: 10px;
   text-align: right;
+  margin-left: -60px;
 }

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -31,6 +31,8 @@ import {
   portTimeSalaryFormToRequestFormat,
 } from '../utils';
 
+import { salaryHint } from '../../../utils/formUtils';
+
 import { HELMET_DATA } from '../../../constants/helmetData';
 import {
   INVALID,
@@ -78,6 +80,9 @@ class TimeSalaryForm extends React.PureComponent {
     this.state = {
       ...defaultForm,
       submitted: false,
+      // for handling salary hint
+      salaryHint: null,
+      showSalaryWarning: false,
     };
     this.basicElValidationStatus = {};
     this.extElValidationStatus = {};
@@ -199,6 +204,23 @@ class TimeSalaryForm extends React.PureComponent {
     this.extElValidationStatus[elementId] = status;
   }
 
+  handleSalaryHint = (key, value) => {
+    let salaryAmount;
+    let salaryType;
+    if (key === 'salaryType') {
+      salaryAmount = this.state.salaryAmount;
+      salaryType = value;
+    } else if (key === 'salaryAmount') {
+      salaryAmount = value;
+      salaryType = this.state.salaryType;
+    }
+    const { showWarning, hint } = salaryHint(salaryType, salaryAmount);
+    this.setState({
+      showSalaryWarning: showWarning,
+      salaryHint: hint,
+    });
+  }
+
   handleState(key) {
     return value => {
       const updateState = {
@@ -210,6 +232,11 @@ class TimeSalaryForm extends React.PureComponent {
         ...updateState,
       };
       localStorage.setItem(LS_TIME_SALARY_FORM_KEY, JSON.stringify(state));
+
+      // handle salary hint
+      if (['salaryType', 'salaryAmount'].indexOf(key) >= 0) {
+        this.handleSalaryHint(key, value);
+      }
     };
   }
 
@@ -282,6 +309,8 @@ class TimeSalaryForm extends React.PureComponent {
             experienceInYear={experienceInYear}
             submitted={submitted}
             changeValidationStatus={this.changeExtElValidationStatus}
+            showWarning={this.state.showSalaryWarning}
+            hint={this.state.salaryHint}
           />
 
           <TimeInfo

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -31,7 +31,7 @@ import {
   portTimeSalaryFormToRequestFormat,
 } from '../utils';
 
-import { salaryHint } from '../../../utils/formUtils';
+import salaryHint from '../../../utils/formUtils';
 
 import { HELMET_DATA } from '../../../constants/helmetData';
 import {

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -1,11 +1,10 @@
 
 /**
  * convert number to [xxxx億][xxxx萬][xxxx]元 format
- * @param {*} num the number to be converted
+ * @param {Integer} num the number to be converted
  */
-export const numToChineseReadableString = num => {
-  let tmpNum = parseInt(num, 10);
-  if (isNaN(tmpNum) || num <= 0) {
+const numToChineseReadableString = num => {
+  if (num <= 0) {
     return null;
   }
   const base = [1, 10000, 100000000];
@@ -13,7 +12,8 @@ export const numToChineseReadableString = num => {
 
   let str = '';
   let c;
-  for (let i = base.length; i >= 0; i -= 1) {
+  let tmpNum = num;
+  for (let i = base.length - 1; i >= 0; i -= 1) {
     if (tmpNum >= base[i]) {
       c = Math.floor(tmpNum / base[i]);
       tmpNum -= c * base[i];
@@ -25,14 +25,10 @@ export const numToChineseReadableString = num => {
 
 /**
  * Decide whether to show salary warning
- * @param {*} salaryType the type of salary (hour, day, month, year)
- * @param {*} salaryAmount the amount of salary
+ * @param {String} salaryType the type of salary (hour, day, month, year)
+ * @param {Integer} salaryAmount the amount of salary
  */
-export const shouldShowSalaryWarning = (salaryType, salaryAmount) => {
-  const amount = parseInt(salaryAmount, 10);
-  if (isNaN(amount)) {
-    return false;
-  }
+const shouldShowSalaryWarning = (salaryType, salaryAmount) => {
   const ranges = {
     hour: [100, 500],
     day: [800, 4000],
@@ -42,7 +38,7 @@ export const shouldShowSalaryWarning = (salaryType, salaryAmount) => {
   if (!(salaryType in ranges)) {
     return false;
   }
-  if (amount < ranges[salaryType][0] || amount > ranges[salaryType][1]) {
+  if (salaryAmount < ranges[salaryType][0] || salaryAmount > ranges[salaryType][1]) {
     return true;
   }
   return false;
@@ -50,12 +46,16 @@ export const shouldShowSalaryWarning = (salaryType, salaryAmount) => {
 
 /**
  * Combine converting and checking warning task for salary field
- * @param {*} salaryType the type of salary (hour, day, month, year)
- * @param {*} salaryAmount the amount of salary
+ * @param {String} salaryType the type of salary (hour, day, month, year)
+ * @param {String} salaryAmount the amount of salary
  */
-export const salaryHint = (salaryType, salaryAmount) => {
-  const readableStr = numToChineseReadableString(salaryAmount);
-  const showWarning = shouldShowSalaryWarning(salaryType, salaryAmount);
+const salaryHint = (salaryType, salaryAmount) => {
+  const amount = parseInt(salaryAmount, 10);
+  if (isNaN(amount)) {
+    return { showWarning: false, hint: null };
+  }
+  const readableStr = numToChineseReadableString(amount);
+  const showWarning = shouldShowSalaryWarning(salaryType, amount);
   const salaryTypeWord = {
     hour: '時薪',
     day: '日薪',
@@ -63,9 +63,11 @@ export const salaryHint = (salaryType, salaryAmount) => {
     year: '年薪',
   };
 
-  let hint = null;
   if (readableStr !== null && salaryType in salaryTypeWord) {
-    hint = `${salaryTypeWord[salaryType]} ${readableStr}`;
+    const hint = `${salaryTypeWord[salaryType]} ${readableStr}`;
+    return { showWarning, hint };
   }
-  return { showWarning, hint };
+  return { showWarning, hint: null };
 };
+
+export default salaryHint;

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -1,0 +1,71 @@
+
+/**
+ * convert number to [xxxx億][xxxx萬][xxxx]元 format
+ * @param {*} num the number to be converted
+ */
+export const numToChineseReadableString = num => {
+  let tmpNum = parseInt(num, 10);
+  if (isNaN(tmpNum) || num <= 0) {
+    return null;
+  }
+  const base = [1, 10000, 100000000];
+  const baseWord = ['', '萬', '億'];
+
+  let str = '';
+  let c;
+  for (let i = base.length; i >= 0; i -= 1) {
+    if (tmpNum >= base[i]) {
+      c = Math.floor(tmpNum / base[i]);
+      tmpNum -= c * base[i];
+      str += `${c}${baseWord[i]}`;
+    }
+  }
+  return `${str}元`;
+};
+
+/**
+ * Decide whether to show salary warning
+ * @param {*} salaryType the type of salary (hour, day, month, year)
+ * @param {*} salaryAmount the amount of salary
+ */
+export const shouldShowSalaryWarning = (salaryType, salaryAmount) => {
+  const amount = parseInt(salaryAmount, 10);
+  if (isNaN(amount)) {
+    return false;
+  }
+  const ranges = {
+    hour: [100, 500],
+    day: [800, 4000],
+    month: [20000, 100000], // 2萬, 10萬
+    year: [200000, 1000000], // 20萬, 100萬
+  };
+  if (!(salaryType in ranges)) {
+    return false;
+  }
+  if (amount < ranges[salaryType][0] || amount > ranges[salaryType][1]) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Combine converting and checking warning task for salary field
+ * @param {*} salaryType the type of salary (hour, day, month, year)
+ * @param {*} salaryAmount the amount of salary
+ */
+export const salaryHint = (salaryType, salaryAmount) => {
+  const readableStr = numToChineseReadableString(salaryAmount);
+  const showWarning = shouldShowSalaryWarning(salaryType, salaryAmount);
+  const salaryTypeWord = {
+    hour: '時薪',
+    day: '日薪',
+    month: '月薪',
+    year: '年薪',
+  };
+
+  let hint = null;
+  if (readableStr !== null && salaryType in salaryTypeWord) {
+    hint = `${salaryTypeWord[salaryType]} ${readableStr}`;
+  }
+  return { showWarning, hint };
+};


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

實作很久以前說要做的薪資提示字，讓使用者注意到自己可能打錯數字。

ref: https://github.com/goodjoblife/WorkTimeSurvey/issues/488 https://github.com/goodjoblife/WorkTimeSurvey/pull/495

位置我有調整，現在是放在下方。不過 style 可能還不是那麼完美，請 @wutingy  給建議

## Screenshots  <!-- 選填，沒有就刪掉 -->
### 大螢幕：
![2018-05-27 12 10 11](https://user-images.githubusercontent.com/3805975/40578190-7a419288-6142-11e8-9ea4-a33363cbd824.png)
![2018-05-27 12 10 04](https://user-images.githubusercontent.com/3805975/40578189-7a0fc884-6142-11e8-8c0f-073870d0ac80.png)
---

### 中螢幕：
![2018-05-27 12 10 26](https://user-images.githubusercontent.com/3805975/40578191-7a764fbe-6142-11e8-861d-251295d2131a.png)
![2018-05-27 12 10 33](https://user-images.githubusercontent.com/3805975/40578192-7af0f6b0-6142-11e8-848f-0fe9520ecfe5.png)
---

### 小螢幕：
![2018-05-27 12 10 49](https://user-images.githubusercontent.com/3805975/40578193-7b23f984-6142-11e8-9692-d2622da8373d.png)
![2018-05-27 12 10 56](https://user-images.githubusercontent.com/3805975/40578194-7c4138a4-6142-11e8-8441-fcfb41346247.png)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進 http://localhost:3000/share/time-and-salary 頁面
- [ ] 薪資種類先不選，單純打數字。應該不會出現任何字。
- [ ] 薪資種類選好，但是薪資額不寫。應該不會出現任何字。
- [ ] 薪資種類、薪資額都寫，且在範圍內，則只出現黑色字。
- [ ] 薪資種類、薪資額都寫，但在範圍外，則出現紅色提醒字。

範圍：
- 時薪：100～500
- 日薪：800～4,000
- 月薪：20,000～100,000 （10萬）
- 年薪：200,000～1,000,000 （100萬）