### PR TITLE
Add type == day in salaryType formatter

### DIFF
--- a/src/components/common/formatter.js
+++ b/src/components/common/formatter.js
@@ -7,6 +7,8 @@ export const formatSalaryType = type => {
       return '年';
     case 'month':
       return '月';
+    case 'day':
+      return '日';
     case 'hour':
       return '小時';
     default:


### PR DESCRIPTION
In #399, 這段 code 沒有處理 type === 'day' 的情況

https://github.com/goodjoblife/GoodJobShare/pull/399/files#diff-55e3f0d5fea1a85f7f2f689f26accf1bL139

在 refactor 的過程，繼續保留原本的錯誤行為

故修正這裡

## 我應該如何手動測試？ <!-- 必填 -->

- [x] 檢查有 salaryType === 'day' 的是否正確顯示 `日`