### PR TITLE
Fix auth change then recursive trigger auth check

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -2,23 +2,17 @@ import authStatus from '../constants/authStatus';
 
 export const SET_LOGIN = '@@auth/SET_LOGIN';
 export const SET_USER = '@@auth/SET_USER';
-export const SET_TOKEN = '@@auth/SET_TOKEN';
 export const LOG_OUT = '@@auth/LOG_OUT';
 
-export const setLogin = (status, token = null) => ({
+const setLogin = (status, token = null) => ({
   type: SET_LOGIN,
   status,
   token,
 });
 
-export const setUser = user => ({
+const setUser = user => ({
   type: SET_USER,
   user,
-});
-
-export const setToken = token => ({
-  type: SET_TOKEN,
-  token,
 });
 
 const logOutAction = () => ({
@@ -56,12 +50,20 @@ export const loginWithFB = FB => (dispatch, getState, { api }) => {
 const getMeInfo = token => (dispatch, getState, { api }) =>
   api.me.getMe({ token }).catch(error => {
     dispatch(logOutAction());
-
-    console.error(error);
+    throw error;
   });
 
+/**
+ * Flow
+ *
+ * loginWithFB   ---\                      |
+ *          (token) +--> loginWithToken  --|
+ * loginWithXXX  ---/                      | Auth State
+ *                                         |   Update
+ *                               logout  --|
+ *                                         |
+ */
 export const loginWithToken = token => (dispatch, getState, { api }) => {
-  dispatch(setToken(token));
   dispatch(getMeInfo(token))
     .then(user => {
       dispatch(setUser(user));

--- a/src/containers/App/SyncAuth/index.js
+++ b/src/containers/App/SyncAuth/index.js
@@ -26,15 +26,6 @@ const hoc = compose(
         loginWithToken(token);
       }
     },
-    componentDidUpdate(prevProps) {
-      if (
-        prevProps.authStatus !== this.props.authStatus &&
-        this.props.authStatus === CONNECTED
-      ) {
-        const { loginWithToken, token } = this.props;
-        loginWithToken(token);
-      }
-    },
   }),
 );
 

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,7 +1,7 @@
 import { fromJS } from 'immutable';
 
 import createReducer from 'utils/createReducer';
-import { SET_LOGIN, SET_USER, SET_TOKEN } from '../actions/auth';
+import { SET_LOGIN, SET_USER } from '../actions/auth';
 
 import authStatus from '../constants/authStatus';
 
@@ -18,7 +18,6 @@ const preloadedState = fromJS({
 const auth = createReducer(preloadedState, {
   [SET_LOGIN]: (state, { status, token }) => state.merge({ status, token }),
   [SET_USER]: (state, { user }) => state.setIn(['user'], fromJS(user)),
-  [SET_TOKEN]: (state, { token }) => state.setIn(['token'], token),
 });
 
 export default auth;


### PR DESCRIPTION
解決登入邏輯判定錯誤，造成無限迴圈的重新登入檢查

1. 在網頁開始時，與後端同步本地端儲存的登入狀態（`src/containers/App/SyncAuth/index.js`），移除不必要的檢查
2. `getMeInfo` (`src/actions/auth.js`) 會拋出錯誤，讓 loginWithToken 處理（無限迴圈的一個原因）
1. 移除 `SET_TOKEN`，麻煩 @WendellLiu 確認
2. 把登入流程具體寫出（見註解）

這個 PR 也是跟著 #668 而發現的