### PR TITLE
Fix #680, avoid force reload

### DIFF
--- a/src/components/common/PermissionBlock/CallToLoginShareButton.js
+++ b/src/components/common/PermissionBlock/CallToLoginShareButton.js
@@ -17,17 +17,9 @@ const CallToLoginShareButton = ({
   FB,
 }) => {
   const onClick = () => {
-    login(FB)
-      .then(status => {
-        if (status === authStatus.CONNECTED) {
-          window.location.reload();
-        } else {
-          throw new Error('can not login');
-        }
-      })
-      .catch(e => {
-        console.log(e);
-      });
+    login(FB).catch(e => {
+      console.log(e);
+    });
   };
 
   return (


### PR DESCRIPTION
close #680 

這個 PR 修正掉 reload 的部分，由於 reload 的關係，有可能導致 store 沒有及時 sync 至 localStorage

major:
1. 麻煩 @barry800414 確認為什麼當初要用 window.location.reload，避免這個 fix 造成新的 bug

minor:
1. 麻煩 @WendellLiu 如果有空確認一下 store 至 localStorage 的時機，這個不影響 bug 修復，事實上本來就不能依賴 localStroage 的儲存會是 non-async