### PR TITLE
解經驗單篇warnings

### DIFF
--- a/src/components/ExperienceDetail/Article/index.js
+++ b/src/components/ExperienceDetail/Article/index.js
@@ -64,12 +64,8 @@ class Article extends React.Component {
                   content.length - (currentTotalWords - MAX_WORDS_IF_HIDDEN);
                 const newContent = `${content.substring(0, showLength)}...`;
                 return (
-                  <GradientMask>
-                    <SectionBlock
-                      key={idx}
-                      subtitle={subtitle}
-                      content={newContent}
-                    />
+                  <GradientMask key={idx}>
+                    <SectionBlock subtitle={subtitle} content={newContent} />
                   </GradientMask>
                 );
               }

--- a/src/components/ExperienceDetail/Article/index.js
+++ b/src/components/ExperienceDetail/Article/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compose, withState, withHandlers } from 'recompose';
 import cn from 'classnames';
 
 import { Heading, P } from 'common/base';
@@ -14,17 +13,11 @@ import { MAX_WORDS_IF_HIDDEN } from '../../../constants/hideContent';
 import ReportDetail from 'common/reaction/ReportDetail';
 import PopoverToggle from 'common/PopoverToggle';
 import ReactionZoneOtherOptions from '../ReactionZone/ReactionZoneOtherOptions';
-import ReportInspectModal from '../ReactionZone/ReportInspectModal';
 import ReactionZoneStyles from '../ReactionZone/ReactionZone.module.css';
 
 class Article extends React.Component {
   renderReportZone = () => {
-    const {
-      id,
-      openReportDetail,
-      isInspectReportOpen,
-      toggleReportInspectModal,
-    } = this.props;
+    const { openReportDetail, toggleReportInspectModal } = this.props;
     return (
       <React.Fragment>
         <div className={styles.functionButtons}>
@@ -47,11 +40,6 @@ class Article extends React.Component {
             </div>
           </PopoverToggle>
         </div>
-        <ReportInspectModal
-          id={id}
-          isOpen={isInspectReportOpen}
-          toggleReportInspectModal={toggleReportInspectModal}
-        />
       </React.Fragment>
     );
   };
@@ -142,22 +130,8 @@ class Article extends React.Component {
 Article.propTypes = {
   experience: PropTypes.object.isRequired,
   hideContent: PropTypes.bool.isRequired,
-  id: PropTypes.string.isRequired,
   openReportDetail: PropTypes.func.isRequired,
-  isInspectReportOpen: PropTypes.bool.isRequired,
   toggleReportInspectModal: PropTypes.func.isRequired,
 };
 
-const enhance = compose(
-  withState('isInspectReportOpen', 'setIsInspectReportOpen', false),
-  withHandlers({
-    toggleReportInspectModal: ({
-      isInspectReportOpen,
-      setIsInspectReportOpen,
-    }) => () => {
-      setIsInspectReportOpen(!isInspectReportOpen);
-    },
-  }),
-);
-
-export default enhance(Article);
+export default Article;

--- a/src/components/ExperienceDetail/Heading/index.js
+++ b/src/components/ExperienceDetail/Heading/index.js
@@ -33,7 +33,7 @@ const ExperienceHeading = ({ experience, className }) => (
       {experience && formatType(experience.type)}
     </P>
     <Heading size="l">
-      {experience && formatComapny(experience.company)}
+      {(experience && formatComapny(experience.company)) || ''}
     </Heading>
   </div>
 );

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -5,7 +5,7 @@ import R from 'ramda';
 import Helmet from 'react-helmet';
 import ReactPixel from 'react-facebook-pixel';
 import { Element as ScrollElement } from 'react-scroll';
-import { compose, setStatic } from 'recompose';
+import { compose, setStatic, withState, withHandlers } from 'recompose';
 
 import Loader from 'common/Loader';
 import { Wrapper, Section } from 'common/base';
@@ -19,6 +19,7 @@ import BackToList from './BackToList';
 import ApiErrorFeedback from './ReportForm/ApiErrorFeedback';
 import ReportSuccessFeedback from './ReportForm/ReportSuccessFeedback';
 import ExperienceHeading from './Heading';
+import ReportInspectModal from './ReactionZone/ReportInspectModal';
 
 import status from '../../constants/status';
 import { fetchExperience } from '../../actions/experienceDetail';
@@ -78,6 +79,8 @@ class ExperienceDetail extends Component {
     }),
     authStatus: PropTypes.string,
     canViewExperirenceDetail: PropTypes.bool.isRequired,
+    isInspectReportOpen: PropTypes.bool.isRequired,
+    toggleReportInspectModal: PropTypes.func.isRequired,
   };
 
   constructor(props) {
@@ -256,7 +259,13 @@ class ExperienceDetail extends Component {
   };
 
   render() {
-    const { likeExperience, likeReply, canViewExperirenceDetail } = this.props;
+    const {
+      likeExperience,
+      likeReply,
+      canViewExperirenceDetail,
+      isInspectReportOpen,
+      toggleReportInspectModal,
+    } = this.props;
     const id = experienceIdSelector(this.props);
 
     const {
@@ -311,16 +320,21 @@ class ExperienceDetail extends Component {
                   />
                 </div>
                 <Article
-                  id={id}
                   experience={experience}
                   hideContent={!canViewExperirenceDetail}
                   openReportDetail={() => {
                     this.setModalClosableOnClickOutside(false);
                     this.handleIsModalOpen(true, MODAL_TYPE.REPORT_DETAIL);
                   }}
+                  toggleReportInspectModal={toggleReportInspectModal}
                 />
               </Fragment>
             )}
+            <ReportInspectModal
+              id={id}
+              isOpen={isInspectReportOpen}
+              toggleReportInspectModal={toggleReportInspectModal}
+            />
 
             <LikeZone experience={experience} likeExperience={likeExperience} />
           </Wrapper>
@@ -358,6 +372,15 @@ const ssr = setStatic('fetchData', ({ store: { dispatch }, ...props }) => {
 const hoc = compose(
   ssr,
   withPermission,
+  withState('isInspectReportOpen', 'setIsInspectReportOpen', false),
+  withHandlers({
+    toggleReportInspectModal: ({
+      isInspectReportOpen,
+      setIsInspectReportOpen,
+    }) => () => {
+      setIsInspectReportOpen(!isInspectReportOpen);
+    },
+  }),
 );
 
 export default hoc(ExperienceDetail);

--- a/src/components/TimeAndSalary/index.js
+++ b/src/components/TimeAndSalary/index.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ImmutablePropTypes from 'react-immutable-proptypes';
 import Helmet from 'react-helmet';
 import { Switch } from 'react-router';
 import { compose } from 'recompose';
@@ -19,8 +18,6 @@ import { IMG_HOST, SITE_NAME } from '../../constants/helmetData';
 
 class TimeAndSalary extends Component {
   static propTypes = {
-    campaignEntries: ImmutablePropTypes.map.isRequired,
-    queryCampaignInfoListIfNeeded: PropTypes.func.isRequired,
     routes: PropTypes.array,
     location: PropTypes.shape({
       pathname: PropTypes.string,


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

目前的經驗單篇有許多warnings，沒解掉的時候開發有點干擾，索性先解掉。
1. `InsepectReportModal`因為放在conditional rendered component裡面，所以因為async actions而造成no-op
 - **解法**：移到非conditional rendered的parent component
2. for loop key prop
 - **解法**：把key放對地方
3. `<Heading />`的`children` isRequired卻傳進`null`
 - **解法**：當null的時候就傳空字串

另外最新薪資工時(`TimeAndSalary`)也有props warning，因為是出於之前把campaign沒拿乾淨而出現的warning，把propTypes拿掉即可。

## Screenshots  <!-- 選填，沒有就刪掉 -->

- Before
![http://g.recordit.co/vm8nQeFvPS.gif](http://g.recordit.co/vm8nQeFvPS.gif)

- After
![http://g.recordit.co/uroK1UJ21V.gif](http://g.recordit.co/uroK1UJ21V.gif)

另外附上TimeAndSalary的warning：
<img width="1280" alt="螢幕快照 2019-05-01 下午3 43 16" src="https://user-images.githubusercontent.com/7566586/57009210-eb606c00-6c27-11e9-9ac9-354267cd7c01.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] dev模式下點開經驗單篇，看有否warning
- [ ] dev模式下點最新薪資工時，看有否warning