### PR TITLE
Fix/salary work time permission

### DIFF
--- a/src/components/common/permission-context/withPermission.js
+++ b/src/components/common/permission-context/withPermission.js
@@ -35,7 +35,7 @@ const withPermission = compose(
         const { pathname } = location;
         const laborRightsSingleRegex = /\/labor-rights\/.+/;
         const experienceDetailRegex = /\/experiences\/.+/;
-        const timeAndSalaryRegex = /\/time-and-salary\/.+/;
+        const salaryWorkTimeRegex = /\/salary-work-times.*/;
 
         // 根據路徑，去更新相關的觀看權限 state
         if (laborRightsSingleRegex.test(pathname)) {
@@ -56,7 +56,7 @@ const withPermission = compose(
             setCanView({ canViewExperirenceDetail: hasPermission });
             return;
           }
-        } else if (timeAndSalaryRegex.test(pathname)) {
+        } else if (salaryWorkTimeRegex.test(pathname)) {
           // 假如是薪資工時查詢頁，localStorage 沒值的話，不更新觀看權限 state。因此不會做阻擋，但是馬上就更新 localStorage。
           const viewedTimeAndSalary = localStorage.getItem(
             'viewedTimeAndSalary',


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

1. 單一公司/職稱薪資工時頁的 permission block 沒有正常運作，原因是 withPermission 裡面的 url regex 沒有根據 route 更新，這個 PR 修正之
2. 薪資時工時列表頁拔掉權限機制

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="957" alt="螢幕快照 2019-03-31 下午1 32 51" src="https://user-images.githubusercontent.com/3805975/55285202-911a8400-53b9-11e9-9109-c86c5e9d92fd.png">
<img width="551" alt="螢幕快照 2019-03-31 下午1 32 59" src="https://user-images.githubusercontent.com/3805975/55285203-911a8400-53b9-11e9-9850-f6fd105ecbbb.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start
- [ ] 不要登入情況下進 `/salary-work-times/latest` 要可以看到所有資料
- [ ] 不要登入情況下進單一公司薪資工時頁 `/companies/{companyName}/salary-work-times` 第一次可以看到該頁資料，第二次就不行了
- [ ] 不要登入情況下進單一職稱薪資工時頁 `/job-titles/{jobTitle}/salary-work-times` 第一次可以看到該頁資料，第二次就不行了
