### PR TITLE
force experience refetch

### DIFF
--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -97,11 +97,7 @@ class ExperienceDetail extends Component {
   componentDidMount() {
     const experienceId = experienceIdSelector(this.props);
 
-    if (
-      this.props.experienceDetail.getIn(['experience', '_id']) !== experienceId
-    ) {
-      this.props.fetchExperience(experienceId);
-    }
+    this.props.fetchExperience(experienceId);
     this.props.fetchReplies(experienceId);
     this.props.fetchPermission();
 


### PR DESCRIPTION
經驗單篇在SSR時因為沒有token，會render出沒有登入的狀態
但若使用者已經登入而且已經對該篇經驗按讚
`liked`的狀態會抓不到，此時也無法取消讚
解法是`componentDidMount`強制重打API使store的資料是登入狀態的