### PR TITLE
Fix/修復面試結果選擇 [其他] 時，輸入文字的錯誤訊息

### DIFF
--- a/src/components/ExperienceDetail/Article/InfoBlock.module.css
+++ b/src/components/ExperienceDetail/Article/InfoBlock.module.css
@@ -19,6 +19,15 @@
 
 .content {
   margin-top: 8px;
+  word-wrap: break-word;
+
+  @media (max-width: 850px) {
+    margin-right: 15px;
+  }
+
+  @media (max-width: 550px) {
+    margin-right: 0;
+  }
 
   > ul {
     margin-left: 1.3em;

--- a/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewResult.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewInfo/InterviewResult.js
@@ -63,7 +63,7 @@ const InterviewResult = ({
             marginTop: '8px',
           }}
         >
-          需填寫面試結果
+          需填寫面試結果，或字數少於 100 字。
         </p>
       ) : null}
     </div>

--- a/src/components/ShareExperience/InterviewForm/formCheck.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.js
@@ -26,7 +26,7 @@ export const interviewTimeYear = R.allPass([n => n > 0]);
 export const interviewTimeMonth = R.allPass([n => n > 0, n => n < 13]);
 
 export const interviewResult = t =>
-  notNullOrUndefined(t) && R.allPass([gtLength(0), lteLength(10)])(t);
+  notNullOrUndefined(t) && R.allPass([gtLength(0), lteLength(100)])(t);
 
 export const salaryAmount = R.anyPass([
   R.allPass([n => n >= 0]),

--- a/src/components/ShareExperience/InterviewForm/formCheck.test.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.test.js
@@ -85,14 +85,14 @@ describe('interviewTimeMonth test', () => {
 });
 
 describe('interviewResult test', () => {
-  test('string length in (0, 10] should pass', () => {
+  test('string length in (0, 100] should pass', () => {
     expect(interviewResult('abcdeabcde')).toBe(true);
     expect(interviewResult('abc')).toBe(true);
   });
 
-  test('string length not in (0, 10] should not pass', () => {
+  test('string length not in (0, 100] should not pass', () => {
     expect(interviewResult('')).toBe(false);
-    expect(interviewResult('abcdeabcdea')).toBe(false);
+    expect(interviewResult(new Array(110).join('a'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Close #389 

## 這個 PR 是？ <!-- 必填 -->

1. 錯誤訊息不只顯示「需填寫面試結果」，還加上字數限制
2. 字數限制拉到 100 字 （需搭配後端 PR： https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/505 ）

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/505

## Screenshots  <!-- 選填，沒有就刪掉 -->

輸入的地方
![ue1wdczaqy](https://user-images.githubusercontent.com/3805975/45924939-356ccb00-bf3e-11e8-9789-781f42fa3feb.gif)

顯示的地方
![8u9mxpxiev](https://user-images.githubusercontent.com/3805975/45925037-2850db80-bf40-11e8-8d0e-cf87c800861e.gif)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] backend 要切到這個 PR https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/505
- [ ] 進 http://localhost:3000/share/interview ，面試結果選其他，打超過 100 字或沒打字看看，應該要跳錯誤訊息
- [ ] 面試結果打 9x 字，去單篇面試經驗，看會不會跑版