### PR TITLE
將薪資工時route改為salary-work-times

### DIFF
--- a/src/components/App/Footer/index.js
+++ b/src/components/App/Footer/index.js
@@ -7,7 +7,7 @@ import LinkItem from './LinkItem';
 import styles from './Footer.module.css';
 
 const link1 = [
-  { to: '/time-and-salary', text: '薪資工時' },
+  { to: '/salary-work-times/latest', text: '薪資工時' },
   { to: '/experiences/search', text: '職場經驗' },
   { to: '/labor-rights', text: '勞動小教室' },
 ];

--- a/src/components/App/Header/SiteMenu.js
+++ b/src/components/App/Header/SiteMenu.js
@@ -30,7 +30,7 @@ const onSendGA = action => {
 const SiteMenu = () => (
   <ul className={styles.menu}>
     <Item
-      to="/time-and-salary"
+      to="/salary-work-times/latest"
       text="薪資工時"
       onClick={() => {
         onSendGA(GA_ACTION.CLICK_TIME_AND_SALARY);

--- a/src/components/CampaignTimeAndSalary/CampaignTimeAndSalaryBoard/index.js
+++ b/src/components/CampaignTimeAndSalary/CampaignTimeAndSalaryBoard/index.js
@@ -288,7 +288,7 @@ class CampaignTimeAndSalaryBoard extends Component {
             timeAndSalaryBannerStyles.btnS,
             timeAndSalaryBannerStyles.btnYellowLine,
           )}
-          to="/time-and-salary/latest"
+          to="/salary-work-times/latest"
         >
           <Star /> 全站薪資工時
         </Link>

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -135,7 +135,7 @@ class TimeSalaryForm extends React.PureComponent {
                 (count || 0)} 次可以上傳。`}
               buttonText="查看最新工時、薪資"
               buttonClick={() => {
-                window.location.replace('/time-and-salary/latest');
+                window.location.replace('/salary-work-times/latest');
               }}
             />
           );

--- a/src/components/TimeAndSalary/NotFound.js
+++ b/src/components/TimeAndSalary/NotFound.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Redirect from 'common/routing/Redirect';
 
-const NotFound = () => <Redirect to="/time-and-salary/latest" />;
+const NotFound = () => <Redirect to="/salary-work-times/latest" />;
 
 export default NotFound;

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -31,60 +31,13 @@ import { toQsString, queryParser } from './helper';
 import { DATA_NUM_PER_PAGE } from '../../../constants/timeAndSalarSearch';
 import renderHelmet from './helmet';
 
-const pathnameMapping = {
-  '/time-and-salary/work-time-dashboard': {
-    title: '工時排行榜',
-    label: '一週平均總工時（高到低）',
-    sortBy: 'week_work_time',
-    order: 'descending',
-    hasExtreme: true,
-  },
-  '/time-and-salary/sort/work-time-asc': {
-    title: '工時排行榜（由低到高）',
-    label: '一週平均總工時（低到高）',
-    sortBy: 'week_work_time',
-    order: 'ascending',
-    hasExtreme: true,
-  },
-  '/time-and-salary/salary-dashboard': {
-    title: '估算時薪排行榜',
-    label: '估算時薪（高到低）',
-    sortBy: 'estimated_hourly_wage',
-    order: 'descending',
-    hasExtreme: true,
-  },
-  '/time-and-salary/sort/salary-asc': {
-    title: '估算時薪排行榜（由低到高）',
-    label: '估算時薪（低到高）',
-    sortBy: 'estimated_hourly_wage',
-    order: 'ascending',
-    hasExtreme: true,
-  },
-  '/time-and-salary/latest': {
-    title: '最新薪資、工時資訊',
-    label: '資料時間（新到舊）',
-    sortBy: 'created_at',
-    order: 'descending',
-    hasExtreme: false,
-  },
-  '/time-and-salary/sort/time-asc': {
-    title: '最舊薪資、工時資訊',
-    label: '資料時間（舊到新）',
-    sortBy: 'created_at',
-    order: 'ascending',
-    hasExtreme: false,
-  },
+const pathParameters = {
+  title: '最新薪資、工時資訊',
+  label: '資料時間（新到舊）',
+  sortBy: 'created_at',
+  order: 'descending',
+  hasExtreme: false,
 };
-
-const selectOptions = R.pipe(
-  R.toPairs,
-  R.map(([path, opt]) => ({ value: path, label: opt.label })),
-);
-
-const pathParameterSelector = R.compose(
-  path => pathnameMapping[path],
-  pathSelector,
-);
 
 const injectPermissionBlock = R.pipe(
   R.take(MAX_ROWS_IF_HIDDEN),
@@ -168,7 +121,7 @@ class TimeAndSalaryBoard extends Component {
   };
 
   componentDidMount() {
-    const { sortBy, order } = pathParameterSelector(this.props);
+    const { sortBy, order } = pathParameters;
     const { page } = queryParser(querySelector(this.props));
 
     this.props.resetBoardExtremeData();
@@ -181,7 +134,7 @@ class TimeAndSalaryBoard extends Component {
       pathSelector(prevProps) !== pathSelector(this.props) ||
       searchSelector(prevProps) !== searchSelector(this.props)
     ) {
-      const { sortBy, order } = pathParameterSelector(this.props);
+      const { sortBy, order } = pathParameters;
       const { page } = queryParser(querySelector(this.props));
       this.setState({ showExtreme: false });
       this.props.resetBoardExtremeData();
@@ -262,7 +215,7 @@ class TimeAndSalaryBoard extends Component {
     const path = pathSelector(this.props);
     const pathname = pathnameSelector(this.props);
     const { page } = queryParser(querySelector(this.props));
-    const { title, hasExtreme } = pathParameterSelector(this.props);
+    const { title, hasExtreme } = pathParameters;
     const {
       data,
       status,
@@ -306,7 +259,12 @@ class TimeAndSalaryBoard extends Component {
               <div className={commonStyles.label}> 排序：</div>
               <div className={commonStyles.select}>
                 <Select
-                  options={selectOptions(pathnameMapping)}
+                  options={[
+                    {
+                      value: '/salary-work-times/latest',
+                      label: pathParameters.label,
+                    },
+                  ]}
                   onChange={e => history.push(e.target.value)}
                   value={path}
                   hasNullOption={false}
@@ -358,7 +316,7 @@ class TimeAndSalaryBoard extends Component {
 }
 
 const ssr = setStatic('fetchData', ({ store: { dispatch }, ...props }) => {
-  const { sortBy, order } = pathParameterSelector(props);
+  const { sortBy, order } = pathParameters;
   const { page } = queryParser(querySelector(props));
 
   return dispatch(queryTimeAndSalary({ sortBy, order, page }));

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -5,7 +5,6 @@ import Loading from 'common/Loader';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import cn from 'classnames';
 import { compose, setStatic } from 'recompose';
-import Select from 'common/form/Select';
 import Pagination from 'common/Pagination';
 import FanPageBlock from 'common/FanPageBlock';
 import { withPermission } from 'common/permission-context';
@@ -212,7 +211,6 @@ class TimeAndSalaryBoard extends Component {
   };
 
   render() {
-    const path = pathSelector(this.props);
     const pathname = pathnameSelector(this.props);
     const { page } = queryParser(querySelector(this.props));
     const { title, hasExtreme } = pathParameters;
@@ -221,7 +219,6 @@ class TimeAndSalaryBoard extends Component {
       status,
       totalCount,
       currentPage,
-      history,
       extremeStatus,
       extremeData,
       canViewTimeAndSalary,
@@ -254,22 +251,6 @@ class TimeAndSalaryBoard extends Component {
                     </button>
                   </span>
                 )}
-            </div>
-            <div className={commonStyles.sort}>
-              <div className={commonStyles.label}> 排序：</div>
-              <div className={commonStyles.select}>
-                <Select
-                  options={[
-                    {
-                      value: '/salary-work-times/latest',
-                      label: pathParameters.label,
-                    },
-                  ]}
-                  onChange={e => history.push(e.target.value)}
-                  value={path}
-                  hasNullOption={false}
-                />
-              </div>
             </div>
           </div>
           {isFetching(status) && (

--- a/src/components/TimeAndSalary/index.js
+++ b/src/components/TimeAndSalary/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Helmet from 'react-helmet';
-import { Redirect, Switch } from 'react-router';
+import { Switch } from 'react-router';
 import { compose, setStatic } from 'recompose';
 import Wrapper from 'common/base/Wrapper';
 import { pathnameSelector } from 'common/routing/selectors';
@@ -92,19 +92,7 @@ class TimeAndSalary extends Component {
   };
 
   render() {
-    const { routes, location, staticContext } = this.props;
-    if (!staticContext) {
-      if (location.pathname === '/salary-work-times') {
-        if (location.hash) {
-          const targets = location.hash.split('#');
-          if (targets.length >= 2) {
-            return <Redirect to={`/salary-work-times${targets[1]}`} />;
-          }
-        }
-        return <Redirect to="/salary-work-times/latest" />;
-      }
-    }
-
+    const { routes } = this.props;
     const campaigns = campaignListFromEntries(this.props.campaignEntries);
 
     return (

--- a/src/components/TimeAndSalary/index.js
+++ b/src/components/TimeAndSalary/index.js
@@ -94,14 +94,14 @@ class TimeAndSalary extends Component {
   render() {
     const { routes, location, staticContext } = this.props;
     if (!staticContext) {
-      if (location.pathname === '/time-and-salary') {
+      if (location.pathname === '/salary-work-times') {
         if (location.hash) {
           const targets = location.hash.split('#');
           if (targets.length >= 2) {
-            return <Redirect to={`/time-and-salary${targets[1]}`} />;
+            return <Redirect to={`/salary-work-times${targets[1]}`} />;
           }
         }
-        return <Redirect to="/time-and-salary/latest" />;
+        return <Redirect to="/salary-work-times/latest" />;
       }
     }
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -150,7 +150,7 @@ const routes = [
       },
       {
         path: '/time-and-salary',
-        exact: true,
+        exact: false,
         component: () => <Redirect to="/salary-work-times/latest" />,
       },
       {

--- a/src/routes.js
+++ b/src/routes.js
@@ -131,36 +131,6 @@ const routes = [
     component: TimeAndSalary,
     routes: [
       {
-        path: '/time-and-salary/latest',
-        exact: true,
-        component: TimeAndSalaryBoard,
-      },
-      {
-        path: '/time-and-salary/sort/time-asc',
-        exact: true,
-        component: TimeAndSalaryBoard,
-      },
-      {
-        path: '/time-and-salary/work-time-dashboard',
-        exact: true,
-        component: TimeAndSalaryBoard,
-      },
-      {
-        path: '/time-and-salary/sort/work-time-asc',
-        exact: true,
-        component: TimeAndSalaryBoard,
-      },
-      {
-        path: '/time-and-salary/salary-dashboard',
-        exact: true,
-        component: TimeAndSalaryBoard,
-      },
-      {
-        path: '/time-and-salary/sort/salary-asc',
-        exact: true,
-        component: TimeAndSalaryBoard,
-      },
-      {
         path: '/time-and-salary/company/:keyword',
         exact: false,
         component: ({ match }) => (
@@ -179,6 +149,11 @@ const routes = [
         ),
       },
       {
+        path: '/time-and-salary',
+        exact: true,
+        component: () => <Redirect to="/salary-work-times/latest" />,
+      },
+      {
         component: TimeAndSalaryNotFound,
       },
     ],
@@ -191,6 +166,14 @@ const routes = [
         path: '/salary-work-times',
         exact: true,
         component: SalaryWorkTimeSearchScreen,
+      },
+      {
+        path: '/salary-work-times/latest',
+        exact: true,
+        component: TimeAndSalaryBoard,
+      },
+      {
+        component: TimeAndSalaryNotFound,
       },
     ],
   },


### PR DESCRIPTION
#622

## 這個 PR 是？ <!-- 必填 -->

> 進到薪資工時頁面的 route 是 /salary-work-times

1. 改為`/salary-work-times/latest`
2. 舊的`/time-and-salary`開頭的都導向至`/salary-work-times/latest`
3. 移除TimeAndSalaryBoard的Select元件

## Screenshots

![http://recordit.co/IVbm929Wy4.gif](http://recordit.co/IVbm929Wy4.gif)