### PR TITLE
Login flow refactoring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,13 +29,6 @@ module.exports = {
     'react/no-array-index-key': 'off',
     'no-unused-vars': 'error',
     'react/no-deprecated': 'error',
-    'prettier/prettier': [
-      'error',
-      {
-        trailingComma: 'es5',
-        singleQuote: true,
-      },
-    ],
   },
   settings: {
     'import/resolver': {

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 coverage
 dist
 build
+webpack-assets.json

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "printWidth": 120,
+  "trailingComma": "all"
+}

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,4 @@
 {
   "singleQuote": true,
-  "printWidth": 120,
   "trailingComma": "all"
 }

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "react-textarea-autosize": "^4.3.0",
     "recompose": "^0.30.0",
     "redux": "^3.7.2",
+    "redux-persist": "^5.10.0",
+    "redux-persist-transform-immutable": "^5.0.0",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.1",
     "serialize-javascript": "^1.3.0"

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -73,6 +73,8 @@ export const getMe = FB => (dispatch, getState) => {
   return new Promise(resolve =>
     FB.api('/me', response => resolve(response)),
   ).then(response => {
+    console.log('response', response);
+
     dispatch(setUser(response));
     return response;
   });

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -14,19 +14,20 @@ export const setUser = ({ name }) => ({
   name,
 });
 
-export const login = FB => dispatch => {
+export const login = FB => (dispatch, getState, { api }) => {
+  console.log(api);
   if (FB) {
     return new Promise(resolve => FB.login(response => resolve(response))).then(
       response => {
         if (response.status === authStatus.CONNECTED) {
           dispatch(
-            setLogin(response.status, response.authResponse.accessToken)
+            setLogin(response.status, response.authResponse.accessToken),
           );
         } else if (response.status === authStatus.NOT_AUTHORIZED) {
           dispatch(setLogin(response.status));
         }
         return response.status;
-      }
+      },
     );
   }
   return Promise.reject('FB should ready');
@@ -35,7 +36,7 @@ export const login = FB => dispatch => {
 export const logout = FB => dispatch => {
   if (FB) {
     return new Promise(resolve =>
-      FB.logout(response => resolve(response))
+      FB.logout(response => resolve(response)),
     ).then(response => {
       if (response.status === authStatus.UNKNOWN) {
         dispatch(setLogin(response.status, response.authResponse.accessToken));
@@ -50,7 +51,7 @@ export const logout = FB => dispatch => {
 export const getLoginStatus = FB => dispatch => {
   if (FB) {
     return new Promise(resolve =>
-      FB.getLoginStatus(response => resolve(response))
+      FB.getLoginStatus(response => resolve(response)),
     ).then(response => {
       if (response.status === authStatus.CONNECTED) {
         dispatch(setLogin(response.status, response.authResponse.accessToken));
@@ -71,7 +72,7 @@ export const getMe = FB => (dispatch, getState) => {
     return Promise.reject('auth status should be connected');
   }
   return new Promise(resolve =>
-    FB.api('/me', response => resolve(response))
+    FB.api('/me', response => resolve(response)),
   ).then(response => {
     dispatch(setUser(response));
     return response;

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -14,16 +14,19 @@ export const setUser = ({ name }) => ({
   name,
 });
 
-export const login = FB => (dispatch, getState, { api }) => {
+export const loginWithFB = FB => (dispatch, getState, { api }) => {
   if (FB) {
     return new Promise(resolve => FB.login(response => resolve(response))).then(
       response => {
         if (response.status === authStatus.CONNECTED) {
-          dispatch(
-            setLogin(response.status, response.authResponse.accessToken),
-          );
+          return api.auth
+            .postAuthFacebook(response.authResponse.accessToken)
+            .then(({ token, user: { _id, facebook_id } }) =>
+              dispatch(setLogin(authStatus.CONNECTED, token)),
+            )
+            .then(() => authStatus.CONNECTED);
         } else if (response.status === authStatus.NOT_AUTHORIZED) {
-          dispatch(setLogin(response.status));
+          dispatch(setLogin(authStatus.NOT_AUTHORIZED));
         }
         return response.status;
       },

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -73,8 +73,6 @@ export const getMe = FB => (dispatch, getState) => {
   return new Promise(resolve =>
     FB.api('/me', response => resolve(response)),
   ).then(response => {
-    console.log('response', response);
-
     dispatch(setUser(response));
     return response;
   });

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -15,7 +15,6 @@ export const setUser = ({ name }) => ({
 });
 
 export const login = FB => (dispatch, getState, { api }) => {
-  console.log(api);
   if (FB) {
     return new Promise(resolve => FB.login(response => resolve(response))).then(
       response => {

--- a/src/actions/campaignInfo.js
+++ b/src/actions/campaignInfo.js
@@ -1,4 +1,3 @@
-import { fetchCampaignList } from '../apis/campaignInfoApi';
 import fetchingStatus, { isUnfetched } from '../constants/status';
 import { campaignEntriesStatusSelector } from '../selectors/campaignSelector';
 
@@ -12,13 +11,14 @@ const setListData = (campaignList, status, error = null) => ({
   error,
 });
 
-export const queryCampaignInfoList = () => dispatch => {
+export const queryCampaignInfoList = () => (dispatch, getState, { api }) => {
   dispatch({
     type: SET_LIST_STATUS,
     status: fetchingStatus.FETCHING,
   });
 
-  return fetchCampaignList()
+  return api.campaignInfo
+    .fetchCampaignList()
     .then(rawData => {
       dispatch(setListData(rawData, fetchingStatus.FETCHED));
     })

--- a/src/actions/campaignTimeAndSalaryBoard.js
+++ b/src/actions/campaignTimeAndSalaryBoard.js
@@ -1,6 +1,5 @@
 import R from 'ramda';
 
-import { fetchCampaignTimeAndSalary } from '../apis/timeAndSalaryApi';
 import fetchingStatus from '../constants/status';
 import { DATA_NUM_PER_PAGE } from '../constants/timeAndSalarSearch';
 
@@ -56,7 +55,7 @@ const setBoardData = (
 export const queryCampaignTimeAndSalary = (
   campaignName,
   { sortBy, order, jobTitles, page },
-) => (dispatch, getState) => {
+) => (dispatch, getState, { api }) => {
   if (
     campaignName !== campaignNameSelector(getState()) ||
     sortBy !== sortBySelector(getState()) ||
@@ -84,7 +83,8 @@ export const queryCampaignTimeAndSalary = (
     skip: (sortBy !== 'created_at').toString(),
   };
 
-  return fetchCampaignTimeAndSalary({ campaignName, opt })
+  return api.timeAndSalary
+    .fetchCampaignTimeAndSalary({ campaignName, opt })
     .then(rawData => {
       // 將Array公司名稱轉換成String
       const takeFirstFromArrayCompanyName = R.over(

--- a/src/actions/campaignTimeAndSalaryBoard.js
+++ b/src/actions/campaignTimeAndSalaryBoard.js
@@ -29,7 +29,7 @@ const resetBoard = ({ campaignName, sortBy, order, page }) => ({
 
 const setBoardData = (
   { campaignName, sortBy, order },
-  { status, data, total = 0, currentPage = 0, error = null }
+  { status, data, total = 0, currentPage = 0, error = null },
 ) => (dispatch, getState) => {
   // make sure the store is consistent
   if (
@@ -55,7 +55,7 @@ const setBoardData = (
 
 export const queryCampaignTimeAndSalary = (
   campaignName,
-  { sortBy, order, jobTitles, page }
+  { sortBy, order, jobTitles, page },
 ) => (dispatch, getState) => {
   if (
     campaignName !== campaignNameSelector(getState()) ||
@@ -84,7 +84,7 @@ export const queryCampaignTimeAndSalary = (
     skip: (sortBy !== 'created_at').toString(),
   };
 
-  return fetchCampaignTimeAndSalary(campaignName, opt)
+  return fetchCampaignTimeAndSalary({ campaignName, opt })
     .then(rawData => {
       // 將Array公司名稱轉換成String
       const takeFirstFromArrayCompanyName = R.over(
@@ -92,11 +92,11 @@ export const queryCampaignTimeAndSalary = (
         R.ifElse(
           R.pipe(
             R.type,
-            R.equals('Array')
+            R.equals('Array'),
           ),
           R.head,
-          R.identity
-        )
+          R.identity,
+        ),
       );
       const data = rawData.time_and_salary.map(takeFirstFromArrayCompanyName);
 
@@ -108,16 +108,16 @@ export const queryCampaignTimeAndSalary = (
             data,
             total: rawData.total,
             currentPage: page,
-          }
-        )
+          },
+        ),
       );
     })
     .catch(error => {
       dispatch(
         setBoardData(
           { campaignName, sortBy, order },
-          { status: fetchingStatus.ERROR, data: [], error }
-        )
+          { status: fetchingStatus.ERROR, data: [], error },
+        ),
       );
     });
 };

--- a/src/actions/experienceDetail.js
+++ b/src/actions/experienceDetail.js
@@ -1,5 +1,12 @@
-import fetchUtil from '../utils/fetchUtil';
 import fetchingStatus from '../constants/status';
+import {
+  postExperienceReply,
+  deleteExperienceLikes,
+  postExperienceLikes,
+  deleteReplyLikes,
+  postReplyLikes,
+  getExperience,
+} from '../apis/experiencesApi';
 
 export const SET_EXPERIENCE = '@@experienceDetail/SET_EXPERIENCE';
 export const SET_EXPERIENCE_STATUS = '@@experienceDetail/SET_EXPERIENCE_STATUS';
@@ -46,9 +53,7 @@ export const submitComment = (id, comment) => (dispatch, getState) => {
     .experienceDetail.get('replies')
     .toJS();
 
-  return fetchUtil(`/experiences/${id}/replies`)('POST', {
-    content: comment,
-  }).then(result => {
+  return postExperienceReply({ id, comment }).then(result => {
     dispatch(
       setRepliesData(id, {
         status: fetchingStatus.FETCHED,
@@ -60,7 +65,7 @@ export const submitComment = (id, comment) => (dispatch, getState) => {
 
 export const likeExperience = o => dispatch => {
   if (o.liked) {
-    return fetchUtil(`/experiences/${o._id}/likes`)('DELETE').then(result => {
+    return deleteExperienceLikes({ id: o._id }).then(result => {
       if (result.success) {
         dispatch(
           setExperience(
@@ -79,7 +84,7 @@ export const likeExperience = o => dispatch => {
     // });
   }
 
-  return fetchUtil(`/experiences/${o._id}/likes`)('POST').then(result => {
+  return postExperienceLikes({ id: o._id }).then(result => {
     if (result.success) {
       dispatch(
         setExperience(
@@ -108,7 +113,7 @@ export const likeReply = reply => dispatch => {
   const { _id: replyId, liked } = reply;
 
   if (liked) {
-    return fetchUtil(`/replies/${replyId}/likes`)('DELETE').then(result => {
+    return deleteReplyLikes({ id: replyId }).then(result => {
       if (result.success) {
         return dispatch(setReplyLiked(replyId, false));
       }
@@ -116,7 +121,7 @@ export const likeReply = reply => dispatch => {
     });
   }
 
-  return fetchUtil(`/replies/${replyId}/likes`)('POST').then(result => {
+  return postReplyLikes({ id: replyId }).then(result => {
     if (result.success) {
       return dispatch(setReplyLiked(replyId, true));
     }
@@ -130,7 +135,7 @@ export const fetchExperience = id => dispatch => {
     status: fetchingStatus.FETCHING,
   });
 
-  return fetchUtil(`/experiences/${id}`)('GET')
+  return getExperience({ id })
     .then(result => {
       dispatch(setExperience(result));
     })

--- a/src/actions/experienceDetail.js
+++ b/src/actions/experienceDetail.js
@@ -1,8 +1,6 @@
 import fetchUtil from '../utils/fetchUtil';
 import fetchingStatus from '../constants/status';
 
-import { getExperienceReply } from '../apis/experiencesApi';
-
 export const SET_EXPERIENCE = '@@experienceDetail/SET_EXPERIENCE';
 export const SET_EXPERIENCE_STATUS = '@@experienceDetail/SET_EXPERIENCE_STATUS';
 export const SET_REPLIES_STATUS = '@@EXPERIENCE_DETAIL/SET_REPLIES_STATUS';
@@ -146,7 +144,7 @@ export const fetchExperience = id => dispatch => {
     });
 };
 
-export const fetchReplies = id => (dispatch, getState) => {
+export const fetchReplies = id => (dispatch, getState, { api }) => {
   if (id !== repliesExperienceIdSelector(getState())) {
     dispatch(resetRepliesData(id));
   }
@@ -156,15 +154,19 @@ export const fetchReplies = id => (dispatch, getState) => {
     status: fetchingStatus.FETCHING,
   });
 
-  return getExperienceReply({
-    experienceId: id,
-    start: 0,
-    limit: 100,
-  })
+  return api.experiences
+    .getExperienceReply({
+      experienceId: id,
+      start: 0,
+      limit: 100,
+    })
     .then(rawData => {
       const replies = rawData.replies;
       return dispatch(
-        setRepliesData(id, { status: fetchingStatus.FETCHED, replies }),
+        setRepliesData(id, {
+          status: fetchingStatus.FETCHED,
+          replies,
+        }),
       );
     })
     .catch(error =>

--- a/src/actions/experienceDetail.js
+++ b/src/actions/experienceDetail.js
@@ -29,7 +29,7 @@ const resetRepliesData = experienceId => ({
 
 const setRepliesData = (experienceId, { status, replies, error = null }) => (
   dispatch,
-  getState
+  getState,
 ) => {
   if (experienceId === repliesExperienceIdSelector(getState())) {
     return dispatch({
@@ -55,7 +55,7 @@ export const submitComment = (id, comment) => (dispatch, getState) => {
       setRepliesData(id, {
         status: fetchingStatus.FETCHED,
         replies: [...oldReplies, result.reply],
-      })
+      }),
     );
   });
 };
@@ -69,8 +69,8 @@ export const likeExperience = o => dispatch => {
             Object.assign({}, o, {
               liked: false,
               like_count: o.like_count - 1,
-            })
-          )
+            }),
+          ),
         );
         return;
       }
@@ -88,8 +88,8 @@ export const likeExperience = o => dispatch => {
           Object.assign({}, o, {
             liked: true,
             like_count: o.like_count + 1,
-          })
-        )
+          }),
+        ),
       );
       return;
     }
@@ -156,11 +156,15 @@ export const fetchReplies = id => (dispatch, getState) => {
     status: fetchingStatus.FETCHING,
   });
 
-  return getExperienceReply(id, 0, 100)
+  return getExperienceReply({
+    experienceId: id,
+    start: 0,
+    limit: 100,
+  })
     .then(rawData => {
       const replies = rawData.replies;
       return dispatch(
-        setRepliesData(id, { status: fetchingStatus.FETCHED, replies })
+        setRepliesData(id, { status: fetchingStatus.FETCHED, replies }),
       );
     })
     .catch(error =>
@@ -169,7 +173,7 @@ export const fetchReplies = id => (dispatch, getState) => {
           status: fetchingStatus.ERROR,
           error,
           replies: [],
-        })
-      )
+        }),
+      ),
     );
 };

--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -1,5 +1,3 @@
-import fetchUtil from '../utils/fetchUtil';
-
 import statusConstant from '../constants/status';
 
 export const SET_SEARCH_BY = 'SET_SEARCH_BY';
@@ -77,7 +75,11 @@ const setKeywords = keywords => ({
   keywords,
 });
 
-export const getNewSearchBy = searchBy => async dispatch => {
+export const getNewSearchBy = searchBy => async (
+  dispatch,
+  getState,
+  { api },
+) => {
   const keywordName =
     searchBy === 'company' ? 'company_keywords' : 'job_title_keywords';
   const body = {
@@ -87,7 +89,7 @@ export const getNewSearchBy = searchBy => async dispatch => {
   };
 
   try {
-    const result = await fetchUtil('/graphql')('POST', body);
+    const result = await api.experiences.newExperienceSearchBy({ body });
     if (!result.data) {
       throw new Error(result.error);
     }

--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -1,7 +1,5 @@
 import fetchUtil from '../utils/fetchUtil';
 
-import { getExperiences as getExperiencesApi } from '../apis/experiencesApi';
-
 import statusConstant from '../constants/status';
 
 export const SET_SEARCH_BY = 'SET_SEARCH_BY';
@@ -28,8 +26,8 @@ export const fetchExperiences = (
   _sort,
   searchBy,
   searchQuery,
-  searchType
-) => dispatch => {
+  searchType,
+) => (dispatch, getState, { api }) => {
   const start = (page - 1) * limit;
   const query = {
     limit,
@@ -54,10 +52,11 @@ export const fetchExperiences = (
       ...objCond,
       experiences: [],
       experienceCount: 0,
-    })
+    }),
   );
 
-  return getExperiencesApi(query)
+  return api.experiences
+    .getExperiences(query)
     .then(result => {
       const payload = {
         ...objCond,

--- a/src/actions/experiences.js
+++ b/src/actions/experiences.js
@@ -1,5 +1,4 @@
 import R from 'ramda';
-import { getExperiences } from '../apis/experiencesApi';
 import fetchingStatus, { isUnfetched } from '../constants/status';
 
 export const SET_COUNT_DATA = '@@EXPERIENCES/SET_COUNT_DATA';
@@ -11,7 +10,7 @@ const setCountData = (count, status, error = null) => ({
   error,
 });
 
-export const queryExperienceCount = () => dispatch => {
+export const queryExperienceCount = () => (dispatch, getState, { api }) => {
   dispatch(setCountData(0, fetchingStatus.FETCHING));
   const opt = {
     searchType: ['interview', 'work', 'intern'],
@@ -20,7 +19,8 @@ export const queryExperienceCount = () => dispatch => {
     sort: 'created_at',
   };
 
-  return getExperiences(opt)
+  return api.experiences
+    .getExperiences(opt)
     .then(rawData => {
       const count = R.prop('total')(rawData);
       dispatch(setCountData(count, fetchingStatus.FETCHED));

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -31,7 +31,7 @@ const setEntryData = (entryId, data, status, error = null) => ({
   error,
 });
 
-export const queryMenu = () => (dispatch, getState, api) => {
+export const queryMenu = () => (dispatch, getState, { api }) => {
   dispatch({
     type: SET_MENU_STATUS,
     status: fetchingStatus.FETCHING,

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -57,7 +57,7 @@ export const queryMenuIfUnfetched = () => (dispatch, getState) => {
 export const queryEntry = entryId => dispatch => {
   dispatch(setEntryStatus(entryId, fetchingStatus.FETCHING));
 
-  return getEntry(entryId)
+  return getEntry({ entryId })
     .then(rawData => {
       dispatch(setEntryData(entryId, rawData, fetchingStatus.FETCHED));
     })
@@ -71,7 +71,7 @@ export const queryEntry = entryId => dispatch => {
               name,
               message,
               statusCode: 404,
-            })
+            }),
           );
         }
       }

--- a/src/actions/laborRights.js
+++ b/src/actions/laborRights.js
@@ -1,4 +1,3 @@
-import { getEntries, getEntry } from '../apis/laborRightsApi';
 import {
   menuStatusSelector,
   entryStatusSelector,
@@ -32,13 +31,14 @@ const setEntryData = (entryId, data, status, error = null) => ({
   error,
 });
 
-export const queryMenu = () => dispatch => {
+export const queryMenu = () => (dispatch, getState, api) => {
   dispatch({
     type: SET_MENU_STATUS,
     status: fetchingStatus.FETCHING,
   });
 
-  return getEntries()
+  return api.laborRights
+    .getEntries()
     .then(rawData => {
       dispatch(setMenuData(rawData, fetchingStatus.FETCHED));
     })
@@ -54,10 +54,11 @@ export const queryMenuIfUnfetched = () => (dispatch, getState) => {
   return Promise.resolve();
 };
 
-export const queryEntry = entryId => dispatch => {
+export const queryEntry = entryId => (dispatch, getState, { api }) => {
   dispatch(setEntryStatus(entryId, fetchingStatus.FETCHING));
 
-  return getEntry({ entryId })
+  return api.laborRights
+    .getEntry({ entryId })
     .then(rawData => {
       dispatch(setEntryData(entryId, rawData, fetchingStatus.FETCHED));
     })

--- a/src/actions/me.js
+++ b/src/actions/me.js
@@ -1,4 +1,3 @@
-import fetchUtil from '../utils/fetchUtil';
 import status from '../constants/status';
 
 export const SET_MY_EXPERIENCES = 'SET_MY_EXPERIENCES';
@@ -31,13 +30,14 @@ export const setMyReplies = (myReplies, err) => ({
   myReplies,
 });
 
-export const fetchMyExperiences = () => dispatch => {
+export const fetchMyExperiences = () => (dispatch, getState, { api }) => {
   dispatch({
     type: SET_MY_EXPERIENCES_STATUS,
     status: status.FETCHING,
   });
 
-  return fetchUtil('/me/experiences')('GET')
+  return api.me
+    .getMeExperiences()
     .then(result => {
       if (result.error) {
         dispatch(setMyExperiences({}, result.error));
@@ -50,13 +50,14 @@ export const fetchMyExperiences = () => dispatch => {
     });
 };
 
-export const fetchMyWorkings = () => dispatch => {
+export const fetchMyWorkings = () => (dispatch, getState, { api }) => {
   dispatch({
     type: SET_MY_WORKINGS_STATUS,
     status: status.FETCHING,
   });
 
-  return fetchUtil('/me/workings')('GET')
+  return api.me
+    .getMeWorkings()
     .then(result => {
       if (result.error) {
         dispatch(setMyWorkings({}, result.error));
@@ -69,13 +70,14 @@ export const fetchMyWorkings = () => dispatch => {
     });
 };
 
-export const fetchMyReplies = () => dispatch => {
+export const fetchMyReplies = () => (dispatch, getState, { api }) => {
   dispatch({
     type: SET_MY_REPLIES_STATUS,
     status: status.FETCHING,
   });
 
-  return fetchUtil('/me/replies')('GET')
+  return api.me
+    .getMeReplies()
     .then(result => {
       if (result.error) {
         dispatch(setMyReplies({}, result.error));
@@ -88,83 +90,94 @@ export const fetchMyReplies = () => dispatch => {
     });
 };
 
-export const setExperienceStatus = o => (dispatch, getState) => {
+export const setExperienceStatus = o => (dispatch, getState, { api }) => {
   const data = getState().me.toJS();
   let experiences = data.myExperiences.experiences;
   const index = getIndex(experiences, o._id);
 
-  return fetchUtil(`/experiences/${o._id}`)('PATCH', {
-    status: o.status === 'published' ? 'hidden' : 'published',
-  }).then(result => {
-    if (result.success) {
-      experiences = [
-        ...experiences.slice(0, index),
-        Object.assign({}, o, {
-          status: result.status,
-        }),
-        ...experiences.slice(index + 1),
-      ];
-      dispatch(
-        setMyExperiences(
-          Object.assign(data.myExperiences, { experiences }),
-          null
-        )
-      );
-      return;
-    }
-    dispatch(setMyExperiences(experiences, null));
-  });
+  return api.experiences
+    .patchExperience({
+      id: o._id,
+      status: o.status === 'published' ? 'hidden' : 'published',
+    })
+    .then(result => {
+      if (result.success) {
+        experiences = [
+          ...experiences.slice(0, index),
+          Object.assign({}, o, {
+            status: result.status,
+          }),
+          ...experiences.slice(index + 1),
+        ];
+        dispatch(
+          setMyExperiences(
+            Object.assign(data.myExperiences, { experiences }),
+            null,
+          ),
+        );
+        return;
+      }
+      dispatch(setMyExperiences(experiences, null));
+    });
 };
 
-export const setWorkingStatus = o => (dispatch, getState) => {
+export const setWorkingStatus = o => (dispatch, getState, { api }) => {
   const data = getState().me.toJS();
   let workings = data.myWorkings.time_and_salary;
   const index = getIndex(workings, o._id);
 
-  return fetchUtil(`/workings/${o._id}`)('PATCH', {
-    status: o.status === 'published' ? 'hidden' : 'published',
-  }).then(result => {
-    if (result.success) {
-      workings = [
-        ...workings.slice(0, index),
-        Object.assign({}, o, {
-          status: result.status,
-        }),
-        ...workings.slice(index + 1),
-      ];
-      dispatch(
-        setMyWorkings(
-          Object.assign(data.myWorkings, {
-            time_and_salary: workings,
+  return api.timeAndSalary
+    .patchWorking({
+      id: o._id,
+      status: o.status === 'published' ? 'hidden' : 'published',
+    })
+    .then(result => {
+      if (result.success) {
+        workings = [
+          ...workings.slice(0, index),
+          Object.assign({}, o, {
+            status: result.status,
           }),
-          null
-        )
-      );
-      return;
-    }
-    dispatch(setMyWorkings(workings, null));
-  });
+          ...workings.slice(index + 1),
+        ];
+        dispatch(
+          setMyWorkings(
+            Object.assign(data.myWorkings, {
+              time_and_salary: workings,
+            }),
+            null,
+          ),
+        );
+        return;
+      }
+      dispatch(setMyWorkings(workings, null));
+    });
 };
 
-export const setReplyStatus = o => (dispatch, getState) => {
+export const setReplyStatus = o => (dispatch, getState, { api }) => {
   const data = getState().me.toJS();
   let replies = data.myReplies.replies;
   const index = getIndex(replies, o._id);
 
-  return fetchUtil(`/replies/${o._id}`)('PATCH', {
-    status: o.status === 'published' ? 'hidden' : 'published',
-  }).then(result => {
-    if (result.success) {
-      replies = [
-        ...replies.slice(0, index),
-        Object.assign({}, o, {
-          status: result.status,
-        }),
-        ...replies.slice(index + 1),
-      ];
-      dispatch(setMyReplies(Object.assign(data.myReplies, { replies }), null));
-      return;
-    }
-    dispatch(setMyReplies(replies, null));
-  });
+  return api.experiences
+    .patchReply({
+      id: o._id,
+      status: o.status === 'published' ? 'hidden' : 'published',
+    })
+    .then(result => {
+      if (result.success) {
+        replies = [
+          ...replies.slice(0, index),
+          Object.assign({}, o, {
+            status: result.status,
+          }),
+          ...replies.slice(index + 1),
+        ];
+        dispatch(
+          setMyReplies(Object.assign(data.myReplies, { replies }), null),
+        );
+        return;
+      }
+      dispatch(setMyReplies(replies, null));
+    });
 };

--- a/src/actions/popularExperiences.js
+++ b/src/actions/popularExperiences.js
@@ -1,5 +1,4 @@
 import R from 'ramda';
-import { getExperiences as getExperiencesApi } from '../apis/experiencesApi';
 import fetchingStatus from '../constants/status';
 
 export const SET_DATA = '@@POPULAR_EXPERIENCES/SET_DATA';
@@ -16,7 +15,11 @@ const setData = ({ data, status, error = null }) => ({
   error,
 });
 
-export const queryPopularExperiences = (limit = 3) => dispatch => {
+export const queryPopularExperiences = (limit = 3) => (
+  dispatch,
+  getState,
+  { api },
+) => {
   dispatch(startFetching());
 
   const opt = {
@@ -26,10 +29,16 @@ export const queryPopularExperiences = (limit = 3) => dispatch => {
     searchType: ['interview', 'work'],
   };
 
-  return getExperiencesApi(opt)
+  return api.experiences
+    .getExperiences(opt)
     .then(rawData => {
       const experiences = R.prop('experiences')(rawData);
-      dispatch(setData({ status: fetchingStatus.FETCHED, data: experiences }));
+      dispatch(
+        setData({
+          status: fetchingStatus.FETCHED,
+          data: experiences,
+        }),
+      );
     })
     .catch(error => {
       dispatch(setData({ status: fetchingStatus.ERROR, data: [], error }));

--- a/src/actions/timeAndSalary.js
+++ b/src/actions/timeAndSalary.js
@@ -18,7 +18,7 @@ export const queryTimeAndSalaryCount = () => dispatch => {
     limit: 1,
   };
 
-  return fetchTimeAndSalary(opt)
+  return fetchTimeAndSalary({ opt })
     .then(rawData => {
       const count = R.prop('total')(rawData);
       dispatch(setCountData(count, fetchingStatus.FETCHED));
@@ -31,7 +31,7 @@ export const queryTimeAndSalaryCount = () => dispatch => {
 
 export const queryTimeAndSalaryCountIfUnfetched = () => (
   dispatch,
-  getState
+  getState,
 ) => {
   if (isUnfetched(getState().timeAndSalary.get('countStatus'))) {
     return dispatch(queryTimeAndSalaryCount());

--- a/src/actions/timeAndSalary.js
+++ b/src/actions/timeAndSalary.js
@@ -1,5 +1,4 @@
 import R from 'ramda';
-import { fetchTimeAndSalary } from '../apis/timeAndSalaryApi';
 import fetchingStatus, { isUnfetched } from '../constants/status';
 
 export const SET_COUNT_DATA = '@@TIME_AND_SALARY/SET_COUNT_DATA';
@@ -11,14 +10,15 @@ const setCountData = (count, status, error = null) => ({
   error,
 });
 
-export const queryTimeAndSalaryCount = () => dispatch => {
+export const queryTimeAndSalaryCount = () => (dispatch, getState, { api }) => {
   dispatch(setCountData(0, fetchingStatus.FETCHING));
 
   const opt = {
     limit: 1,
   };
 
-  return fetchTimeAndSalary({ opt })
+  return api.timeAndSalary
+    .fetchTimeAndSalary({ opt })
     .then(rawData => {
       const count = R.prop('total')(rawData);
       dispatch(setCountData(count, fetchingStatus.FETCHED));

--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -33,7 +33,7 @@ const resetBoard = ({ sortBy, order, page }) => ({
 
 const setBoardData = (
   { sortBy, order },
-  { status, data, total = 0, currentPage = 0, error = null }
+  { status, data, total = 0, currentPage = 0, error = null },
 ) => (dispatch, getState) => {
   // make sure the store is consistent
   if (
@@ -57,7 +57,7 @@ const setBoardData = (
 
 export const queryTimeAndSalary = ({ sortBy, order, page }) => (
   dispatch,
-  getState
+  getState,
 ) => {
   if (
     sortBy !== sortBySelector(getState()) ||
@@ -84,7 +84,7 @@ export const queryTimeAndSalary = ({ sortBy, order, page }) => (
     skip: (sortBy !== 'created_at').toString(),
   };
 
-  return fetchTimeAndSalary(opt)
+  return fetchTimeAndSalary({ opt })
     .then(rawData => {
       // 將Array公司名稱轉換成String
       const takeFirstFromArrayCompanyName = R.over(
@@ -92,11 +92,11 @@ export const queryTimeAndSalary = ({ sortBy, order, page }) => (
         R.ifElse(
           R.pipe(
             R.type,
-            R.equals('Array')
+            R.equals('Array'),
           ),
           R.head,
-          R.identity
-        )
+          R.identity,
+        ),
       );
       const data = rawData.time_and_salary.map(takeFirstFromArrayCompanyName);
 
@@ -108,16 +108,16 @@ export const queryTimeAndSalary = ({ sortBy, order, page }) => (
             data,
             total: rawData.total,
             currentPage: page,
-          }
-        )
+          },
+        ),
       );
     })
     .catch(error => {
       dispatch(
         setBoardData(
           { sortBy, order },
-          { status: fetchingStatus.ERROR, data: [], error }
-        )
+          { status: fetchingStatus.ERROR, data: [], error },
+        ),
       );
     });
 };
@@ -131,7 +131,7 @@ export const resetBoardExtremeData = () => ({
 
 const setBoardExtremeData = (
   { sortBy, order },
-  { extremeStatus, extremeData, extremeError = null }
+  { extremeStatus, extremeData, extremeError = null },
 ) => (dispatch, getState) => {
   // make sure the store is consistent
   if (
@@ -171,7 +171,7 @@ export const queryExtremeTimeAndSalary = () => (dispatch, getState) => {
     order,
   };
 
-  return fetchTimeAndSalaryExtreme(opt)
+  return fetchTimeAndSalaryExtreme({ opt })
     .then(rawData => {
       // 將Array公司名稱轉換成String
       const takeFirstFromArrayCompanyName = R.over(
@@ -179,28 +179,32 @@ export const queryExtremeTimeAndSalary = () => (dispatch, getState) => {
         R.when(
           R.pipe(
             R.type,
-            R.equals('Array')
+            R.equals('Array'),
           ),
-          R.head
-        )
+          R.head,
+        ),
       );
       const extremeData = rawData.time_and_salary.map(
-        takeFirstFromArrayCompanyName
+        takeFirstFromArrayCompanyName,
       );
 
       dispatch(
         setBoardExtremeData(
           { sortBy, order },
-          { extremeStatus: fetchingStatus.FETCHED, extremeData }
-        )
+          { extremeStatus: fetchingStatus.FETCHED, extremeData },
+        ),
       );
     })
     .catch(extremeError => {
       dispatch(
         setBoardExtremeData(
           { sortBy, order },
-          { extremeStatus: fetchingStatus.ERROR, extremeData: [], extremeError }
-        )
+          {
+            extremeStatus: fetchingStatus.ERROR,
+            extremeData: [],
+            extremeError,
+          },
+        ),
       );
     });
 };

--- a/src/actions/timeAndSalaryBoard.js
+++ b/src/actions/timeAndSalaryBoard.js
@@ -1,9 +1,5 @@
 import R from 'ramda';
 
-import {
-  fetchTimeAndSalary,
-  fetchTimeAndSalaryExtreme,
-} from '../apis/timeAndSalaryApi';
 import fetchingStatus from '../constants/status';
 import { DATA_NUM_PER_PAGE } from '../constants/timeAndSalarSearch';
 
@@ -58,6 +54,7 @@ const setBoardData = (
 export const queryTimeAndSalary = ({ sortBy, order, page }) => (
   dispatch,
   getState,
+  { api },
 ) => {
   if (
     sortBy !== sortBySelector(getState()) ||
@@ -84,7 +81,8 @@ export const queryTimeAndSalary = ({ sortBy, order, page }) => (
     skip: (sortBy !== 'created_at').toString(),
   };
 
-  return fetchTimeAndSalary({ opt })
+  return api.timeAndSalary
+    .fetchTimeAndSalary({ opt })
     .then(rawData => {
       // 將Array公司名稱轉換成String
       const takeFirstFromArrayCompanyName = R.over(
@@ -148,7 +146,11 @@ const setBoardExtremeData = (
   });
 };
 
-export const queryExtremeTimeAndSalary = () => (dispatch, getState) => {
+export const queryExtremeTimeAndSalary = () => (
+  dispatch,
+  getState,
+  { api },
+) => {
   // extreme data only available for data sorted by estimated_hourly_wage and week_work_time
   if (
     sortBySelector(getState()) !== 'estimated_hourly_wage' &&
@@ -171,7 +173,8 @@ export const queryExtremeTimeAndSalary = () => (dispatch, getState) => {
     order,
   };
 
-  return fetchTimeAndSalaryExtreme({ opt })
+  return api.timeAndSalary
+    .fetchTimeAndSalaryExtreme({ opt })
     .then(rawData => {
       // 將Array公司名稱轉換成String
       const takeFirstFromArrayCompanyName = R.over(

--- a/src/actions/timeAndSalaryCompany.js
+++ b/src/actions/timeAndSalaryCompany.js
@@ -1,4 +1,3 @@
-import { fetchSearchCompany } from '../apis/timeAndSalaryApi';
 import fetchingStatus from '../constants/status';
 
 export const SET_COMPANY_DATA = '@@timeAndSalaryCompany/SET_COMPANY_DATA';
@@ -24,6 +23,7 @@ export const setCompanyData = (
 export const queryCompany = ({ groupSortBy, order, company }) => (
   dispatch,
   getState,
+  { api },
 ) => {
   if (
     groupSortBy !== getState().timeAndSalaryCompany.get('groupSortBy') ||
@@ -59,7 +59,8 @@ export const queryCompany = ({ groupSortBy, order, company }) => (
     group_sort_order: order,
   };
 
-  return fetchSearchCompany({ opt })
+  return api.timeAndSalary
+    .fetchSearchCompany({ opt })
     .then(data => {
       dispatch(
         setCompanyData(

--- a/src/actions/timeAndSalaryCompany.js
+++ b/src/actions/timeAndSalaryCompany.js
@@ -10,7 +10,7 @@ export const setCompanyData = (
   order,
   company,
   data,
-  error
+  error,
 ) => ({
   type: SET_COMPANY_DATA,
   groupSortBy,
@@ -23,7 +23,7 @@ export const setCompanyData = (
 
 export const queryCompany = ({ groupSortBy, order, company }) => (
   dispatch,
-  getState
+  getState,
 ) => {
   if (
     groupSortBy !== getState().timeAndSalaryCompany.get('groupSortBy') ||
@@ -37,8 +37,8 @@ export const queryCompany = ({ groupSortBy, order, company }) => (
         order,
         company,
         [],
-        null
-      )
+        null,
+      ),
     );
   }
 
@@ -59,7 +59,7 @@ export const queryCompany = ({ groupSortBy, order, company }) => (
     group_sort_order: order,
   };
 
-  return fetchSearchCompany(opt)
+  return fetchSearchCompany({ opt })
     .then(data => {
       dispatch(
         setCompanyData(
@@ -68,8 +68,8 @@ export const queryCompany = ({ groupSortBy, order, company }) => (
           order,
           company,
           data,
-          null
-        )
+          null,
+        ),
       );
     })
     .catch(err => {
@@ -80,8 +80,8 @@ export const queryCompany = ({ groupSortBy, order, company }) => (
           order,
           company,
           [],
-          err
-        )
+          err,
+        ),
       );
     });
 };

--- a/src/actions/timeAndSalaryJobTitle.js
+++ b/src/actions/timeAndSalaryJobTitle.js
@@ -1,4 +1,3 @@
-import { fetchSearchJobTitle } from '../apis/timeAndSalaryApi';
 import fetchingStatus from '../constants/status';
 
 export const SET_JOB_TITLE_DATA = '@@timeAndSalaryJobTitle/SET_JOB_TITLE_DATA';
@@ -25,6 +24,7 @@ export const setJobTitleData = (
 export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
   dispatch,
   getState,
+  { api },
 ) => {
   if (
     groupSortBy !== getState().timeAndSalaryJobTitle.get('groupSortBy') ||
@@ -60,7 +60,8 @@ export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
     group_sort_order: order,
   };
 
-  return fetchSearchJobTitle({ opt })
+  return api.timeAndSalary
+    .fetchSearchJobTitle({ opt })
     .then(data => {
       dispatch(
         setJobTitleData(

--- a/src/actions/timeAndSalaryJobTitle.js
+++ b/src/actions/timeAndSalaryJobTitle.js
@@ -11,7 +11,7 @@ export const setJobTitleData = (
   order,
   jobTitle,
   data,
-  error
+  error,
 ) => ({
   type: SET_JOB_TITLE_DATA,
   groupSortBy,
@@ -24,7 +24,7 @@ export const setJobTitleData = (
 
 export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
   dispatch,
-  getState
+  getState,
 ) => {
   if (
     groupSortBy !== getState().timeAndSalaryJobTitle.get('groupSortBy') ||
@@ -38,8 +38,8 @@ export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
         order,
         jobTitle,
         [],
-        null
-      )
+        null,
+      ),
     );
   }
 
@@ -60,7 +60,7 @@ export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
     group_sort_order: order,
   };
 
-  return fetchSearchJobTitle(opt)
+  return fetchSearchJobTitle({ opt })
     .then(data => {
       dispatch(
         setJobTitleData(
@@ -69,8 +69,8 @@ export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
           order,
           jobTitle,
           data,
-          null
-        )
+          null,
+        ),
       );
     })
     .catch(err => {
@@ -81,8 +81,8 @@ export const queryJobTitle = ({ groupSortBy, order, jobTitle }) => (
           order,
           jobTitle,
           [],
-          err
-        )
+          err,
+        ),
       );
     });
 };

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -1,0 +1,20 @@
+// import fetchUtil from 'utils/fetchUtil';
+
+// const endpoint = '/auth';
+
+// const getAuthFacebook = () => fetchUtil(`${endpoint}/facebook`)('get');
+
+const mockAuthFacebook = accessToken =>
+  Promise.resolve(accessToken)
+    .then(console.log)
+    .then(() => ({
+      user: {
+        _id: 123,
+        facebook_id: 123,
+      },
+      token: 'iamtoken',
+    }));
+
+export default {
+  getAuthFacebook: mockAuthFacebook,
+};

--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -1,20 +1,10 @@
-// import fetchUtil from 'utils/fetchUtil';
+import fetchUtil from 'utils/fetchUtil';
 
-// const endpoint = '/auth';
+const endpoint = '/auth';
 
-// const getAuthFacebook = () => fetchUtil(`${endpoint}/facebook`)('get');
-
-const mockAuthFacebook = accessToken =>
-  Promise.resolve(accessToken)
-    .then(console.log)
-    .then(() => ({
-      user: {
-        _id: 123,
-        facebook_id: 123,
-      },
-      token: 'iamtoken',
-    }));
+const postAuthFacebook = accessToken =>
+  fetchUtil(`${endpoint}/facebook`)('post', { access_token: accessToken });
 
 export default {
-  getAuthFacebook: mockAuthFacebook,
+  postAuthFacebook,
 };

--- a/src/apis/campaignInfoApi.js
+++ b/src/apis/campaignInfoApi.js
@@ -59,3 +59,7 @@ export const fetchCampaignList = () =>
       ],
     },
   ]);
+
+export default {
+  fetchCampaignList,
+};

--- a/src/apis/campaignInfoApi.js
+++ b/src/apis/campaignInfoApi.js
@@ -59,5 +59,3 @@ export const fetchCampaignList = () =>
       ],
     },
   ]);
-
-export const foo = 1;

--- a/src/apis/companySearchApi.js
+++ b/src/apis/companySearchApi.js
@@ -5,3 +5,5 @@ const endpoint = '/companies/search';
 
 export const getCompaniesSearch = ({ key }) =>
   fetchUtil(`${endpoint}?${qs.stringify({ key })}`)('get');
+
+export default { getCompaniesSearch };

--- a/src/apis/companySearchApi.js
+++ b/src/apis/companySearchApi.js
@@ -3,5 +3,5 @@ import qs from 'qs';
 
 const endpoint = '/companies/search';
 
-export const getCompaniesSearch = key =>
+export const getCompaniesSearch = ({ key }) =>
   fetchUtil(`${endpoint}?${qs.stringify({ key })}`)('get');

--- a/src/apis/companySearchApi.js
+++ b/src/apis/companySearchApi.js
@@ -5,4 +5,3 @@ const endpoint = '/companies/search';
 
 export const getCompaniesSearch = key =>
   fetchUtil(`${endpoint}?${qs.stringify({ key })}`)('get');
-export const foo = 1;

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -76,6 +76,9 @@ export const postReplyLikes = ({ id }) =>
 
 export const getExperience = ({ id }) => fetchUtil(`/experiences/${id}`)('GET');
 
+export const newExperienceSearchBy = ({ body }) =>
+  fetchUtil('/graphql')('POST', body);
+
 export default {
   getExperience,
   getExperiencesRecommended,
@@ -86,4 +89,5 @@ export default {
   postExperienceLikes,
   deleteReplyLikes,
   postReplyLikes,
+  newExperienceSearchBy,
 };

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -56,3 +56,9 @@ export const getExperienceReply = options => {
 
   return fetchUtil(queryString ? `${url}?${queryString}` : url)('GET');
 };
+
+export default {
+  getExperiencesRecommended,
+  getExperiences,
+  getExperienceReply,
+};

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -57,8 +57,33 @@ export const getExperienceReply = options => {
   return fetchUtil(queryString ? `${url}?${queryString}` : url)('GET');
 };
 
+export const postExperienceReply = ({ id, comment }) =>
+  fetchUtil(`/experiences/${id}/replies`)('POST', {
+    content: comment,
+  });
+
+export const deleteExperienceLikes = ({ id }) =>
+  fetchUtil(`/experiences/${id}/likes`)('DELETE');
+
+export const postExperienceLikes = ({ id }) =>
+  fetchUtil(`/experiences/${id}/likes`)('POST');
+
+export const deleteReplyLikes = ({ id }) =>
+  fetchUtil(`/replies/${id}/likes`)('DELETE');
+
+export const postReplyLikes = ({ id }) =>
+  fetchUtil(`/replies/${id}/likes`)('POST');
+
+export const getExperience = ({ id }) => fetchUtil(`/experiences/${id}`)('GET');
+
 export default {
+  getExperience,
   getExperiencesRecommended,
   getExperiences,
   getExperienceReply,
+  postExperienceReply,
+  deleteExperienceLikes,
+  postExperienceLikes,
+  deleteReplyLikes,
+  postReplyLikes,
 };

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -35,7 +35,19 @@ export const getExperiences = ({
   return fetchUtil(url)('GET');
 };
 
-export const getExperienceReply = (experienceId, start = 0, limit = 100) => {
+const getExperienceReplyOptions = {
+  start: 0,
+  limit: 100,
+};
+
+export const getExperienceReply = options => {
+  const finalOptions = {
+    ...getExperienceReplyOptions,
+    ...options,
+  };
+
+  const { experienceId, start, limit } = finalOptions;
+
   const url = `/experiences/${experienceId}/replies`;
   const queryString = qs.stringify({
     start,

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -74,10 +74,20 @@ export const deleteReplyLikes = ({ id }) =>
 export const postReplyLikes = ({ id }) =>
   fetchUtil(`/replies/${id}/likes`)('POST');
 
+const patchReply = ({ id, status }) =>
+  fetchUtil(`/replies/${id}`)('PATCH', {
+    status,
+  });
+
 export const getExperience = ({ id }) => fetchUtil(`/experiences/${id}`)('GET');
 
 export const newExperienceSearchBy = ({ body }) =>
   fetchUtil('/graphql')('POST', body);
+
+const patchExperience = ({ id, status }) =>
+  fetchUtil(`/experiences/${id}`)('PATCH', {
+    status,
+  });
 
 export default {
   getExperience,
@@ -90,4 +100,6 @@ export default {
   deleteReplyLikes,
   postReplyLikes,
   newExperienceSearchBy,
+  patchExperience,
+  patchReply,
 };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,0 +1,23 @@
+import campaignInfo from './campaignInfoApi';
+import companySearch from './companySearchApi';
+import experiences from './experiencesApi';
+import interviewExperiences from './interviewExperiencesApi';
+import jobTitleSearch from './jobTitleSearchApi';
+import laborRights from './laborRightsApi';
+import report from './reportApi';
+import reportsExperiences from './reportsExperiencesApi';
+import timeAndSalary from './timeAndSalaryApi';
+import workExperiences from './workExperiencesApi';
+
+export default {
+  campaignInfo,
+  companySearch,
+  experiences,
+  interviewExperiences,
+  jobTitleSearch,
+  laborRights,
+  report,
+  reportsExperiences,
+  timeAndSalary,
+  workExperiences,
+};

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -9,6 +9,7 @@ import reportsExperiences from './reportsExperiencesApi';
 import timeAndSalary from './timeAndSalaryApi';
 import workExperiences from './workExperiencesApi';
 import me from './me';
+import auth from './auth';
 
 export default {
   campaignInfo,
@@ -22,4 +23,5 @@ export default {
   timeAndSalary,
   workExperiences,
   me,
+  auth,
 };

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -8,6 +8,7 @@ import report from './reportApi';
 import reportsExperiences from './reportsExperiencesApi';
 import timeAndSalary from './timeAndSalaryApi';
 import workExperiences from './workExperiencesApi';
+import me from './me';
 
 export default {
   campaignInfo,
@@ -20,4 +21,5 @@ export default {
   reportsExperiences,
   timeAndSalary,
   workExperiences,
+  me,
 };

--- a/src/apis/interviewExperiencesApi.js
+++ b/src/apis/interviewExperiencesApi.js
@@ -4,3 +4,7 @@ const endpoint = '/interview_experiences';
 const fetch = fetchUtil(endpoint);
 
 export const postInterviewExperience = ({ body }) => fetch('post', body);
+
+export default {
+  postInterviewExperience,
+};

--- a/src/apis/interviewExperiencesApi.js
+++ b/src/apis/interviewExperiencesApi.js
@@ -3,4 +3,4 @@ import fetchUtil from 'utils/fetchUtil';
 const endpoint = '/interview_experiences';
 const fetch = fetchUtil(endpoint);
 
-export const postInterviewExperience = body => fetch('post', body);
+export const postInterviewExperience = ({ body }) => fetch('post', body);

--- a/src/apis/interviewExperiencesApi.js
+++ b/src/apis/interviewExperiencesApi.js
@@ -4,4 +4,3 @@ const endpoint = '/interview_experiences';
 const fetch = fetchUtil(endpoint);
 
 export const postInterviewExperience = body => fetch('post', body);
-export const foo = 1;

--- a/src/apis/jobTitleSearchApi.js
+++ b/src/apis/jobTitleSearchApi.js
@@ -3,5 +3,5 @@ import qs from 'qs';
 
 const endpoint = '/jobs/search';
 
-export const getJobTitlesSearch = key =>
+export const getJobTitlesSearch = ({ key }) =>
   fetchUtil(`${endpoint}?${qs.stringify({ key })}`)('get');

--- a/src/apis/jobTitleSearchApi.js
+++ b/src/apis/jobTitleSearchApi.js
@@ -5,3 +5,7 @@ const endpoint = '/jobs/search';
 
 export const getJobTitlesSearch = ({ key }) =>
   fetchUtil(`${endpoint}?${qs.stringify({ key })}`)('get');
+
+export default {
+  getJobTitlesSearch,
+};

--- a/src/apis/jobTitleSearchApi.js
+++ b/src/apis/jobTitleSearchApi.js
@@ -5,4 +5,3 @@ const endpoint = '/jobs/search';
 
 export const getJobTitlesSearch = key =>
   fetchUtil(`${endpoint}?${qs.stringify({ key })}`)('get');
-export const foo = 1;

--- a/src/apis/laborRightsApi.js
+++ b/src/apis/laborRightsApi.js
@@ -2,13 +2,10 @@ import fetchUtil from 'utils/fetchUtil';
 
 import { CONTENTFUL_API_HOST } from '../config';
 
-const fetchLaborRightsMetaList = () =>
-  fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
+const fetchLaborRightsMetaList = () => fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
 
 export default fetchLaborRightsMetaList;
 
-export const getEntries = () =>
-  fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
+export const getEntries = () => fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
 
-export const getEntry = entryId =>
-  fetchUtil(`/entries/${entryId}`, CONTENTFUL_API_HOST)('GET');
+export const getEntry = entryId => fetchUtil(`/entries/${entryId}`, CONTENTFUL_API_HOST)('GET');

--- a/src/apis/laborRightsApi.js
+++ b/src/apis/laborRightsApi.js
@@ -2,13 +2,13 @@ import fetchUtil from 'utils/fetchUtil';
 
 import { CONTENTFUL_API_HOST } from '../config';
 
-const fetchLaborRightsMetaList = () =>
-  fetchUtil('/entries', { apiHost: CONTENTFUL_API_HOST })('GET');
-
-export default fetchLaborRightsMetaList;
-
 export const getEntries = () =>
   fetchUtil('/entries', { apiHost: CONTENTFUL_API_HOST })('GET');
 
 export const getEntry = ({ entryId }) =>
   fetchUtil(`/entries/${entryId}`, { apiHost: CONTENTFUL_API_HOST })('GET');
+
+export default {
+  getEntries,
+  getEntry,
+};

--- a/src/apis/laborRightsApi.js
+++ b/src/apis/laborRightsApi.js
@@ -10,5 +10,5 @@ export default fetchLaborRightsMetaList;
 export const getEntries = () =>
   fetchUtil('/entries', { apiHost: CONTENTFUL_API_HOST })('GET');
 
-export const getEntry = entryId =>
+export const getEntry = ({ entryId }) =>
   fetchUtil(`/entries/${entryId}`, { apiHost: CONTENTFUL_API_HOST })('GET');

--- a/src/apis/laborRightsApi.js
+++ b/src/apis/laborRightsApi.js
@@ -2,10 +2,13 @@ import fetchUtil from 'utils/fetchUtil';
 
 import { CONTENTFUL_API_HOST } from '../config';
 
-const fetchLaborRightsMetaList = () => fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
+const fetchLaborRightsMetaList = () =>
+  fetchUtil('/entries', { apiHost: CONTENTFUL_API_HOST })('GET');
 
 export default fetchLaborRightsMetaList;
 
-export const getEntries = () => fetchUtil('/entries', CONTENTFUL_API_HOST)('GET');
+export const getEntries = () =>
+  fetchUtil('/entries', { apiHost: CONTENTFUL_API_HOST })('GET');
 
-export const getEntry = entryId => fetchUtil(`/entries/${entryId}`, CONTENTFUL_API_HOST)('GET');
+export const getEntry = entryId =>
+  fetchUtil(`/entries/${entryId}`, { apiHost: CONTENTFUL_API_HOST })('GET');

--- a/src/apis/me.js
+++ b/src/apis/me.js
@@ -1,0 +1,11 @@
+import fetchUtil from 'utils/fetchUtil';
+
+const getMeExperiences = () => fetchUtil('/me/experiences')('GET');
+const getMeWorkings = () => fetchUtil('/me/workings')('GET');
+const getMeReplies = () => fetchUtil('/me/replies')('GET');
+
+export default {
+  getMeExperiences,
+  getMeWorkings,
+  getMeReplies,
+};

--- a/src/apis/reportApi.js
+++ b/src/apis/reportApi.js
@@ -3,5 +3,3 @@ import R from 'ramda';
 
 export const getReports = id =>
   fetchUtil(`/experiences/${id}/reports`)('GET').then(R.prop('reports'));
-
-export const foo = 1;

--- a/src/apis/reportApi.js
+++ b/src/apis/reportApi.js
@@ -3,3 +3,7 @@ import R from 'ramda';
 
 export const getReports = ({ id }) =>
   fetchUtil(`/experiences/${id}/reports`)('GET').then(R.prop('reports'));
+
+export default {
+  getReports,
+};

--- a/src/apis/reportApi.js
+++ b/src/apis/reportApi.js
@@ -1,5 +1,5 @@
 import fetchUtil from 'utils/fetchUtil';
 import R from 'ramda';
 
-export const getReports = id =>
+export const getReports = ({ id }) =>
   fetchUtil(`/experiences/${id}/reports`)('GET').then(R.prop('reports'));

--- a/src/apis/reportsExperiencesApi.js
+++ b/src/apis/reportsExperiencesApi.js
@@ -4,4 +4,3 @@ const getEndpoint = id => `/experiences/${id}/reports`;
 const fetch = id => fetchUtil(getEndpoint(id));
 
 export const postExperiencesReports = (id, body) => fetch(id)('post', body);
-export const foo = 1;

--- a/src/apis/reportsExperiencesApi.js
+++ b/src/apis/reportsExperiencesApi.js
@@ -4,3 +4,5 @@ const getEndpoint = id => `/experiences/${id}/reports`;
 const fetch = id => fetchUtil(getEndpoint(id));
 
 export const postExperiencesReports = ({ id, body }) => fetch(id)('post', body);
+
+export default { postExperiencesReports };

--- a/src/apis/reportsExperiencesApi.js
+++ b/src/apis/reportsExperiencesApi.js
@@ -3,4 +3,4 @@ import fetchUtil from 'utils/fetchUtil';
 const getEndpoint = id => `/experiences/${id}/reports`;
 const fetch = id => fetchUtil(getEndpoint(id));
 
-export const postExperiencesReports = (id, body) => fetch(id)('post', body);
+export const postExperiencesReports = ({ id, body }) => fetch(id)('post', body);

--- a/src/apis/timeAndSalaryApi.js
+++ b/src/apis/timeAndSalaryApi.js
@@ -31,3 +31,14 @@ export const fetchSearchJobTitle = ({ opt }) =>
   )('GET');
 
 export const postWorkings = ({ body }) => fetchUtil(endpoint)('post', body);
+
+export default {
+  fetchCompanyCandidates,
+  fetchJobTitleCandidates,
+  fetchTimeAndSalary,
+  fetchTimeAndSalaryExtreme,
+  fetchCampaignTimeAndSalary,
+  fetchSearchCompany,
+  fetchSearchJobTitle,
+  postWorkings,
+};

--- a/src/apis/timeAndSalaryApi.js
+++ b/src/apis/timeAndSalaryApi.js
@@ -32,6 +32,11 @@ export const fetchSearchJobTitle = ({ opt }) =>
 
 export const postWorkings = ({ body }) => fetchUtil(endpoint)('post', body);
 
+const patchWorking = ({ id, status }) =>
+  fetchUtil(`/workings/${id}`)('PATCH', {
+    status,
+  });
+
 export default {
   fetchCompanyCandidates,
   fetchJobTitleCandidates,
@@ -41,4 +46,5 @@ export default {
   fetchSearchCompany,
   fetchSearchJobTitle,
   postWorkings,
+  patchWorking,
 };

--- a/src/apis/timeAndSalaryApi.js
+++ b/src/apis/timeAndSalaryApi.js
@@ -3,31 +3,31 @@ import qs from 'qs';
 
 const endpoint = '/workings';
 
-export const fetchCompanyCandidates = key =>
+export const fetchCompanyCandidates = ({ key }) =>
   fetchUtil(`${endpoint}/companies/search?${qs.stringify({ key })}`)('GET');
 
-export const fetchJobTitleCandidates = key =>
+export const fetchJobTitleCandidates = ({ key }) =>
   fetchUtil(`${endpoint}/jobs/search?${qs.stringify({ key })}`)('GET');
 
-export const fetchTimeAndSalary = opt =>
+export const fetchTimeAndSalary = ({ opt }) =>
   fetchUtil(`${endpoint}?${qs.stringify(opt)}`)('GET');
 
-export const fetchTimeAndSalaryExtreme = opt =>
+export const fetchTimeAndSalaryExtreme = ({ opt }) =>
   fetchUtil(`${endpoint}/extreme?${qs.stringify(opt)}`)('GET');
 
-export const fetchCampaignTimeAndSalary = (campaignName, opt) =>
+export const fetchCampaignTimeAndSalary = ({ campaignName, opt }) =>
   fetchUtil(`${endpoint}/campaigns/${campaignName}?${qs.stringify(opt)}`)(
-    'GET'
+    'GET',
   );
 
-export const fetchSearchCompany = opt =>
+export const fetchSearchCompany = ({ opt }) =>
   fetchUtil(
-    `${endpoint}/search_by/company/group_by/company?${qs.stringify(opt)}`
+    `${endpoint}/search_by/company/group_by/company?${qs.stringify(opt)}`,
   )('GET');
 
-export const fetchSearchJobTitle = opt =>
+export const fetchSearchJobTitle = ({ opt }) =>
   fetchUtil(
-    `${endpoint}/search_by/job_title/group_by/company?${qs.stringify(opt)}`
+    `${endpoint}/search_by/job_title/group_by/company?${qs.stringify(opt)}`,
   )('GET');
 
-export const postWorkings = body => fetchUtil(endpoint)('post', body);
+export const postWorkings = ({ body }) => fetchUtil(endpoint)('post', body);

--- a/src/apis/workExperiencesApi.js
+++ b/src/apis/workExperiencesApi.js
@@ -4,4 +4,3 @@ const endpoint = '/work_experiences';
 const fetch = fetchUtil(endpoint);
 
 export const postWorkExperience = body => fetch('post', body);
-export const foo = 1;

--- a/src/apis/workExperiencesApi.js
+++ b/src/apis/workExperiencesApi.js
@@ -4,3 +4,7 @@ const endpoint = '/work_experiences';
 const fetch = fetchUtil(endpoint);
 
 export const postWorkExperience = ({ body }) => fetch('post', body);
+
+export default {
+  postWorkExperience,
+};

--- a/src/apis/workExperiencesApi.js
+++ b/src/apis/workExperiencesApi.js
@@ -3,4 +3,4 @@ import fetchUtil from 'utils/fetchUtil';
 const endpoint = '/work_experiences';
 const fetch = fetchUtil(endpoint);
 
-export const postWorkExperience = body => fetch('post', body);
+export const postWorkExperience = ({ body }) => fetch('post', body);

--- a/src/client.js
+++ b/src/client.js
@@ -5,8 +5,8 @@ import { fromJS } from 'immutable';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ScrollContext } from 'react-router-scroll-4';
-import { PersistGate } from 'redux-persist/integration/react';
-import { persistStore } from 'redux-persist';
+// import { PersistGate } from 'redux-persist/integration/react';
+// import { persistStore } from 'redux-persist';
 
 import initSentry from 'utils/sentryUtil';
 import Root from './components/Root';
@@ -34,19 +34,19 @@ const preloadedState = parseState(window);
 
 const history = createHistory();
 const store = configureStore(preloadedState, history);
-const persistor = persistStore(store);
+// const persistor = persistStore(store);
 
 hydrate(
   <Provider store={store}>
-    <PersistGate loading={null} persistor={persistor}>
-      <Router>
-        <ScrollContext>
-          <Root />
-        </ScrollContext>
-      </Router>
-    </PersistGate>
+    {/* <PersistGate loading={null} persistor={persistor}> */}
+    <Router>
+      <ScrollContext>
+        <Root />
+      </ScrollContext>
+    </Router>
+    {/* </PersistGate> */}
   </Provider>,
-  document.getElementById('root')
+  document.getElementById('root'),
 );
 
 if (module.hot) {
@@ -59,7 +59,7 @@ if (module.hot) {
           </ScrollContext>
         </Router>
       </Provider>,
-      document.getElementById('root')
+      document.getElementById('root'),
     );
   });
 }

--- a/src/client.js
+++ b/src/client.js
@@ -5,6 +5,9 @@ import { fromJS } from 'immutable';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { ScrollContext } from 'react-router-scroll-4';
+import { PersistGate } from 'redux-persist/integration/react';
+import { persistStore } from 'redux-persist';
+
 import initSentry from 'utils/sentryUtil';
 import Root from './components/Root';
 import configureStore from './store/configureStore';
@@ -31,14 +34,17 @@ const preloadedState = parseState(window);
 
 const history = createHistory();
 const store = configureStore(preloadedState, history);
+const persistor = persistStore(store);
 
 hydrate(
   <Provider store={store}>
-    <Router>
-      <ScrollContext>
-        <Root />
-      </ScrollContext>
-    </Router>
+    <PersistGate loading={null} persistor={persistor}>
+      <Router>
+        <ScrollContext>
+          <Root />
+        </ScrollContext>
+      </Router>
+    </PersistGate>
   </Provider>,
   document.getElementById('root')
 );

--- a/src/components/ExperienceDetail/ReactionZone/ReportInspectModal.js
+++ b/src/components/ExperienceDetail/ReactionZone/ReportInspectModal.js
@@ -19,7 +19,7 @@ const store = compose(
   withHandlers({
     fetchReports: ({ setStatus, setReports }) => id => {
       setStatus(fetchingStatus.FETCHING);
-      getReports(id)
+      getReports({ id })
         .then(reports => {
           setStatus(fetchingStatus.FETCHED);
           setReports(reports);
@@ -29,7 +29,7 @@ const store = compose(
           setReports([]);
         });
     },
-  })
+  }),
 );
 
 const queryData = lifecycle({
@@ -99,7 +99,7 @@ ReportInspectModal.propTypes = {
 
 const hoc = compose(
   store,
-  queryData
+  queryData,
 );
 
 export default hoc(ReportInspectModal);

--- a/src/components/ExperienceDetail/ReportForm/ReportForm.js
+++ b/src/components/ExperienceDetail/ReportForm/ReportForm.js
@@ -57,13 +57,16 @@ class ReportForm extends PureComponent {
     const valid = validReasomForm(this.state);
 
     if (valid) {
-      return postExperiencesReports(id, handleToApiParams(this.state))
+      return postExperiencesReports({
+        id,
+        body: handleToApiParams(this.state),
+      })
         .then(close)
         .then(onSuccess)
         .catch(e =>
           onApiError({
             message: e.message,
-          })
+          }),
         );
     }
 

--- a/src/components/Me/index.js
+++ b/src/components/Me/index.js
@@ -28,10 +28,7 @@ class Me extends Component {
     this.props.fetchMyWorkings();
     this.props.fetchMyReplies();
     const { getLoginStatus, FB, getMe } = this.props;
-    FB &&
-      getLoginStatus(FB)
-        .then(() => getMe(FB))
-        .catch(() => {});
+    FB && getLoginStatus(FB).then(() => getMe(FB));
   }
 
   componentDidUpdate(prevProps) {
@@ -39,7 +36,7 @@ class Me extends Component {
       // FB instance changed
       const { getLoginStatus, FB } = this.props;
 
-      FB && getLoginStatus(FB).catch(() => {});
+      FB && getLoginStatus(FB);
     }
 
     if (
@@ -47,13 +44,13 @@ class Me extends Component {
       this.props.auth.get('status') === authStatus.CONNECTED
     ) {
       const { getMe, FB } = this.props;
-      FB && getMe(FB).catch(() => {});
+      FB && getMe(FB);
     }
   }
 
   login = () => {
     const { login, FB } = this.props;
-    FB && login(FB).catch(() => {});
+    FB && login(FB);
   };
 
   render() {

--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -144,15 +144,15 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
       .get(campaignName)
       .toJS();
     const valid4 = campaignExtendedFormCheck(extraFields)(
-      getCampaignExtendedForm(extraFields)(this.state)
+      getCampaignExtendedForm(extraFields)(this.state),
     );
 
     if (valid && (valid2 || valid3) && valid4) {
-      const p = postWorkings(
-        portTimeSalaryFormToRequestFormat(
-          getCampaignTimeAndSalaryForm(extraFields, defaultContent)(this.state)
-        )
-      );
+      const p = postWorkings({
+        body: portTimeSalaryFormToRequestFormat(
+          getCampaignTimeAndSalaryForm(extraFields, defaultContent)(this.state),
+        ),
+      });
 
       return p.then(
         response => {
@@ -175,7 +175,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
               buttonText="查看最新工時、薪資"
               buttonClick={() => {
                 window.location.replace(
-                  `/time-and-salary/campaigns/${campaignName}/latest`
+                  `/time-and-salary/campaigns/${campaignName}/latest`,
                 );
               }}
             />
@@ -190,7 +190,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
           return ({ buttonClick }) => (
             <FailFeedback info={error.message} buttonClick={buttonClick} />
           );
-        }
+        },
       );
     }
     this.handleState('submitted')(true);
@@ -308,7 +308,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
           {
             property: 'og:url',
             content: formatCanonicalPath(
-              `/share/time-and-salary/campaign/${campaignName}`
+              `/share/time-and-salary/campaign/${campaignName}`,
             ),
           },
           { property: 'og:image', content: ogImgUrl },
@@ -317,7 +317,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
           {
             rel: 'canonical',
             href: formatCanonicalPath(
-              `/share/time-and-salary/campaign/${campaignName}`
+              `/share/time-and-salary/campaign/${campaignName}`,
             ),
           },
         ],

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -36,7 +36,7 @@ import FailFeedback from '../common/FailFeedback';
 const createSection = id => (
   subtitle,
   placeholder = '',
-  titlePlaceholder = '段落標題，例：面試方式'
+  titlePlaceholder = '段落標題，例：面試方式',
 ) => {
   const section = {
     id,
@@ -122,7 +122,7 @@ class InterviewForm extends React.Component {
 
     try {
       defaultFromDraft = JSON.parse(
-        localStorage.getItem(LS_INTERVIEW_FORM_KEY)
+        localStorage.getItem(LS_INTERVIEW_FORM_KEY),
       );
     } catch (error) {
       defaultFromDraft = null;
@@ -145,7 +145,7 @@ class InterviewForm extends React.Component {
     if (valid) {
       localStorage.removeItem(LS_INTERVIEW_FORM_KEY);
       const p = postInterviewExperience(
-        portInterviewFormToRequestFormat(getInterviewForm(this.state))
+        portInterviewFormToRequestFormat(getInterviewForm(this.state)),
       );
       return p.then(
         response => {
@@ -178,7 +178,7 @@ class InterviewForm extends React.Component {
           return ({ buttonClick }) => (
             <FailFeedback info={error.message} buttonClick={buttonClick} />
           );
-        }
+        },
       );
     }
     this.handleState('submitted')(true);
@@ -234,7 +234,7 @@ class InterviewForm extends React.Component {
           [id]: createBlock[blockKey](id)(
             subtitle,
             placeholder,
-            titlePlaceholder
+            titlePlaceholder,
           ),
         },
       }));
@@ -269,9 +269,9 @@ class InterviewForm extends React.Component {
 
   handleSubmit() {
     localStorage.removeItem(LS_INTERVIEW_FORM_KEY);
-    return postInterviewExperience(
-      portInterviewFormToRequestFormat(getInterviewForm(this.state))
-    );
+    return postInterviewExperience({
+      body: portInterviewFormToRequestFormat(getInterviewForm(this.state)),
+    });
   }
 
   render() {

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -144,9 +144,9 @@ class InterviewForm extends React.Component {
 
     if (valid) {
       localStorage.removeItem(LS_INTERVIEW_FORM_KEY);
-      const p = postInterviewExperience(
-        portInterviewFormToRequestFormat(getInterviewForm(this.state)),
-      );
+      const p = postInterviewExperience({
+        body: portInterviewFormToRequestFormat(getInterviewForm(this.state)),
+      });
       return p.then(
         response => {
           const experienceId = response.experience._id;

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -87,7 +87,7 @@ class TimeSalaryForm extends React.PureComponent {
 
     try {
       defaultFromDraft = JSON.parse(
-        localStorage.getItem(LS_TIME_SALARY_FORM_KEY)
+        localStorage.getItem(LS_TIME_SALARY_FORM_KEY),
       );
     } catch (error) {
       defaultFromDraft = null;
@@ -112,9 +112,11 @@ class TimeSalaryForm extends React.PureComponent {
     if (valid && (valid2 || valid3)) {
       localStorage.removeItem(LS_TIME_SALARY_FORM_KEY);
 
-      const p = postWorkings(
-        portTimeSalaryFormToRequestFormat(getTimeAndSalaryForm(this.state))
-      );
+      const p = postWorkings({
+        body: portTimeSalaryFormToRequestFormat(
+          getTimeAndSalaryForm(this.state),
+        ),
+      });
 
       return p.then(
         response => {
@@ -150,7 +152,7 @@ class TimeSalaryForm extends React.PureComponent {
           return ({ buttonClick }) => (
             <FailFeedback info={error.message} buttonClick={buttonClick} />
           );
-        }
+        },
       );
     }
     this.handleState('submitted')(true);

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -37,7 +37,7 @@ import FailFeedback from '../common/FailFeedback';
 const createSection = id => (
   subtitle,
   placeholder = '',
-  titlePlaceholder = '段落標題，例：實際工作內容'
+  titlePlaceholder = '段落標題，例：實際工作內容',
 ) => {
   const section = {
     id,
@@ -112,7 +112,7 @@ class WorkExperiencesForm extends React.Component {
 
     try {
       defaultFromDraft = JSON.parse(
-        localStorage.getItem(LS_WORK_EXPERIENCES_FORM_KEY)
+        localStorage.getItem(LS_WORK_EXPERIENCES_FORM_KEY),
       );
     } catch (error) {
       defaultFromDraft = null;
@@ -132,12 +132,12 @@ class WorkExperiencesForm extends React.Component {
 
   onSubmit() {
     const valid = workExperiencesFormCheck(
-      propsWorkExperiencesForm(this.state)
+      propsWorkExperiencesForm(this.state),
     );
 
     if (valid) {
       localStorage.removeItem(LS_WORK_EXPERIENCES_FORM_KEY);
-      const p = postWorkExperience(workExperiencesToBody(this.state));
+      const p = postWorkExperience({ body: workExperiencesToBody(this.state) });
       return p.then(
         response => {
           const experienceId = response.experience._id;
@@ -169,7 +169,7 @@ class WorkExperiencesForm extends React.Component {
           return ({ buttonClick }) => (
             <FailFeedback info={error.message} buttonClick={buttonClick} />
           );
-        }
+        },
       );
     }
     this.handleState('submitted')(true);
@@ -225,7 +225,7 @@ class WorkExperiencesForm extends React.Component {
           [id]: createBlock.sections(id)(
             subtitle,
             placeholder,
-            titlePlaceholder
+            titlePlaceholder,
           ),
         },
       }));

--- a/src/components/ShareExperience/common/CompanyQuery.js
+++ b/src/components/ShareExperience/common/CompanyQuery.js
@@ -26,12 +26,12 @@ class CompanyQuery extends React.Component {
 
   search = debounce((e, value) => {
     if (value) {
-      return getCompaniesSearch(value)
+      return getCompaniesSearch({ key: value })
         .then(
           r =>
             Array.isArray(r)
               ? this.handleAutocompleteItems(r.map(mapToAutocompleteList))
-              : this.handleAutocompleteItems([])
+              : this.handleAutocompleteItems([]),
         )
         .catch(() => this.handleAutocompleteItems([]));
     }

--- a/src/components/ShareExperience/common/JobTitle.js
+++ b/src/components/ShareExperience/common/JobTitle.js
@@ -26,12 +26,12 @@ class JobTitle extends React.Component {
 
   search = debounce((e, value) => {
     if (value) {
-      return getJobTitlesSearch(value)
+      return getJobTitlesSearch({ key: value })
         .then(
           r =>
             Array.isArray(r)
               ? this.handleAutocompleteItems(r.map(mapToAutocompleteList))
-              : this.handleAutocompleteItems([])
+              : this.handleAutocompleteItems([]),
         )
         .catch(() => this.handleAutocompleteItems([]));
     }

--- a/src/components/TimeAndSalary/SearchBar.js
+++ b/src/components/TimeAndSalary/SearchBar.js
@@ -77,18 +77,18 @@ class SearchBar extends Component {
   fetchCandidates = value => {
     const { searchType } = this.state;
     if (searchType === 'company') {
-      return fetchCompanyCandidates(value).then(r =>
+      return fetchCompanyCandidates({ key: value }).then(r =>
         r.map(({ _id: { name } }) => ({
           label: name,
           value: name,
-        }))
+        })),
       );
     }
-    return fetchJobTitleCandidates(value).then(r =>
+    return fetchJobTitleCandidates({ key: value }).then(r =>
       r.map(({ _id: name }) => ({
         label: name,
         value: name,
-      }))
+      })),
     );
   };
 
@@ -118,8 +118,8 @@ class SearchBar extends Component {
     const { searchType, keyword } = this.state;
     this.props.history.push(
       `/time-and-salary/${searchType}/${encodeURIComponent(
-        keyword
-      )}/work-time-dashboard`
+        keyword,
+      )}/work-time-dashboard`,
     );
 
     ReactPixel.track('Search', {
@@ -134,7 +134,7 @@ class SearchBar extends Component {
         className={cn(
           styles.section,
           styles.showSearchbar,
-          searchBarStyles.searchbar
+          searchBarStyles.searchbar,
         )}
         onSubmit={this.handleSubmit}
       >

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -11,4 +11,5 @@ module.exports = {
   PIXEL_ID: process.env.RAZZLE_PIXEL_ID || '603414113402034',
   SENTRY_DSN: process.env.RAZZLE_SENTRY_DSN,
   GIT_SHA1: process.env.RAZZLE_GIT_SHA1,
+  PERSIST_KEY: process.env.PERSIST_KEY || 'goodjob',
 };

--- a/src/containers/App/Header/index.js
+++ b/src/containers/App/Header/index.js
@@ -4,18 +4,26 @@ import { withRouter } from 'react-router-dom';
 
 import { withFB } from 'common/facebook';
 import Header from '../../../components/App/Header';
-import { login, logout, getLoginStatus, getMe } from '../../../actions/auth';
+import {
+  loginWithFB,
+  logout,
+  getLoginStatus,
+  getMe,
+} from '../../../actions/auth';
 
 const mapStateToProps = state => ({
   auth: state.auth,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ login, logout, getLoginStatus, getMe }, dispatch);
+  bindActionCreators(
+    { login: loginWithFB, logout, getLoginStatus, getMe },
+    dispatch,
+  );
 
 export default withRouter(
   connect(
     mapStateToProps,
-    mapDispatchToProps
-  )(withFB(Header))
+    mapDispatchToProps,
+  )(withFB(Header)),
 );

--- a/src/containers/ExperienceDetail/CommentBlock.js
+++ b/src/containers/ExperienceDetail/CommentBlock.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import CommentBlock from '../../components/ExperienceDetail/MessageBoard/CommentBlock';
-import { login } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 
 import { statusSelector } from '../../selectors/authSelector';
 
@@ -11,9 +11,10 @@ const mapStateToProps = state => ({
   authStatus: statusSelector(state),
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ login }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login: loginWithFB }, dispatch);
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(CommentBlock));

--- a/src/containers/ExperienceDetail/MessageBoard.js
+++ b/src/containers/ExperienceDetail/MessageBoard.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import MessageBoard from '../../components/ExperienceDetail/MessageBoard';
-import { login } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 
 import { statusSelector } from '../../selectors/authSelector';
 
@@ -11,9 +11,10 @@ const mapStateToProps = state => ({
   authStatus: statusSelector(state),
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ login }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login: loginWithFB }, dispatch);
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(MessageBoard));

--- a/src/containers/ExperienceDetail/ReactionZone.js
+++ b/src/containers/ExperienceDetail/ReactionZone.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import ReactionZone from '../../components/ExperienceDetail/ReactionZone';
-import { login } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 
 import { statusSelector } from '../../selectors/authSelector';
 
@@ -11,9 +11,10 @@ const mapStateToProps = state => ({
   authStatus: statusSelector(state),
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ login }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login: loginWithFB }, dispatch);
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(ReactionZone));

--- a/src/containers/ExperienceDetail/ReportFormContainer.js
+++ b/src/containers/ExperienceDetail/ReportFormContainer.js
@@ -3,15 +3,16 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import ReportForm from '../../components/ExperienceDetail/ReportForm/ReportForm';
-import { login } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 
 const mapStateToProps = state => ({
   auth: state.auth,
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ login }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login: loginWithFB }, dispatch);
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(ReportForm));

--- a/src/containers/Me/index.js
+++ b/src/containers/Me/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import Me from '../../components/Me';
-import { login, getLoginStatus, getMe } from '../../actions/auth';
+import { loginWithFB, getLoginStatus, getMe } from '../../actions/auth';
 import * as MyActions from '../../actions/me';
 
 const mapStateToProps = state => ({
@@ -12,9 +12,12 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators({ login, getLoginStatus, getMe, ...MyActions }, dispatch);
+  bindActionCreators(
+    { login: loginWithFB, getLoginStatus, getMe, ...MyActions },
+    dispatch,
+  );
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(Me));

--- a/src/containers/PermissionBlock/CallToLoginShareButtonContainer.js
+++ b/src/containers/PermissionBlock/CallToLoginShareButtonContainer.js
@@ -3,15 +3,16 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import CallToLoginShareButton from 'common/PermissionBlock/CallToLoginShareButton';
-import { login } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 
 const mapStateToProps = state => ({
   auth: state.auth,
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ login }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login: loginWithFB }, dispatch);
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(CallToLoginShareButton));

--- a/src/containers/ShareExperience/SubmitAreaContainer.js
+++ b/src/containers/ShareExperience/SubmitAreaContainer.js
@@ -3,15 +3,16 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import SubmitArea from '../../components/ShareExperience/common/SubmitArea';
-import { login } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 
 const mapStateToProps = state => ({
   auth: state.auth,
 });
 
-const mapDispatchToProps = dispatch => bindActionCreators({ login }, dispatch);
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ login: loginWithFB }, dispatch);
 
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  mapDispatchToProps,
 )(withFB(SubmitArea));

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,6 +1,7 @@
 import { fromJS } from 'immutable';
 
 import createReducer from 'utils/createReducer';
+import { saveToken } from 'utils/tokenUtil';
 import { SET_LOGIN, SET_USER } from '../actions/auth';
 
 import authStatus from '../constants/authStatus';
@@ -14,8 +15,12 @@ const preloadedState = fromJS({
 });
 
 const auth = createReducer(preloadedState, {
-  [SET_LOGIN]: (state, { status, token }) =>
-    state.set('status', status).set('token', token),
+  [SET_LOGIN]: (state, { status, token }) => {
+    if (token) {
+      saveToken(token);
+    }
+    return state.set('status', status).set('token', token);
+  },
   [SET_USER]: (state, { name }) => state.setIn(['user', 'name'], name),
 });
 

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,7 +1,6 @@
 import { fromJS } from 'immutable';
 
 import createReducer from 'utils/createReducer';
-import { saveToken } from 'utils/tokenUtil';
 import { SET_LOGIN, SET_USER } from '../actions/auth';
 
 import authStatus from '../constants/authStatus';
@@ -15,12 +14,8 @@ const preloadedState = fromJS({
 });
 
 const auth = createReducer(preloadedState, {
-  [SET_LOGIN]: (state, { status, token }) => {
-    if (token) {
-      saveToken(token);
-    }
-    return state.set('status', status).set('token', token);
-  },
+  [SET_LOGIN]: (state, { status, token }) =>
+    state.set('status', status).set('token', token),
   [SET_USER]: (state, { name }) => state.setIn(['user', 'name'], name),
 });
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux';
-import { persistReducer } from 'redux-persist';
-import storage from 'redux-persist/lib/storage';
-import immutableTransform from 'redux-persist-transform-immutable';
+// import { persistReducer } from 'redux-persist';
+// import storage from 'redux-persist/lib/storage';
+// import immutableTransform from 'redux-persist-transform-immutable';
 
 import auth from './auth';
 import experienceDetail from './experienceDetail';
@@ -16,14 +16,14 @@ import timeAndSalaryJobTitle from './timeAndSalaryJobTitle';
 import popularExperiences from './popularExperiences';
 import campaignInfo from './campaignInfo';
 import campaignTimeAndSalaryBoard from './campaignTimeAndSalaryBoard';
-import { PERSIST_KEY } from '../config';
+// import { PERSIST_KEY } from '../config';
 
-const persistConfig = {
-  key: PERSIST_KEY,
-  storage,
-  whitelist: ['auth'],
-  transforms: [immutableTransform()],
-};
+// const persistConfig = {
+//   key: PERSIST_KEY,
+//   storage,
+//   whitelist: [],
+//   transforms: [immutableTransform()],
+// };
 
 const rootReducer = combineReducers({
   auth,
@@ -41,4 +41,4 @@ const rootReducer = combineReducers({
   campaignTimeAndSalaryBoard,
 });
 
-export default persistReducer(persistConfig, rootReducer);
+export default rootReducer;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import { persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
+import immutableTransform from 'redux-persist-transform-immutable';
 
 import auth from './auth';
 import experienceDetail from './experienceDetail';
@@ -20,6 +21,7 @@ const persistConfig = {
   key: 'root',
   storage,
   whitelist: ['auth'],
+  transforms: [immutableTransform()],
 };
 
 const rootReducer = combineReducers({

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,6 @@
 import { combineReducers } from 'redux';
+import { persistReducer } from 'redux-persist';
+import storage from 'redux-persist/lib/storage';
 
 import auth from './auth';
 import experienceDetail from './experienceDetail';
@@ -13,6 +15,12 @@ import timeAndSalaryJobTitle from './timeAndSalaryJobTitle';
 import popularExperiences from './popularExperiences';
 import campaignInfo from './campaignInfo';
 import campaignTimeAndSalaryBoard from './campaignTimeAndSalaryBoard';
+
+const persistConfig = {
+  key: 'root',
+  storage,
+  whitelist: ['auth'],
+};
 
 const rootReducer = combineReducers({
   auth,
@@ -30,4 +38,4 @@ const rootReducer = combineReducers({
   campaignTimeAndSalaryBoard,
 });
 
-export default rootReducer;
+export default persistReducer(persistConfig, rootReducer);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -16,9 +16,10 @@ import timeAndSalaryJobTitle from './timeAndSalaryJobTitle';
 import popularExperiences from './popularExperiences';
 import campaignInfo from './campaignInfo';
 import campaignTimeAndSalaryBoard from './campaignTimeAndSalaryBoard';
+import { PERSIST_KEY } from '../config';
 
 const persistConfig = {
-  key: 'root',
+  key: PERSIST_KEY,
   storage,
   whitelist: ['auth'],
   transforms: [immutableTransform()],

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -1,5 +1,5 @@
 /* eslint-disable global-require */
-import { createStore, applyMiddleware } from 'redux';
+import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import createLogger from 'redux-logger';
 
@@ -10,11 +10,14 @@ const logger = createLogger({
   collapsed: true,
 });
 
+const composeEnhancers =
+  (global.window && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
+
 const configureStore = (preloadedState, history) => {
   const store = createStore(
     rootReducer,
     preloadedState,
-    applyMiddleware(thunk, logger)
+    composeEnhancers(applyMiddleware(thunk, logger))
   );
 
   if (module.hot) {

--- a/src/store/configureStore.dev.js
+++ b/src/store/configureStore.dev.js
@@ -2,6 +2,7 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
 import createLogger from 'redux-logger';
+import api from '../apis';
 
 import rootReducer from '../reducers';
 
@@ -17,7 +18,7 @@ const configureStore = (preloadedState, history) => {
   const store = createStore(
     rootReducer,
     preloadedState,
-    composeEnhancers(applyMiddleware(thunk, logger))
+    composeEnhancers(applyMiddleware(thunk.withExtraArgument({ api }), logger)),
   );
 
   if (module.hot) {

--- a/src/store/configureStore.prod.js
+++ b/src/store/configureStore.prod.js
@@ -2,12 +2,13 @@ import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 import { errorHandlingMiddleware } from './middlewares';
 import rootReducer from '../reducers';
+import api from '../apis';
 
 const configureStore = (preloadedState, history) =>
   createStore(
     rootReducer,
     preloadedState,
-    applyMiddleware(errorHandlingMiddleware, thunk)
+    applyMiddleware(errorHandlingMiddleware, thunk.withExtraArgument({ api })),
   );
 
 export default configureStore;

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -47,8 +47,20 @@ const checkStatus = response => {
   return response.json();
 };
 
-const fetchUtil = (token = getToken()) => (endpoint, apiHost = API_HOST) => (method, body) =>
-  fetch(
+const defaultOptions = {
+  apiHost: API_HOST,
+  token: getToken(),
+};
+
+const fetchUtil = (endpoint, options) => (method, body) => {
+  const finalOptions = {
+    ...defaultOptions,
+    ...options,
+  };
+
+  const { token, apiHost } = finalOptions;
+
+  return fetch(
     `${apiHost}${endpoint}`,
     optionsBuilder({
       token,
@@ -56,5 +68,6 @@ const fetchUtil = (token = getToken()) => (endpoint, apiHost = API_HOST) => (met
       method,
     }),
   ).then(checkStatus);
+};
 
 export default fetchUtil;

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -49,13 +49,15 @@ const checkStatus = response => {
 
 const defaultOptions = {
   apiHost: API_HOST,
-  token: getToken(),
+  token: null,
 };
 
 const fetchUtil = (endpoint, options) => (method, body) => {
   const finalOptions = {
     ...defaultOptions,
     ...options,
+    // FIXME: workaround before get it from store
+    token: getToken(),
   };
 
   const { token, apiHost } = finalOptions;

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -24,7 +24,7 @@ const removeContentType = headers => {
   return rest;
 };
 
-const optionsBuilder = body => method => token =>
+const optionsBuilder = ({ body, method, token }) =>
   body
     ? {
         method: method.toUpperCase(),

--- a/src/utils/fetchUtil.js
+++ b/src/utils/fetchUtil.js
@@ -24,16 +24,16 @@ const removeContentType = headers => {
   return rest;
 };
 
-const optionsBuilder = body => method =>
+const optionsBuilder = body => method => token =>
   body
     ? {
         method: method.toUpperCase(),
-        headers: headerBuilder(getToken()),
+        headers: headerBuilder(token),
         body: JSON.stringify(body),
       }
     : {
         method: method.toUpperCase(),
-        headers: removeContentType(headerBuilder(getToken())),
+        headers: removeContentType(headerBuilder(token)),
       };
 
 const checkStatus = response => {
@@ -47,9 +47,14 @@ const checkStatus = response => {
   return response.json();
 };
 
-const fetchUtil = (endpoint, apiHost = API_HOST) => (method, body) =>
-  fetch(`${apiHost}${endpoint}`, optionsBuilder(body)(method)).then(
-    checkStatus
-  );
+const fetchUtil = (token = getToken()) => (endpoint, apiHost = API_HOST) => (method, body) =>
+  fetch(
+    `${apiHost}${endpoint}`,
+    optionsBuilder({
+      token,
+      body,
+      method,
+    }),
+  ).then(checkStatus);
 
 export default fetchUtil;

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -1,17 +1,9 @@
-import { path } from 'ramda';
+const TOKEN_KEY_NAME = 'apiToken';
 
-const TOKEN_KEY_NAME = 'persist:goodjob';
+const checkSessionStorage = () => typeof sessionStorage !== 'undefined';
 
-const checkStorage = () => typeof localStorage !== 'undefined';
+export const saveToken = token =>
+  checkSessionStorage() ? sessionStorage.setItem(TOKEN_KEY_NAME, token) : null;
 
-export const getToken = () => {
-  // FIXME: remove this util
-  if (checkStorage()) {
-    const item = localStorage.getItem(TOKEN_KEY_NAME);
-    if (item) {
-      const localData = JSON.parse(JSON.parse(JSON.parse(item).auth));
-      return path(['data', 'token'])(localData);
-    }
-  }
-  return null;
-};
+export const getToken = () =>
+  checkSessionStorage() ? sessionStorage.getItem(TOKEN_KEY_NAME) : null;

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -6,10 +6,9 @@ const checkStorage = () => typeof localStorage !== 'undefined';
 
 export const getToken = () => {
   // FIXME: remove this util
-  if (checkStorage()) {
-    const localData = JSON.parse(
-      JSON.parse(JSON.parse(localStorage.getItem(TOKEN_KEY_NAME)).auth),
-    );
+  const item = localStorage.getItem(TOKEN_KEY_NAME);
+  if (checkStorage() && item) {
+    const localData = JSON.parse(JSON.parse(JSON.parse(item).auth));
     return path(['data', 'token'])(localData);
   }
   return null;

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -1,9 +1,16 @@
-const TOKEN_KEY_NAME = 'apiToken';
+import { path } from 'ramda';
 
-const checkSessionStorage = () => typeof sessionStorage !== 'undefined';
+const TOKEN_KEY_NAME = 'persist:goodjob';
 
-export const saveToken = token =>
-  checkSessionStorage() ? sessionStorage.setItem(TOKEN_KEY_NAME, token) : null;
+const checkStorage = () => typeof localStorage !== 'undefined';
 
-export const getToken = () =>
-  checkSessionStorage() ? sessionStorage.getItem(TOKEN_KEY_NAME) : null;
+export const getToken = () => {
+  // FIXME: remove this util
+  if (checkStorage()) {
+    const localData = JSON.parse(
+      JSON.parse(JSON.parse(localStorage.getItem(TOKEN_KEY_NAME)).auth),
+    );
+    return path(['data', 'token'])(localData);
+  }
+  return null;
+};

--- a/src/utils/tokenUtil.js
+++ b/src/utils/tokenUtil.js
@@ -6,10 +6,12 @@ const checkStorage = () => typeof localStorage !== 'undefined';
 
 export const getToken = () => {
   // FIXME: remove this util
-  const item = localStorage.getItem(TOKEN_KEY_NAME);
-  if (checkStorage() && item) {
-    const localData = JSON.parse(JSON.parse(JSON.parse(item).auth));
-    return path(['data', 'token'])(localData);
+  if (checkStorage()) {
+    const item = localStorage.getItem(TOKEN_KEY_NAME);
+    if (item) {
+      const localData = JSON.parse(JSON.parse(JSON.parse(item).auth));
+      return path(['data', 'token'])(localData);
+    }
   }
   return null;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,6 +5465,11 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
+jsan@^3.1.13:
+  version "3.1.13"
+  resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.13.tgz#4de8c7bf8d1cfcd020c313d438f930cec4b91d86"
+  integrity sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -8220,6 +8225,18 @@ redux-logger@^2.7.4:
   dependencies:
     deep-diff "0.3.4"
 
+redux-persist-transform-immutable@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/redux-persist-transform-immutable/-/redux-persist-transform-immutable-5.0.0.tgz#0ae277b4d8d662016f62af394df2572525ad6671"
+  integrity sha512-Gf7pNqHIVrCM459BzyqT25A8+8/PP6ce57kXY+PEgYnWn8jQRCAZaSNxw7T1eqKGXrJfICnMQ39RwehvMqlJMg==
+  dependencies:
+    remotedev-serialize "^0.1.0"
+
+redux-persist@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
+  integrity sha512-sSJAzNq7zka3qVHKce1hbvqf0Vf5DuTVm7dr4GtsqQVOexnrvbV47RWFiPxQ8fscnyiuWyD2O92DOxPl0tGCRg==
+
 redux-thunk@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
@@ -8308,6 +8325,13 @@ regjsparser@^0.1.4:
   integrity sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=
   dependencies:
     jsesc "~0.5.0"
+
+remotedev-serialize@^0.1.0:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.8.tgz#c99cb184e7f71a906162abc404be8ce33810205f"
+  integrity sha512-3YG/FDcOmiK22bl5oMRM8RRnbGrFEuPGjbcDG+z2xi5aQaNQNZ8lqoRnZTwXVfaZtutXuiAQOgPRrogzQk8edg==
+  dependencies:
+    jsan "^3.1.13"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
## 這個 PR 是？

* 重構了使用API 的方式，往後希望集中在action creator layer 引入並處理
* 承上，把API 傳入thunk 的dependencies 參數，便可封閉的在action creator 拿到。目前尚有一些component 直接從 `apis` 取得API Promise ，在把client side token 機制修改後會修掉
* login action creator --> loginWithFB action creator 
* 修改了fetchUtil 與API 的介面，為往後要直接在action creator 取得token in store 準備
* 往後不會再從任何storage 取得token ，storage 僅是備份，只有頁面開始時與store sync 一次的功能

## 我應該從何看起？
大體思路在上面有寫了，主要建議從 `fetchUtil` `actions/auth` 看，其他大多是因應介面改變，使用端的過改而以

## Questions: 

- 我需要更新 Packages 嗎？Yes ，但目前其實還不需要，不過我更新了package.json 
- 有哪些文件需要被更新嗎？ No

## 做了什麼

## 我應該如何手動測試？ 

- [ ] 成功登入
- [ ] 是否可以做出以下目前後端也改好的功能：發布面試經驗、回覆任何經驗文

## Issues will be solved in the next PR
* Save `auth` store to localStorage
* Get Token in action creator layer