### PR TITLE
Fix: getDerivedStateFromProps reset state every props values change

### DIFF
--- a/src/components/ExperienceSearch/Searchbar.js
+++ b/src/components/ExperienceSearch/Searchbar.js
@@ -24,10 +24,20 @@ class SearchBar extends PureComponent {
 
   static getDerivedStateFromProps(props, state) {
     const { searchBy, searchQuery } = props;
-    return {
-      searchBy,
-      searchQuery,
-    };
+    const { prevPropsSearchBy, prevPropsSearchQuery } = state;
+
+    if (
+      searchBy !== prevPropsSearchBy ||
+      searchQuery !== prevPropsSearchQuery
+    ) {
+      return {
+        prevPropsSearchBy: searchBy,
+        prevPropsSearchQuery: searchQuery,
+        searchBy,
+        searchQuery,
+      };
+    }
+    return null;
   }
 
   render() {


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

這個 PR 修正 getDerivedStateFromProps 會一直重設 state，導致表單無法輸入值 (Searchbar)
