### PR TITLE
Refactor: request user email field in FB SDK

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -27,24 +27,25 @@ export const logout = () => (dispatch, getState, { history }) => {
 
 export const loginWithFB = FB => (dispatch, getState, { api }) => {
   if (FB) {
-    return new Promise(resolve => FB.login(response => resolve(response))).then(
-      response => {
-        if (response.status === authStatus.CONNECTED) {
-          return api.auth
-            .postAuthFacebook({
-              accessToken: response.authResponse.accessToken,
-            })
-            .then(({ token, user: { _id, facebook_id } }) => {
-              dispatch(setLogin(authStatus.CONNECTED, token));
-              dispatch(getMeInfo(token));
-            })
-            .then(() => authStatus.CONNECTED);
-        } else if (response.status === authStatus.NOT_AUTHORIZED) {
-          dispatch(setLogin(authStatus.NOT_AUTHORIZED));
-        }
-        return response.status;
-      },
-    );
+    return new Promise(resolve =>
+      FB.login(response => resolve(response), { scope: 'email' }),
+    ).then(response => {
+      console.log(response);
+      if (response.status === authStatus.CONNECTED) {
+        return api.auth
+          .postAuthFacebook({
+            accessToken: response.authResponse.accessToken,
+          })
+          .then(({ token, user: { _id, facebook_id } }) => {
+            dispatch(setLogin(authStatus.CONNECTED, token));
+            dispatch(getMeInfo(token));
+          })
+          .then(() => authStatus.CONNECTED);
+      } else if (response.status === authStatus.NOT_AUTHORIZED) {
+        dispatch(setLogin(authStatus.NOT_AUTHORIZED));
+      }
+      return response.status;
+    });
   }
   return Promise.reject('FB should ready');
 };

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -30,7 +30,6 @@ export const loginWithFB = FB => (dispatch, getState, { api }) => {
     return new Promise(resolve =>
       FB.login(response => resolve(response), { scope: 'email' }),
     ).then(response => {
-      console.log(response);
       if (response.status === authStatus.CONNECTED) {
         return api.auth
           .postAuthFacebook({


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

前端打 FB login SDK 多要 email 權限

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/558

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

[facebook 文件](https://developers.facebook.com/docs/facebook-login/web/permissions) 最下方有範例 

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 搭配後端 PR https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/558
- [ ] 登出，再登入，`POST /auth/facebook` 應該要回傳 user.email
