### PR TITLE
hotfix: fix modal max-height at any device width

### DIFF
--- a/src/components/common/Modal.module.css
+++ b/src/components/common/Modal.module.css
@@ -30,15 +30,15 @@ $orange: #ec7910;
 }
 
 .content {
+  max-height: 90vh;
+  overflow-y: auto;
+  overflow-x: hidden;
   position: relative;
   background: #fff;
 	padding: 40px;
 	box-shadow: 0px 0px 10px rgba(0,0,0,.2);
 
 	@media (max-width: 850px) {
-		max-height: 90vh;
-		overflow-y: auto;
-		overflow-x: hidden;
 		padding: 32px 16px;
 	}
 }


### PR DESCRIPTION
Close #440 

## 這個 PR 是？ <!-- 必填 -->

原本 Modal 是只有在 850 px 以下，會設定 
```
  max-height: 90vh;
  overflow-y: auto;
  overflow-x: hidden;
```
讓 modal 的內容在超過高度的時候，可以捲動。Ｘ按鈕也會在上方可以關閉。

現在改成不論任何螢幕寬度，都是這樣設定。

## Screenshots  <!-- 選填，沒有就刪掉 -->

![e2r1uthdj4](https://user-images.githubusercontent.com/3805975/40985682-36d6bbe0-6917-11e8-8321-c71f56c79168.gif)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進到 http://localhost:3000/time-and-salary/latest （後端是接 https://api-dev.goodjob.life ），打開一個放大鏡，把內容改到超過螢幕高度。 看看 Modal 內的內容，是不是就變成可以捲動，而且Ｘ按鈕一直可以點得到。
