### PR TITLE
Sync Auth in one place

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -68,18 +68,3 @@ export const setAuthForFB = (status, accessToken) => async (
   const { token } = response;
   await dispatch(setLogin(authStatus.CONNECTED, token));
 };
-
-export const getMe = FB => (dispatch, getState) => {
-  if (!FB) {
-    return Promise.reject('FB should ready');
-  }
-  if (getState().auth.get('status') !== authStatus.CONNECTED) {
-    return Promise.reject('auth status should be connected');
-  }
-  return new Promise(resolve =>
-    FB.api('/me', response => resolve(response)),
-  ).then(response => {
-    dispatch(setUser(response));
-    return response;
-  });
-};

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -66,6 +66,25 @@ export const getLoginStatus = FB => dispatch => {
   return Promise.reject('FB should ready');
 };
 
+export const setAuthForFB = (status, accessToken) => async (
+  dispatch,
+  getState,
+  { api },
+) => {
+  if (status !== authStatus.CONNECTED) {
+    await dispatch(setLogin(status));
+    return;
+  }
+
+  const response = await api.auth.postAuthFacebook(accessToken);
+  if (response.error) {
+    await dispatch(setLogin(authStatus.NOT_AUTHORIZED));
+    return;
+  }
+  const { token } = response;
+  await dispatch(setLogin(authStatus.CONNECTED, token));
+};
+
 export const getMe = FB => (dispatch, getState) => {
   if (!FB) {
     return Promise.reject('FB should ready');

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -50,22 +50,6 @@ export const logout = FB => dispatch => {
   return Promise.reject('FB should ready');
 };
 
-export const getLoginStatus = FB => dispatch => {
-  if (FB) {
-    return new Promise(resolve =>
-      FB.getLoginStatus(response => resolve(response)),
-    ).then(response => {
-      if (response.status === authStatus.CONNECTED) {
-        dispatch(setLogin(response.status, response.authResponse.accessToken));
-      } else if (response.status === authStatus.NOT_AUTHORIZED) {
-        dispatch(setLogin(response.status));
-      }
-      return response.status;
-    });
-  }
-  return Promise.reject('FB should ready');
-};
-
 export const setAuthForFB = (status, accessToken) => async (
   dispatch,
   getState,

--- a/src/components/App/Header/index.js
+++ b/src/components/App/Header/index.js
@@ -31,29 +31,14 @@ class Header extends React.Component {
   componentDidMount() {
     const { history } = this.props;
     this.unlisten = history.listen(this.closeNav);
-
-    const { getLoginStatus, FB, getMe } = this.props;
-    FB &&
-      getLoginStatus(FB)
-        .then(() => getMe(FB))
-        .catch(() => {});
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.FB !== this.props.FB) {
-      // FB instance changed
-      const { getLoginStatus, FB } = this.props;
-
-      FB && getLoginStatus(FB).catch(() => {});
-    }
-
     if (
       prevProps.auth.get('status') !== this.props.auth.get('status') &&
       this.props.auth.get('status') === authStatus.CONNECTED
     ) {
-      const { getMe, FB } = this.props;
       this.props.fetchPermission();
-      FB && getMe(FB).catch(() => {});
     }
   }
 
@@ -169,8 +154,6 @@ class Header extends React.Component {
 Header.propTypes = {
   login: PropTypes.func.isRequired,
   logout: PropTypes.func.isRequired,
-  getLoginStatus: PropTypes.func.isRequired,
-  getMe: PropTypes.func.isRequired,
   auth: PropTypes.object,
   FB: PropTypes.object,
   location: PropTypes.object,

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -6,6 +6,7 @@ import RouteWithSubRoutes from '../route';
 import styles from './App.module.css';
 import Header from '../../containers/App/Header';
 import Footer from './Footer';
+import SyncAuth from '../../containers/App/SyncAuth';
 import { HELMET_DATA } from '../../constants/helmetData';
 
 import routes from '../../routes';
@@ -13,6 +14,7 @@ import routes from '../../routes';
 const App = () => (
   <div className={styles.App}>
     <Header />
+    <SyncAuth />
     <Helmet {...HELMET_DATA.DEFAULT} />
     <div className={styles.content}>
       <Switch>

--- a/src/components/Me/index.js
+++ b/src/components/Me/index.js
@@ -9,7 +9,6 @@ import { Comment2 } from 'common/icons';
 
 import styles from './Me.module.css';
 import ShareBlockElement from './ShareBlockElement';
-import authStatus from '../../constants/authStatus';
 import status from '../../constants/status';
 
 class Me extends Component {
@@ -27,25 +26,6 @@ class Me extends Component {
     this.props.fetchMyExperiences();
     this.props.fetchMyWorkings();
     this.props.fetchMyReplies();
-    const { getLoginStatus, FB, getMe } = this.props;
-    FB && getLoginStatus(FB).then(() => getMe(FB));
-  }
-
-  componentDidUpdate(prevProps) {
-    if (prevProps.FB !== this.props.FB) {
-      // FB instance changed
-      const { getLoginStatus, FB } = this.props;
-
-      FB && getLoginStatus(FB);
-    }
-
-    if (
-      prevProps.auth.get('status') !== this.props.auth.get('status') &&
-      this.props.auth.get('status') === authStatus.CONNECTED
-    ) {
-      const { getMe, FB } = this.props;
-      FB && getMe(FB);
-    }
   }
 
   login = () => {
@@ -165,8 +145,6 @@ class Me extends Component {
 }
 Me.propTypes = {
   login: PropTypes.func.isRequired,
-  getLoginStatus: PropTypes.func.isRequired,
-  getMe: PropTypes.func.isRequired,
   auth: PropTypes.object,
   FB: PropTypes.object,
 };

--- a/src/containers/App/Header/index.js
+++ b/src/containers/App/Header/index.js
@@ -4,22 +4,14 @@ import { withRouter } from 'react-router-dom';
 
 import { withFB } from 'common/facebook';
 import Header from '../../../components/App/Header';
-import {
-  loginWithFB,
-  logout,
-  getLoginStatus,
-  getMe,
-} from '../../../actions/auth';
+import { loginWithFB, logout } from '../../../actions/auth';
 
 const mapStateToProps = state => ({
   auth: state.auth,
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    { login: loginWithFB, logout, getLoginStatus, getMe },
-    dispatch,
-  );
+  bindActionCreators({ login: loginWithFB, logout }, dispatch);
 
 export default withRouter(
   connect(

--- a/src/containers/App/SyncAuth/index.js
+++ b/src/containers/App/SyncAuth/index.js
@@ -1,0 +1,74 @@
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { compose, lifecycle } from 'recompose';
+import { withFB } from 'common/facebook';
+import { setAuthForFB, setUser } from '../../../actions/auth';
+import authStatus from '../../../constants/authStatus';
+
+const { CONNECTED } = authStatus;
+
+const getLoginStatus = async ({ FB, setAuthForFB }) => {
+  if (!FB) {
+    return;
+  }
+  const response = await new Promise(resolve =>
+    FB.getLoginStatus(response => resolve(response)),
+  );
+
+  const status = response.status;
+  if (status === CONNECTED) {
+    await setAuthForFB(status, response.authResponse.accessToken);
+  } else {
+    await setAuthForFB(status);
+  }
+  return status;
+};
+
+const getMe = async ({ FB, setUser }) => {
+  if (!FB) {
+    return;
+  }
+  const response = await new Promise(resolve =>
+    FB.api('/me', response => resolve(response)),
+  );
+  const { id, name } = response;
+  const user = { id, name };
+  await setUser(user);
+  return user;
+};
+
+const mapStateToProps = state => ({
+  authStatus: state.auth.get('status'),
+});
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ setAuthForFB, setUser }, dispatch);
+
+const hoc = compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  withFB,
+  lifecycle({
+    componentDidMount() {
+      const { FB, setAuthForFB } = this.props;
+      getLoginStatus({ FB, setAuthForFB });
+    },
+    componentDidUpdate(prevProps) {
+      if (prevProps.FB !== this.props.FB) {
+        const { FB, setAuthForFB } = this.props;
+        getLoginStatus({ FB, setAuthForFB });
+      }
+
+      if (
+        prevProps.authStatus !== this.props.authStatus &&
+        this.props.authStatus === CONNECTED
+      ) {
+        const { FB, setUser } = this.props;
+        getMe({ FB, setUser });
+      }
+    },
+  }),
+);
+
+export default hoc(() => null);

--- a/src/containers/Me/index.js
+++ b/src/containers/Me/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 
 import { withFB } from 'common/facebook';
 import Me from '../../components/Me';
-import { loginWithFB, getLoginStatus, getMe } from '../../actions/auth';
+import { loginWithFB } from '../../actions/auth';
 import * as MyActions from '../../actions/me';
 
 const mapStateToProps = state => ({
@@ -12,10 +12,7 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    { login: loginWithFB, getLoginStatus, getMe, ...MyActions },
-    dispatch,
-  );
+  bindActionCreators({ login: loginWithFB, ...MyActions }, dispatch);
 
 export default connect(
   mapStateToProps,


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

這個 PR 將 FB SDK 的狀態改變更新至 Redux 中

1. 當 SDK 讀取完成 --> 檢查登入狀態 --> 並跟後端取得登入憑證
2. 當 FB 登入 --> 取得使用者帳戶名稱

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

從 `src/containers/App/SyncAuth/index.js` 的 componentDidMount, componentDidUpdate 來看

備註：

目前登入的狀態會透過 FB SDK 幫忙，之後等 token 被放進 localStorage，就不需要每次都等待 FB SDK

## Questions:  <!-- 選填，沒有就刪掉 -->

- 我需要更新 Packages 嗎？ No <!-- Yes / No -->
- 有哪些文件需要被更新嗎？ No <!-- 文件的連結 -->
