### PR TITLE
上方通知連結為何的Rule

### DIFF
--- a/src/components/App/Header/index.js
+++ b/src/components/App/Header/index.js
@@ -105,7 +105,9 @@ class Header extends React.Component {
       ) : (
         <ProgressTop />
       );
-    return <Top link={isLogin ? null : shareLink}>{content}</Top>;
+    return (
+      <Top link={isLogin && !isEmailVerified ? null : shareLink}>{content}</Top>
+    );
   };
 
   render() {


### PR DESCRIPTION
## 這個 PR 是
原本在非登入並且需要顯示進度條的情況下，那條會是沒有連結的，應當為原本的規則。

## 我應該從何看起？
未來還是應該把這段稍微重構一下，但先上這個補救功能，把同一個邏輯寫在不同地方判斷不同事情

## 我應該如何手動測試？
* 以非登入狀態下看進度條的連結