### PR TITLE
refactor: increase experience.title length to 50 chars

### DIFF
--- a/src/components/ShareExperience/InterviewForm/formCheck.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.js
@@ -35,7 +35,7 @@ export const salaryAmount = R.anyPass([
 
 export const overallRating = R.allPass([n => n >= 1, n => n <= 5]);
 
-export const title = R.allPass([gtLength(0), lteLength(25)]);
+export const title = R.allPass([gtLength(0), lteLength(50)]);
 
 const sectionSubtitle = R.compose(
   R.allPass([lteLength(25), gtLength(0)]),

--- a/src/components/ShareExperience/InterviewForm/formCheck.test.js
+++ b/src/components/ShareExperience/InterviewForm/formCheck.test.js
@@ -122,14 +122,19 @@ describe('overallRating test', () => {
 });
 
 describe('title test', () => {
-  test('string length in (0, 25] should pass', () => {
+  test('string length in (0, 50] should pass', () => {
     expect(title('abcdeabcde')).toBe(true);
     expect(title('abcdeabcdeabcdeabcdeabcde')).toBe(true);
     expect(title('abc')).toBe(true);
+    expect(title('abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde')).toBe(
+      true,
+    );
   });
 
-  test('string length not in (0, 25] should not pass', () => {
-    expect(title('abcdeabcdeabcdeabcdeabcdeabcde')).toBe(false);
+  test('string length not in (0, 50] should not pass', () => {
+    expect(
+      title('abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde'),
+    ).toBe(false);
     expect(title('')).toBe(false);
   });
 });

--- a/src/components/ShareExperience/InterviewStepsForm/formCheck.js
+++ b/src/components/ShareExperience/InterviewStepsForm/formCheck.js
@@ -35,7 +35,7 @@ export const salaryAmount = R.anyPass([
 
 export const overallRating = R.allPass([n => n >= 1, n => n <= 5]);
 
-export const title = R.allPass([gtLength(0), lteLength(25)]);
+export const title = R.allPass([gtLength(0), lteLength(50)]);
 
 const sectionSubtitle = R.compose(
   R.allPass([lteLength(25), gtLength(0)]),

--- a/src/components/ShareExperience/InterviewStepsForm/formCheck.test.js
+++ b/src/components/ShareExperience/InterviewStepsForm/formCheck.test.js
@@ -122,14 +122,19 @@ describe('overallRating test', () => {
 });
 
 describe('title test', () => {
-  test('string length in (0, 25] should pass', () => {
+  test('string length in (0, 50] should pass', () => {
     expect(title('abcdeabcde')).toBe(true);
     expect(title('abcdeabcdeabcdeabcdeabcde')).toBe(true);
     expect(title('abc')).toBe(true);
+    expect(title('abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde')).toBe(
+      true,
+    );
   });
 
-  test('string length not in (0, 25] should not pass', () => {
-    expect(title('abcdeabcdeabcdeabcdeabcdeabcde')).toBe(false);
+  test('string length not in (0, 50] should not pass', () => {
+    expect(
+      title('abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde'),
+    ).toBe(false);
     expect(title('')).toBe(false);
   });
 });

--- a/src/components/ShareExperience/WorkExperiencesForm/formCheck.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/formCheck.js
@@ -22,7 +22,7 @@ export const salaryAmount = R.anyPass([
 
 export const weekWorkTime = R.allPass([n => n >= 0, n => n <= 168]);
 
-export const title = R.allPass([gtLength(0), lteLength(25)]);
+export const title = R.allPass([gtLength(0), lteLength(50)]);
 
 const sectionSubtitle = R.compose(
   R.allPass([lteLength(25), gtLength(0)]),

--- a/src/components/ShareExperience/WorkExperiencesForm/formCheck.test.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/formCheck.test.js
@@ -84,14 +84,19 @@ describe('salaryAmount test', () => {
 });
 
 describe('title test', () => {
-  test('string length in (0, 25] should pass', () => {
+  test('string length in (0, 50] should pass', () => {
     expect(title('abcdeabcde')).toBe(true);
     expect(title('abcdeabcdeabcdeabcdeabcde')).toBe(true);
     expect(title('abc')).toBe(true);
+    expect(title('abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde')).toBe(
+      true,
+    );
   });
 
-  test('string length not in (0, 25] should not pass', () => {
-    expect(title('abcdeabcdeabcdeabcdeabcdeabcde')).toBe(false);
+  test('string length not in (0,50] should not pass', () => {
+    expect(
+      title('abcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcdeabcde'),
+    ).toBe(false);
     expect(title('')).toBe(false);
   });
 });

--- a/src/components/ShareExperience/common/Title.js
+++ b/src/components/ShareExperience/common/Title.js
@@ -13,7 +13,7 @@ const Title = ({ title, onChange, placeholder, validator, submitted }) => (
       placeholder={placeholder}
       onChange={e => onChange(e.target.value)}
       isWarning={submitted && !validator(title)}
-      warningWording="需輸入 1 ~ 25 字"
+      warningWording="需輸入 1 ~ 50 字"
     />
   </div>
 );


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

有使用者反映標題長度太短，公司名稱太長時，就會導致錯誤訊息
因此把經驗分享標題的字數拉到 50 個字

## 若可以手動測試，要如何測試？ <!-- 選填 -->

- [ ] 拉後端 https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/584 ，進行測試
- [ ] 標題若大於 25 字，小於等於 50 字，應該要可以送出
- [ ] 標題若大於 50 字，應該不能送出
