### PR TITLE
SalaryWorkTimes: 使用Link取代history.push

### DIFF
--- a/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
+++ b/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
@@ -100,14 +100,27 @@ class SearchScreen extends Component {
     }
   }
 
+  getLinkForData(data) {
+    const searchBy = searchCriteriaSelector(this.props);
+    if (searchBy === 'company') {
+      return `/companies/${data.name}/salary-work-times${
+        this.props.location.search
+      }`;
+    } else if (searchBy === 'job_title') {
+      return `/job-titles/${data.name}/salary-work-times${
+        this.props.location.search
+      }`;
+    }
+    return '';
+  }
+
   render() {
-    const { status, history } = this.props;
+    const { status } = this.props;
     const pathname = pathnameSelector(this.props);
     const page = validatePage(pageSelector(this.props));
     const pageSize = 10;
     const totalNum = this.props.data.size;
 
-    const searchBy = searchCriteriaSelector(this.props);
     const keyword = validateSearchKeyword(searchKeywordSelector(this.props));
     const title = keyword ? `查詢「${keyword}」的結果` : '請輸入搜尋條件！';
 
@@ -134,25 +147,7 @@ class SearchScreen extends Component {
             </P>
           )}
         {raw.map((o, i) => (
-          <WorkingHourBlock
-            key={i}
-            data={o}
-            onClickHeader={() => {
-              if (searchBy === 'company') {
-                history.push(
-                  `/companies/${o.name}/salary-work-times${
-                    this.props.location.search
-                  }`,
-                );
-              } else if (searchBy === 'job_title') {
-                history.push(
-                  `/job-titles/${o.name}/salary-work-times${
-                    this.props.location.search
-                  }`,
-                );
-              }
-            }}
-          />
+          <WorkingHourBlock key={i} data={o} to={this.getLinkForData(o)} />
         ))}
         <Pagination
           totalCount={totalNum}

--- a/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
+++ b/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
@@ -103,12 +103,16 @@ class SearchScreen extends Component {
   getLinkForData(data) {
     const searchBy = searchCriteriaSelector(this.props);
     if (searchBy === 'company') {
-      return `/companies/${data.name}/salary-work-times${qs.stringify(
+      return `/companies/${encodeURIComponent(
+        data.name,
+      )}/salary-work-times${qs.stringify(
         { ...querySelector(this.props), p: 1 },
         { addQueryPrefix: true },
       )}`;
     } else if (searchBy === 'job_title') {
-      return `/job-titles/${data.name}/salary-work-times${qs.stringify(
+      return `/job-titles/${encodeURIComponent(
+        data.name,
+      )}/salary-work-times${qs.stringify(
         { ...querySelector(this.props), p: 1 },
         { addQueryPrefix: true },
       )}`;

--- a/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
+++ b/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
@@ -103,13 +103,15 @@ class SearchScreen extends Component {
   getLinkForData(data) {
     const searchBy = searchCriteriaSelector(this.props);
     if (searchBy === 'company') {
-      return `/companies/${data.name}/salary-work-times${
-        this.props.location.search
-      }`;
+      return `/companies/${data.name}/salary-work-times${qs.stringify(
+        { ...querySelector(this.props), p: 1 },
+        { addQueryPrefix: true },
+      )}`;
     } else if (searchBy === 'job_title') {
-      return `/job-titles/${data.name}/salary-work-times${
-        this.props.location.search
-      }`;
+      return `/job-titles/${data.name}/salary-work-times${qs.stringify(
+        { ...querySelector(this.props), p: 1 },
+        { addQueryPrefix: true },
+      )}`;
     }
     return '';
   }

--- a/src/components/TimeAndSalary/SearchScreen/WorkingHourBlock.js
+++ b/src/components/TimeAndSalary/SearchScreen/WorkingHourBlock.js
@@ -1,21 +1,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Heading } from 'common/base';
+import { Link } from 'react-router-dom';
 
 import styles from '../common/WorkingHourBlock.module.css';
 
 class WorkingHourBlock extends Component {
   static propTypes = {
     data: PropTypes.object.isRequired,
-    onClickHeader: PropTypes.func,
+    to: PropTypes.string.isRequired,
   };
 
   render() {
-    const { data, onClickHeader } = this.props;
+    const { data, to } = this.props;
     const { name } = data;
     return (
       <section className={styles.container}>
-        <button className={styles.toggleButton} onClick={onClickHeader}>
+        <Link className={styles.toggleButton} to={to}>
           <div className={styles.headingWrapper}>
             <Heading size="sl" className={styles.headingBlock}>
               {name}
@@ -27,7 +28,7 @@ class WorkingHourBlock extends Component {
               </span>
             </div>
           </div>
-        </button>
+        </Link>
       </section>
     );
   }


### PR DESCRIPTION
Close #632

#622 

## 這個 PR 是？ <!-- 必填 -->

用`Link`取代`history.push`

<!-- 請簡單說明這個 PR 做了什麼 -->

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 在搜尋頁面 (如 `/salary-work-times?q=d&s_by=company` ) 點選項目應仍舊正常導向至單篇頁面