### PR TITLE
Decrease the hover hitzone

### DIFF
--- a/src/components/ExperienceDetail/LikeZone/LikeZone.js
+++ b/src/components/ExperienceDetail/LikeZone/LikeZone.js
@@ -2,17 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 import i from 'common/icons';
+import { P } from 'common/base';
 import authStatusConstant from '../../../constants/authStatus';
 import styles from './LikeZone.module.css';
-import { P } from 'common/base';
 
 // count 是 number，不能使用 `count && xxx`，否則 count = 0 會有問題
 const ThumbsUp = ({ onClick, label, count, ...restProps }) => (
-  <div onClick={onClick} {...restProps}>
+  <button onClick={onClick} {...restProps}>
     <i.Like className={styles.icon} />
     {typeof label !== undefined && <div className={styles.label}>{label}</div>}
     {typeof count !== undefined && <div className={styles.count}>{count}</div>}
-  </div>
+  </button>
 );
 
 const LikeZone = ({ likeExperience, experience, login, authStatus, FB }) => (

--- a/src/components/ExperienceDetail/LikeZone/LikeZone.module.css
+++ b/src/components/ExperienceDetail/LikeZone/LikeZone.module.css
@@ -11,16 +11,8 @@
     margin-bottom: 26px;
   }
 
-  & > *:last-of-type {
+  & > *:last-child {
     margin-bottom: 0;
-  }
-
-  @media (min-width: 1025px) {
-    &:hover {
-      .icon {
-        fill: main-yellow;
-      }
-    }
   }
 }
 
@@ -35,6 +27,14 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
+
+  @media (min-width: 1025px) {
+    &:hover {
+      > .icon {
+        fill: main-yellow;
+      }
+    }
+  }
 }
 
 .toggled {


### PR DESCRIPTION
## 這個 PR 是？

1. 修了LikeZone hover hitzone 過大的問題
2. ThumbsUp wrapper 改用button ，css 也換成相對應會符合原spec 的寫法

## Screenshots

![2019-02-22 00 03 30](https://user-images.githubusercontent.com/8898129/53183046-973c7880-3635-11e9-8a02-8afa22067146.gif)

## 我應該如何手動測試？

- [ ] `/experiences/5c6e8fbbd0ddee0011e77fe4`
