### PR TITLE
Modal的close button stop propagation

### DIFF
--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -22,7 +22,7 @@ const Modal = ({ children, isOpen, hasClose, close, size, onClickOutside }) => (
             <img
               src={Cross}
               className={styles.close__icon}
-              onClick={close}
+              onClick={e => e.stopPropagation() || close()}
               alt="close"
             />
           </div>


### PR DESCRIPTION
Modal的close button需要stopPropagation
因為現在的Modal已經可以點背景就關閉了
而close button也在背景上，所以若沒stopPropagation就會呼叫close兩次
這在AboutThisJobModal會有問題～