### PR TITLE
Update/modal close on background tap

### DIFF
--- a/src/components/ExperienceDetail/ReactionZone/ReportInspectModal.js
+++ b/src/components/ExperienceDetail/ReactionZone/ReportInspectModal.js
@@ -58,6 +58,7 @@ const ReportInspectModal = ({
       isOpen={isOpen}
       close={() => toggleReportInspectModal(false)}
       hasClose
+      closableOnClickOutside
     >
       <Heading size="l" marginBottomS center>
         查看檢舉

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -88,6 +88,7 @@ class ExperienceDetail extends Component {
   state = {
     isModalOpen: false,
     modalType: '',
+    ModalClosableOnClickOutside: true,
   };
 
   componentDidMount() {
@@ -160,6 +161,12 @@ class ExperienceDetail extends Component {
       modalPayload,
     });
 
+  setModalClosableOnClickOutside = closableOnClickOutside => {
+    this.setState({
+      closableOnClickOutside,
+    });
+  };
+
   renderModalChildren = modalType => {
     const { modalPayload } = this.state;
 
@@ -169,20 +176,23 @@ class ExperienceDetail extends Component {
           <ReportFormContainer
             close={() => this.handleIsModalOpen(false)}
             id={experienceIdSelector(this.props)}
-            onApiError={pload =>
-              this.handleIsModalOpen(true, MODAL_TYPE.REPORT_API_ERROR, pload)
-            }
-            onSuccess={() =>
-              this.handleIsModalOpen(true, MODAL_TYPE.REPORT_SUCCESS)
-            }
+            onApiError={pload => {
+              this.setModalClosableOnClickOutside(false);
+              this.handleIsModalOpen(true, MODAL_TYPE.REPORT_API_ERROR, pload);
+            }}
+            onSuccess={() => {
+              this.setModalClosableOnClickOutside(true);
+              this.handleIsModalOpen(true, MODAL_TYPE.REPORT_SUCCESS);
+            }}
           />
         );
       case MODAL_TYPE.REPORT_API_ERROR:
         return (
           <ApiErrorFeedback
-            buttonClick={() =>
-              this.handleIsModalOpen(true, MODAL_TYPE.REPORT_DETAIL)
-            }
+            buttonClick={() => {
+              this.setModalClosableOnClickOutside(false);
+              this.handleIsModalOpen(true, MODAL_TYPE.REPORT_DETAIL);
+            }}
             message={modalPayload.message}
           />
         );
@@ -251,7 +261,12 @@ class ExperienceDetail extends Component {
     const { likeExperience, likeReply, canViewExperirenceDetail } = this.props;
     const id = experienceIdSelector(this.props);
 
-    const { isModalOpen, modalType, modalPayload } = this.state;
+    const {
+      isModalOpen,
+      modalType,
+      modalPayload,
+      closableOnClickOutside,
+    } = this.state;
 
     const backable = R.pathOr(
       false,
@@ -296,9 +311,10 @@ class ExperienceDetail extends Component {
                   id={id}
                   experience={experience}
                   hideContent={!canViewExperirenceDetail}
-                  openReportDetail={() =>
-                    this.handleIsModalOpen(true, MODAL_TYPE.REPORT_DETAIL)
-                  }
+                  openReportDetail={() => {
+                    this.setModalClosableOnClickOutside(false);
+                    this.handleIsModalOpen(true, MODAL_TYPE.REPORT_DETAIL);
+                  }}
                 />
               </Fragment>
             )}
@@ -322,6 +338,7 @@ class ExperienceDetail extends Component {
           isOpen={isModalOpen}
           close={() => this.handleIsModalOpen(false)}
           hasClose={false}
+          closableOnClickOutside={closableOnClickOutside}
         >
           {this.renderModalChildren(modalType, modalPayload)}
         </Modal>

--- a/src/components/Me/ShareBlockElement/index.js
+++ b/src/components/Me/ShareBlockElement/index.js
@@ -86,6 +86,7 @@ const ShareBlock = ({
           <Modal
             isOpen={isArchiveModalOpen}
             close={() => setArchiveModalOpen(false)}
+            closableOnClickOutside
           >
             {archive.reason}
           </Modal>

--- a/src/components/ShareExperience/common/SubmitArea.js
+++ b/src/components/ShareExperience/common/SubmitArea.js
@@ -31,6 +31,7 @@ class SubmitArea extends React.PureComponent {
       isOpen: false,
       feedback: null,
       hasClose: false,
+      closableOnClickOutside: true,
       isSubmitting: false,
     };
   }
@@ -45,6 +46,7 @@ class SubmitArea extends React.PureComponent {
       .then(Feedback => {
         this.handleIsOpen(true);
         this.handleHasClose(false);
+        this.handleclosableOnClickOutside(true);
         return this.handleFeedback(
           Feedback({
             buttonClick: () => this.handleIsOpen(false),
@@ -60,6 +62,7 @@ class SubmitArea extends React.PureComponent {
   onFacebookFail() {
     this.handleIsOpen(true);
     this.handleHasClose(true);
+    this.handleclosableOnClickOutside(true);
     return this.handleFeedback(getFacebookFail(this.login));
   }
 
@@ -102,10 +105,22 @@ class SubmitArea extends React.PureComponent {
     }));
   }
 
+  handleclosableOnClickOutside = closableOnClickOutside => {
+    this.setState({
+      closableOnClickOutside,
+    });
+  };
+
   render() {
     const { auth } = this.props;
 
-    const { agree, isOpen, feedback, hasClose } = this.state;
+    const {
+      agree,
+      isOpen,
+      feedback,
+      hasClose,
+      closableOnClickOutside,
+    } = this.state;
 
     return (
       <div
@@ -173,6 +188,7 @@ class SubmitArea extends React.PureComponent {
           isOpen={isOpen}
           close={() => this.handleIsOpen(!isOpen)}
           hasClose={hasClose}
+          closableOnClickOutside={closableOnClickOutside}
         >
           {feedback}
         </Modal>

--- a/src/components/TimeAndSalary/common/AboutThisJobModal.js
+++ b/src/components/TimeAndSalary/common/AboutThisJobModal.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Modal from 'common/Modal';
 
 const AboutThisJobModal = ({ isOpen, close, title, aboutThisJob }) => (
-  <Modal isOpen={isOpen} hasClose close={close}>
+  <Modal isOpen={isOpen} hasClose close={close} closableOnClickOutside>
     <h1 style={{ textAlign: 'center', fontSize: '150%', marginBottom: '1em' }}>
       {title}
     </h1>

--- a/src/components/TimeAndSalary/common/InfoSalaryModal.js
+++ b/src/components/TimeAndSalary/common/InfoSalaryModal.js
@@ -7,7 +7,7 @@ import editorStyles from 'common/Editor.module.css';
 import Button from 'common/button/Button';
 
 const InfoSalaryModal = ({ isOpen, close }) => (
-  <Modal isOpen={isOpen} hasClose close={close}>
+  <Modal isOpen={isOpen} hasClose close={close} closableOnClickOutside>
     <div>
       <Question
         style={{

--- a/src/components/TimeAndSalary/common/InfoTimeModal.js
+++ b/src/components/TimeAndSalary/common/InfoTimeModal.js
@@ -7,7 +7,7 @@ import editorStyles from 'common/Editor.module.css';
 import Button from 'common/button/Button';
 
 const InfoTimeModal = ({ isOpen, close }) => (
-  <Modal isOpen={isOpen} hasClose close={close}>
+  <Modal isOpen={isOpen} hasClose close={close} closableOnClickOutside>
     <div>
       <Question
         style={{

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -27,7 +27,9 @@ const Modal = ({ children, isOpen, hasClose, close, size, onClickOutside }) => (
             />
           </div>
         ) : null}
-        <div className={styles.content}>{children}</div>
+        <div className={styles.content} onClick={e => e.stopPropagation()}>
+          {children}
+        </div>
       </div>
     </div>
   </div>

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -5,12 +5,14 @@ import cn from 'classnames';
 import Cross from '../images/x.svg';
 
 import styles from './Modal.module.css';
+import { compose, withHandlers } from 'recompose';
 
-const Modal = ({ children, isOpen, hasClose, close, size }) => (
+const Modal = ({ children, isOpen, hasClose, close, size, onClickOutside }) => (
   <div
     className={cn(styles.modal, {
       [styles.isOpen]: isOpen,
     })}
+    onClick={onClickOutside}
   >
     <div className={styles.inner}>
       <div className={cn(styles.container, styles[size])}>
@@ -37,6 +39,7 @@ Modal.propTypes = {
   hasClose: PropTypes.bool,
   close: PropTypes.func,
   size: PropTypes.string,
+  onClickOutside: PropTypes.func.isRequired,
 };
 
 Modal.defaultProps = {
@@ -44,7 +47,17 @@ Modal.defaultProps = {
   size: 's',
 };
 
-export default Modal;
+const enhanceModal = compose(
+  withHandlers({
+    onClickOutside: ({ closableOnClickOutside, close }) => () => {
+      if (closableOnClickOutside) {
+        close();
+      }
+    },
+  }),
+);
+
+export default enhanceModal(Modal);
 
 const InfoButton = ({ children, onClick }) => (
   <button className={styles.infoButton} onClick={onClick}>

--- a/src/components/common/button/ButtonSubmit.js
+++ b/src/components/common/button/ButtonSubmit.js
@@ -88,6 +88,7 @@ class ButtonSubmit extends React.PureComponent {
           isOpen={isOpen}
           close={() => this.handleIsOpen(!isOpen)}
           hasClose={false}
+          closableOnClickOutside
         >
           {feedback}
         </Modal>


### PR DESCRIPTION
Close #593 

在Modal增加`closableOnClickOutside`，也去檢查各個Modal使用的時機設定
1. `ButtonSubmit`：「為什麼需要帳戶認證」的modal，所以設為`true`
2. `ExperienceDetail`：依照`MODAL_TYPE`而render的內容做設定
- `REPORT_DETAIL`: 檢舉的modal，因為有textarea，設為`false`
- `REPORT_API_ERROR`: 因為下個動作是回檢舉modal，設為`false`
- `REPORT_SUCCESS`: 顯示檢舉成功的訊息，設為`true`
3. `ReportInspectModal`: 顯示檢舉內容，設為`true`
4. `ShareBlockElement`: 顯示封存理由，設為`true`
5. `SubmitArea`: 依照上傳的狀態render modal
- `onSubmit`: 顯示成功的狀態，設為`true`
- `onFacebookFail`: 顯示失敗的狀態，設為`true`
6. `AboutThisJobModal`: 顯示工作的內容，設為`true`
7. `InfoSalaryModal`: 顯示估計時薪算法，設為`true`
8. `InfoTimeModal`: 顯示參考時間說明，設為`true`