### PR TITLE
Update/helmet for SalaryWorkTimes pages

### DIFF
--- a/src/components/Company/SalaryWorkTimeScreen.js
+++ b/src/components/Company/SalaryWorkTimeScreen.js
@@ -67,13 +67,31 @@ class SalaryWorkTimeScreen extends Component {
     const pageSize = 10;
 
     const companyName = companyNameSelector(this.props);
-    const title = `${companyName} 薪水、加班情況`;
+    const title = `${companyName} 薪水`;
+    const statistics = data
+      ? data.get('salary_work_time_statistics').toJS()
+      : null;
+    const dataNum = R.propOr(0, 'count', statistics);
+    const avgWeekWorkTime = R.propOr(0, 'average_week_work_time', statistics);
+    const avgHourWage = R.propOr(
+      0,
+      'average_estimated_hourly_wage',
+      statistics,
+    );
 
     const queryParams = querySelector(this.props);
 
     return (
       <section className={styles.searchResult}>
-        {renderHelmet({ title, pathname, companyName })}
+        {renderHelmet({
+          title,
+          pathname,
+          page,
+          companyName,
+          dataNum,
+          avgWeekWorkTime: Math.round(avgWeekWorkTime),
+          avgHourWage: Math.round(avgHourWage),
+        })}
         <h2 className={styles.heading}>{title}</h2>
         {isFetching(status) && <Loading size="s" />}
         {isFetched(status) &&

--- a/src/components/Company/SalaryWorkTimeScreen.js
+++ b/src/components/Company/SalaryWorkTimeScreen.js
@@ -67,7 +67,7 @@ class SalaryWorkTimeScreen extends Component {
     const pageSize = 10;
 
     const companyName = companyNameSelector(this.props);
-    const title = `${companyName} 薪水`;
+    const title = `${companyName}薪水`;
     const statistics = data
       ? data.get('salary_work_time_statistics').toJS()
       : null;

--- a/src/components/Company/helmet.js
+++ b/src/components/Company/helmet.js
@@ -3,16 +3,26 @@ import Helmet from 'react-helmet';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { imgHost, SITE_NAME } from '../../constants/helmetData';
 
-export default ({ title, pathname, companyName }) => {
+export default ({
+  title,
+  pathname,
+  page,
+  companyName,
+  dataNum,
+  avgWeekWorkTime,
+  avgHourWage,
+}) => {
+  const helmetTitle = `${title} - 第${page}頁`;
   const url = formatCanonicalPath(pathname);
-  const description = `馬上查看${companyName}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
-
+  const description = `${companyName} 的薪水平均 ${avgHourWage} 元/小時，平均每週工作 ${avgWeekWorkTime} 小時，總共 ${dataNum} 筆的薪水、加班狀況資料。`;
+  const keywords = `${companyName}薪水, ${companyName}薪資, ${companyName}加班狀況, ${companyName}工時`;
   return (
     <Helmet
-      title={title}
+      title={helmetTitle}
       meta={[
         { name: 'description', content: description },
-        { property: 'og:title', content: formatTitle(title, SITE_NAME) },
+        { name: 'keywords', content: keywords },
+        { property: 'og:title', content: formatTitle(helmetTitle, SITE_NAME) },
         { property: 'og:description', content: description },
         { property: 'og:url', content: url },
         {

--- a/src/components/Company/helmet.js
+++ b/src/components/Company/helmet.js
@@ -13,7 +13,7 @@ export default ({
   avgHourWage,
 }) => {
   const helmetTitle = `${title} - 第${page}頁`;
-  const url = formatCanonicalPath(pathname);
+  const url = `${formatCanonicalPath(pathname)}?p=${page}`;
   const description = `${companyName} 的薪水平均 ${avgHourWage} 元/小時，平均每週工作 ${avgWeekWorkTime} 小時，總共 ${dataNum} 筆的薪水、加班狀況資料。`;
   const keywords = `${companyName}薪水, ${companyName}薪資, ${companyName}加班狀況, ${companyName}工時`;
   return (

--- a/src/components/JobTitle/SalaryWorkTimeScreen.js
+++ b/src/components/JobTitle/SalaryWorkTimeScreen.js
@@ -67,13 +67,31 @@ class SalaryWorkTimeScreen extends Component {
     const pageSize = 10;
 
     const jobTitle = jobTitleSelector(this.props);
-    const title = `${jobTitle} 薪水、加班情況`;
+    const title = `${jobTitle}薪水`;
+    const statistics = data
+      ? data.get('salary_work_time_statistics').toJS()
+      : null;
+    const dataNum = R.propOr(0, 'count', statistics);
+    const avgWeekWorkTime = R.propOr(0, 'average_week_work_time', statistics);
+    const avgHourWage = R.propOr(
+      0,
+      'average_estimated_hourly_wage',
+      statistics,
+    );
 
     const queryParams = querySelector(this.props);
 
     return (
       <section className={styles.searchResult}>
-        {renderHelmet({ title, pathname, jobTitle })}
+        {renderHelmet({
+          title,
+          pathname,
+          page,
+          jobTitle,
+          dataNum,
+          avgWeekWorkTime: Math.round(avgWeekWorkTime),
+          avgHourWage: Math.round(avgHourWage),
+        })}
         <h2 className={styles.heading}>{title}</h2>
         {isFetching(status) && <Loading size="s" />}
         {isFetched(status) &&

--- a/src/components/JobTitle/helmet.js
+++ b/src/components/JobTitle/helmet.js
@@ -14,7 +14,7 @@ export default ({
 }) => {
   const helmetTitle = `${title} - 第${page}頁`;
   const url = formatCanonicalPath(pathname);
-  const description = `${jobTitle} 的薪水平均 ${avgHourWage} 元/小時，平均每週工作 ${avgWeekWorkTime} 小時，總共 ${dataNum} 筆的薪水、加班狀況資料。`;
+  const description = `${jobTitle} 的薪水平均 ${avgHourWage} 元/小時，平均每週工作 ${avgWeekWorkTime} 小時，總共 ${dataNum} 筆的薪水、加班狀況資料。`;
   const keywords = `${jobTitle}薪水, ${jobTitle}薪資, ${jobTitle}加班狀況, ${jobTitle}工時`;
 
   return (

--- a/src/components/JobTitle/helmet.js
+++ b/src/components/JobTitle/helmet.js
@@ -3,16 +3,27 @@ import Helmet from 'react-helmet';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { imgHost, SITE_NAME } from '../../constants/helmetData';
 
-export default ({ title, pathname, jobTitle }) => {
+export default ({
+  title,
+  pathname,
+  page,
+  jobTitle,
+  dataNum,
+  avgWeekWorkTime,
+  avgHourWage,
+}) => {
+  const helmetTitle = `${title} - 第${page}頁`;
   const url = formatCanonicalPath(pathname);
-  const description = `馬上查看${jobTitle}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
+  const description = `${jobTitle} 的薪水平均 ${avgHourWage} 元/小時，平均每週工作 ${avgWeekWorkTime} 小時，總共 ${dataNum} 筆的薪水、加班狀況資料。`;
+  const keywords = `${jobTitle}薪水, ${jobTitle}薪資, ${jobTitle}加班狀況, ${jobTitle}工時`;
 
   return (
     <Helmet
-      title={title}
+      title={helmetTitle}
       meta={[
         { name: 'description', content: description },
-        { property: 'og:title', content: formatTitle(title, SITE_NAME) },
+        { name: 'keywords', content: keywords },
+        { property: 'og:title', content: formatTitle(helmetTitle, SITE_NAME) },
         { property: 'og:description', content: description },
         { property: 'og:url', content: url },
         {

--- a/src/components/JobTitle/helmet.js
+++ b/src/components/JobTitle/helmet.js
@@ -13,7 +13,7 @@ export default ({
   avgHourWage,
 }) => {
   const helmetTitle = `${title} - 第${page}頁`;
-  const url = formatCanonicalPath(pathname);
+  const url = `${formatCanonicalPath(pathname)}?p=${page}`;
   const description = `${jobTitle} 的薪水平均 ${avgHourWage} 元/小時，平均每週工作 ${avgWeekWorkTime} 小時，總共 ${dataNum} 筆的薪水、加班狀況資料。`;
   const keywords = `${jobTitle}薪水, ${jobTitle}薪資, ${jobTitle}加班狀況, ${jobTitle}工時`;
 

--- a/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
+++ b/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
@@ -11,6 +11,7 @@ import {
   querySelector,
   pathSelector,
   pathnameSelector,
+  searchSelector,
 } from 'common/routing/selectors';
 import Pagination from 'common/Pagination';
 import {
@@ -138,6 +139,7 @@ class SearchScreen extends Component {
   render() {
     const { status } = this.props;
     const pathname = pathnameSelector(this.props);
+    const search = searchSelector(this.props);
     const page = validatePage(pageSelector(this.props));
     const pageSize = 10;
     const totalNum = this.props.data.size;
@@ -153,7 +155,7 @@ class SearchScreen extends Component {
 
     return (
       <section className={styles.searchResult}>
-        {renderHelmet({ title, pathname, page, keyword })}
+        {renderHelmet({ title, pathname, search, page, keyword })}
         <h2 className={styles.heading}>{title}</h2>
         {isFetching(status) && <Loading size="s" />}
         {isFetched(status) &&

--- a/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
+++ b/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
@@ -47,7 +47,7 @@ function getTitle(keyword) {
     if (keyword.length < keywordMinLength) {
       return '請輸入更長的搜尋關鍵字';
     } else {
-      return `查詢「${keyword}」的結果`;
+      return `查詢「${keyword}」薪水的結果`;
     }
   } else {
     return '請輸入搜尋條件！';
@@ -153,7 +153,7 @@ class SearchScreen extends Component {
 
     return (
       <section className={styles.searchResult}>
-        {renderHelmet({ title, pathname, keyword })}
+        {renderHelmet({ title, pathname, page, keyword })}
         <h2 className={styles.heading}>{title}</h2>
         {isFetching(status) && <Loading size="s" />}
         {isFetched(status) &&

--- a/src/components/TimeAndSalary/SearchScreen/helmet.js
+++ b/src/components/TimeAndSalary/SearchScreen/helmet.js
@@ -3,16 +3,17 @@ import Helmet from 'react-helmet';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { imgHost, SITE_NAME } from '../../../constants/helmetData';
 
-export default ({ title, pathname, keyword }) => {
+export default ({ title, pathname, page, keyword }) => {
+  const helmetTitle = `${title} - 第${page}頁`;
   const url = formatCanonicalPath(pathname);
-  const description = `馬上查看${keyword}的薪資、工時資訊以及加班狀況，協助您找到更好的工作！`;
+  const description = `馬上查看${keyword}的薪水、工時資訊以及加班狀況，協助您找到更好的工作！`;
 
   return (
     <Helmet
-      title={title}
+      title={helmetTitle}
       meta={[
         { name: 'description', content: description },
-        { property: 'og:title', content: formatTitle(title, SITE_NAME) },
+        { property: 'og:title', content: formatTitle(helmetTitle, SITE_NAME) },
         { property: 'og:description', content: description },
         { property: 'og:url', content: url },
         {

--- a/src/components/TimeAndSalary/SearchScreen/helmet.js
+++ b/src/components/TimeAndSalary/SearchScreen/helmet.js
@@ -3,9 +3,9 @@ import Helmet from 'react-helmet';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { imgHost, SITE_NAME } from '../../../constants/helmetData';
 
-export default ({ title, pathname, page, keyword }) => {
+export default ({ title, pathname, search, page, keyword }) => {
   const helmetTitle = `${title} - 第${page}頁`;
-  const url = formatCanonicalPath(pathname);
+  const url = `${formatCanonicalPath(pathname)}${search}`;
   const description = `馬上查看${keyword}的薪水、工時資訊以及加班狀況，協助您找到更好的工作！`;
 
   return (

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/helmet.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/helmet.js
@@ -4,18 +4,18 @@ import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { imgHost, SITE_NAME } from '../../../constants/helmetData';
 import { toQsString } from './helper';
 
-export default ({ title, pathname, page }) => {
+export default ({ title, pathname, page, dataNum }) => {
+  const helmetTitle = `${title} - 第${page}頁`;
   const search = page === 1 ? '' : `?${toQsString({ page })}`;
   const url = `${formatCanonicalPath(pathname)}${search}`;
-  const description =
-    '馬上查看薪資、工時資訊以及加班狀況，協助您找到更好的工作！';
+  const description = `查詢各行各業的薪水、加班情況、工時資料，共 ${dataNum} 筆資料`;
 
   return (
     <Helmet
-      title={title}
+      title={helmetTitle}
       meta={[
         { name: 'description', content: description },
-        { property: 'og:title', content: formatTitle(title, SITE_NAME) },
+        { property: 'og:title', content: formatTitle(helmetTitle, SITE_NAME) },
         { property: 'og:description', content: description },
         { property: 'og:url', content: url },
         {

--- a/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
+++ b/src/components/TimeAndSalary/TimeAndSalaryBoard/index.js
@@ -31,7 +31,7 @@ import { DATA_NUM_PER_PAGE } from '../../../constants/timeAndSalarSearch';
 import renderHelmet from './helmet';
 
 const pathParameters = {
-  title: '最新薪資、工時資訊',
+  title: '各行各業薪水查詢',
   label: '資料時間（新到舊）',
   sortBy: 'created_at',
   order: 'descending',
@@ -233,7 +233,7 @@ class TimeAndSalaryBoard extends Component {
 
     return (
       <section className={commonStyles.searchResult}>
-        {renderHelmet({ title, pathname, page })}
+        {renderHelmet({ title, pathname, page, dataNum: totalCount })}
         <h2 className={commonStyles.heading}>{title}</h2>
         <div className={commonStyles.result}>
           <div className={styles.sortRow}>

--- a/src/constants/helmetData.js
+++ b/src/constants/helmetData.js
@@ -39,7 +39,7 @@ export const HELMET_DATA = {
       {
         name: 'keywords',
         content:
-          '工作時間, 薪資福利, 面試經驗, 工作經驗, 實習經驗, 工作評論, 職場資訊透明化',
+          '工作時間, 加班狀況, 薪資福利, 面試經驗, 工作心得, 實習經驗, 工作評論, 職場資訊透明化',
       },
       { property: 'og:title', content: SITE_NAME },
       { property: 'og:url', content: formatCanonicalPath('/') },

--- a/src/graphql/timeAndSalary.js
+++ b/src/graphql/timeAndSalary.js
@@ -34,6 +34,26 @@ export const getCompanyQuery = `
           month
         }
       }
+      salary_work_time_statistics {
+        count
+        average_week_work_time
+        average_estimated_hourly_wage
+        has_compensatory_dayoff_count {
+          yes
+          no
+          unknown
+        }
+        has_overtime_salary_count {
+          yes
+          no
+          unknown
+        }
+        is_overtime_salary_legal_count {
+          yes
+          no
+          unknown
+        }
+      }
     }
   }
 `;
@@ -72,6 +92,26 @@ export const getJobTitleQuery = `
         data_time {
           year
           month
+        }
+      }
+      salary_work_time_statistics {
+        count
+        average_week_work_time
+        average_estimated_hourly_wage
+        has_compensatory_dayoff_count {
+          yes
+          no
+          unknown
+        }
+        has_overtime_salary_count {
+          yes
+          no
+          unknown
+        }
+        is_overtime_salary_legal_count {
+          yes
+          no
+          unknown
         }
       }
     }


### PR DESCRIPTION
Close https://github.com/goodjoblife/GoodJobShare/issues/600

## 這個 PR 是？ <!-- 必填 -->

更新薪資工時列表頁、薪資工時查詢結果頁、單一公司薪資工時頁、單一職業薪資工時頁 的 meta description

## Screenshots  <!-- 選填，沒有就刪掉 -->



## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

1. 最重要的 meta description 是 title & description ，title 的原則是盡可能抓到使用者在搜尋引擎搜尋的字詞，而 description 的原則是儘可能把使用者想要的資訊摘錄在一定的字數內。

因此，幾乎所有原本的 OOO 薪資、加班狀況、工時的字眼都直接改成「OOO薪水」，這個詞在 google trend 上還是最高的。而 description 則是摘要一些重要的統計資訊。

2. 分頁要放標題，內容不同確有一樣標題對 SEO 來說很傷
 

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

by commit 

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 後端起 dev branch 
- [ ] 前端跑起來，打開 devtools element tab
- [ ] 進到薪資工時預設頁面，devtools 搜 title, description, keywords 要是對的，og:title, og:description 要是對的
- [ ] 以公司名稱搜尋結果頁，devtools 搜 title, description, keywords 要是對的，og:title, og:description 要是對的
- [ ] 以職稱搜尋結果頁，devtools 搜 title, description, keywords 要是對的，og:title, og:description 要是對的
- [ ] 單一公司薪資工時頁，devtools 搜 title, description, keywords 要是對的，og:title, og:description 要是對的
- [ ] 單一職業薪資工時頁，devtools 搜 title, description, keywords 要是對的，og:title, og:description 要是對的