### PR TITLE
Refactor: remove email field from SalaryWorkTime form

### DIFF
--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -458,13 +458,6 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
               />
             </div>
           ))}
-
-          <InputTitle text="電子郵件 - 有消息時將通知您" />
-          <TextInput
-            value={email}
-            placeholder="example@email.com"
-            onChange={e => this.handleState('email')(e.target.value)}
-          />
         </IconHeadingBlock>
 
         <SubmitArea onSubmit={this.onSubmit} />

--- a/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
+++ b/src/components/ShareExperience/TimeSalaryForm/TimeSalaryForm.module.css
@@ -193,7 +193,9 @@
 }
 
 .radioButton {
-  margin-bottom: 40px;
+  &:not(:last-child) {
+    margin-bottom: 40px;
+  }
   &:before,
   &:after {
     content: '';

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -5,11 +5,9 @@ import { scroller } from 'react-scroll';
 import { Heading } from 'common/base';
 import { People } from 'common/icons';
 import IconHeadingBlock from 'common/IconHeadingBlock';
-import TextInput from 'common/form/TextInput';
 import BasicInfo from './BasicInfo';
 import SalaryInfo from './SalaryInfo';
 import TimeInfo from './TimeInfo';
-import InputTitle from '../common/InputTitle';
 import SubmitArea from '../../../containers/ShareExperience/SubmitAreaContainer';
 import styles from './TimeSalaryForm.module.css';
 
@@ -253,7 +251,6 @@ class TimeSalaryForm extends React.PureComponent {
       hasOvertimeSalary,
       isOvertimeSalaryLegal,
       hasCompensatoryDayoff,
-      email,
     } = this.state;
 
     return (
@@ -311,13 +308,6 @@ class TimeSalaryForm extends React.PureComponent {
             hasOvertimeSalary={hasOvertimeSalary}
             isOvertimeSalaryLegal={isOvertimeSalaryLegal}
             hasCompensatoryDayoff={hasCompensatoryDayoff}
-          />
-
-          <InputTitle text="電子郵件 - 有消息時將通知您" />
-          <TextInput
-            value={email}
-            placeholder="example@email.com"
-            onChange={e => this.handleState('email')(e.target.value)}
           />
         </IconHeadingBlock>
 


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

移除薪資工時表單的 email 欄位

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="893" alt="螢幕快照 2019-05-01 下午5 16 15" src="https://user-images.githubusercontent.com/3805975/57011572-e1913580-6c34-11e9-9e4c-a71bdc75d3c9.png">

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

<!-- 這個 PR 要怎麼 review 才會比較好懂 (e.g. by commit 看，或先看哪些檔案) -->
<!-- 介紹一下你為什麼要這麼寫，思路是什麼？ -->

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進到 /share/time-and-salary 頁，填寫一筆薪資工時資料，要能正常送出資料
