### PR TITLE
修正表訂/實際工時 UI bug

### DIFF
--- a/src/components/TimeAndSalary/common/WorkingHourTable.js
+++ b/src/components/TimeAndSalary/common/WorkingHourTable.js
@@ -35,7 +35,7 @@ class WorkingHourTable extends Component {
   static getEmploymentType = type => (type ? employmentType[type] : '')
 
   static getWorkingHour = (val, row) => (
-    <div>{`${val} / ${row.day_real_work_time}`}</div>
+    <div>{`${typeof val === 'undefined' ? '-' : val} / ${typeof row.day_real_work_time === 'undefined' ? '-' : row.day_real_work_time}`}</div>
   )
 
   static getYear = val => {


### PR DESCRIPTION
## 這個 PR 是？ 
表訂/實際工時在沒有數值的時候會顯示`undefined`，實際上經過測試上傳工作資訊時必填欄位很多都沒有做檢查，不曉得這個是否是正常的

- Front-end PR：簡易ＵＩ修正

## Screenshots 
![image](https://user-images.githubusercontent.com/13104102/41026426-1da276f6-69a7-11e8-9c0a-e1a2a7e9ff05.png)


- 我需要更新 Packages 嗎？ No <!-- Yes / No -->
- 有哪些文件需要被更新嗎？ No <!-- 文件的連結 -->