### PR TITLE
Hotfix/修復面試經驗表單，敏感問題的其他字數超過時，沒有出現錯誤訊息的狀況

### DIFF
--- a/src/components/ShareExperience/InterviewForm/InterviewExperience/InterviewSensitiveQuestions.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewExperience/InterviewSensitiveQuestions.js
@@ -80,7 +80,10 @@ const InterviewSensitiveQuestions = ({
             value={otherValue || ''}
             onChange={e => onChange([...resultsBesidesOther, e.target.value])}
             placeholder="輸入敏感問題"
-            warningWording="請輸入20個字以內"
+            warningWording="請輸入 1～20 字"
+            isWarning={
+              !otherValue || otherValue.length > 20 || otherValue.length === 0
+            }
           />
         </section>
       ) : null}

--- a/src/components/ShareExperience/InterviewForm/InterviewExperience/index.js
+++ b/src/components/ShareExperience/InterviewForm/InterviewExperience/index.js
@@ -16,11 +16,16 @@ import shareStyles from '../../common/share.module.css';
 import {
   title as titleValidator,
   sections as sectionsValidator,
+  interviewSensitiveQuestions as interviewSensitiveQuestionsValidator,
 } from '../formCheck';
 
 import { interviewSectionSubtitleOptions } from '../../common/optionMap';
 
-import { TITLE, SECTIONS } from '../../../../constants/formElements';
+import {
+  TITLE,
+  SECTIONS,
+  INTERVIEW_SENSITIVE_QUESTIONS,
+} from '../../../../constants/formElements';
 
 const TitleWithValidation = subscribeValidation(
   Title,
@@ -32,6 +37,12 @@ const SectionsWithValidation = subscribeValidation(
   Sections,
   props => props.validator(props.sections),
   SECTIONS
+);
+
+const InterviewSensitiveQuestionsWithValidation = subscribeValidation(
+  InterviewSensitiveQuestions,
+  props => props.validator(props.interviewSensitiveQuestions),
+  INTERVIEW_SENSITIVE_QUESTIONS
 );
 
 class InterviewExperience extends Component {
@@ -123,9 +134,11 @@ class InterviewExperience extends Component {
           }}
         />
         <div>
-          <InterviewSensitiveQuestions
+          <InterviewSensitiveQuestionsWithValidation
             interviewSensitiveQuestions={interviewSensitiveQuestions}
             onChange={handleState('interviewSensitiveQuestions')}
+            validator={interviewSensitiveQuestionsValidator}
+            changeValidationStatus={changeValidationStatus}
           />
         </div>
       </IconHeadingBlock>

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -15,6 +15,7 @@ export const OVERTIME_FREQUENCY = 'overtime_frequency';
 
 export const INTERVIEW_TIME = 'interview_time';
 export const INTERVIEW_RESULT = 'interview_result';
+export const INTERVIEW_SENSITIVE_QUESTIONS = 'interview_sensitive_questions';
 export const OVERALL_RATING = 'overall_rating';
 export const TITLE = 'title';
 export const SECTIONS = 'sections';
@@ -29,6 +30,7 @@ export const INTERVIEW_FORM_ORDER = [
   OVERALL_RATING,
   TITLE,
   SECTIONS,
+  INTERVIEW_SENSITIVE_QUESTIONS,
 ];
 
 export const TIME_SALARY_BASIC_ORDER = [COMPANY, JOB_TITLE, EMPLOYMENT_TYPE];


### PR DESCRIPTION
Close #590 

## 這個 PR 是？ <!-- 必填 -->

修復面試經驗表單，敏感問題選「其他」時，input 字數超過時，沒有出現錯誤訊息的狀況

## Screenshots  <!-- 選填，沒有就刪掉 -->

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進到面試經驗表單，該填的填寫完。面試敏感問題選其他，沒有字的情況下就會紅框。
- [ ] 打超過 20 字也會紅框
- [ ] 只要紅框的狀態下按送出，都會把敏感問題捲到螢幕中間