### PR TITLE
hotfix: use break-word to prevent layout bug

### DIFF
--- a/src/components/ExperienceDetail/Article/SectionBlock.module.css
+++ b/src/components/ExperienceDetail/Article/SectionBlock.module.css
@@ -5,4 +5,5 @@
 .content {
   margin-bottom: 1.5em;
   white-space: pre-line;
+  word-break: break-word;
 }


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

像這篇：
https://www.goodjob.life/experiences/5c8378e82d9f5a00111dc220

有網址太長的時候會造成跑版，這個 PR 把 css style 加上 `word-break: break-word`，可以解決這個問題。


## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="1146" alt="螢幕快照 2019-03-09 下午10 51 34" src="https://user-images.githubusercontent.com/3805975/54073073-eb925a00-42bd-11e9-8286-9c83d9015ee2.png">

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] local 端跑起來，隨便找一篇文章直接 html 插入上面那篇文章內容中的網址： https://docs.google.com/document/d/17QF6g9wsNVHxSpVuCdHnIe0HEAkBg2HVXN9Df4z6IEs/edit ，不應該造成跑版
