### PR TITLE
fix: fix working hour formatter

### DIFF
--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -40,8 +40,8 @@ export const getName = (o, row) => (
 export const getEmploymentType = type => (type ? employmentType[type] : '');
 
 export const getWorkingHour = (val, row) => (
-  <div>{`${typeof val === 'undefined' ? '-' : val} / ${
-    typeof row.day_real_work_time === 'undefined' ? '-' : row.day_real_work_time
+  <div>{`${val ? val : '-'} / ${
+    row.day_real_work_time ? row.day_real_work_time : '-'
   }`}</div>
 );
 

--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -40,8 +40,10 @@ export const getName = (o, row) => (
 export const getEmploymentType = type => (type ? employmentType[type] : '');
 
 export const getWorkingHour = (val, row) => (
-  <div>{`${val ? val : '-'} / ${
-    row.day_real_work_time ? row.day_real_work_time : '-'
+  <div>{`${val === undefined || val === null ? '-' : val} / ${
+    row.day_real_work_time === undefined || row.day_real_work_time === null
+      ? '-'
+      : row.day_real_work_time
   }`}</div>
 );
 


### PR DESCRIPTION
Close #622 

## 這個 PR 是？ <!-- 必填 -->

解決後端回 null 時，表訂工時、實際工時會出現 null 的問題
更新後的檢查的方式會讓 null / undefined / 0 都顯示為 `-`  
0 的部分沒什麼參考價值，顯示 `-` 覺得 ok

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="798" alt="螢幕快照 2019-04-05 上午11 38 28" src="https://user-images.githubusercontent.com/3805975/55602311-78361800-5797-11e9-9120-f1408e2b0823.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 留一筆沒有表訂工時、實際工時的資料
- [ ] 前端顯示不應該出現 null / null