### PR TITLE
Bugfix init api in constructor

### DIFF
--- a/src/components/Layout/Header/index.js
+++ b/src/components/Layout/Header/index.js
@@ -24,17 +24,16 @@ class Header extends React.Component {
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
     this.unlisten = () => {};
-
-    const { getLoginStatus, FB, getMe } = this.props;
-
-    getLoginStatus(FB)
-      .then(() => getMe(FB))
-      .catch(() => {});
   }
 
   componentDidMount() {
     const { history } = this.props;
     this.unlisten = history.listen(this.closeNav);
+
+    const { getLoginStatus, FB, getMe } = this.props;
+    getLoginStatus(FB)
+      .then(() => getMe(FB))
+      .catch(() => {});
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
這個 bug 是在追蹤 middleware 時，意外發現不尋常的錯誤

打 API 的部分應該在 `componentDidMount` 完成