### PR TITLE
Fix/修復面試表單 style bug

### DIFF
--- a/src/components/ShareExperience/common/Dialog.module.css
+++ b/src/components/ShareExperience/common/Dialog.module.css
@@ -10,7 +10,7 @@
   marginLeft: 74px;
   padding: 10px;
 
-  @media (max-width: 550px) {
+  @media (max-width: 850px) {
     width: auto;
     margin: 0;
     margin-top: 8px;

--- a/src/components/ShareExperience/common/Salary.module.css
+++ b/src/components/ShareExperience/common/Salary.module.css
@@ -1,7 +1,7 @@
 .container {
   display: flex;
 
-  @media (max-width: 550px) {
+  @media (max-width: 850px) {
     flex-direction: column;
   }
 }


### PR DESCRIPTION
Close #280

## 這個 PR 是？ <!-- 必填 -->

修復一個很古老的 style bug，大約螢幕寬度在 551px~620px 這段的時候，面試經驗表單裡面薪資旁的說明區塊會稍微跑版：

![2018-09-23 12 32 27](https://user-images.githubusercontent.com/3805975/45924211-c33fba80-bf2c-11e8-9b51-cbc306e9a08c.png)

用 chrome 測是 iphone 5/SE 裝置在橫著擺的時候會出現，想說還是解一下。

## Screenshots  <!-- 選填，沒有就刪掉 -->

修復後：
![m1erdhigj3](https://user-images.githubusercontent.com/3805975/45924230-73adbe80-bf2d-11e8-9c9a-5d282de12557.gif)


## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

會動到 Dialog style 的斷點，總計會影響到 面試表單的 OverallRating component 、工作經驗表單的 WeekWorkTime component，都實測過 style 正常。

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進 http://localhost:3000/share/interview ，拉動螢幕（尤其是 551px~620px 這段），看看是否有跑版的狀況
- [ ] 進 http://localhost:3000/share/work-experiences ，拉動螢幕（尤其是 551px~620px 這段），看看是否有跑版的狀況
