### PR TITLE
[hotfix] Time and Salary Board Link of Job Title

### DIFF
--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -22,7 +22,9 @@ export const getJobTitle = item => {
   return (
     <div>
       <Link
-        to={`/job-titles/${encodeURIComponent(jobTitle)}/salary-work-times`}
+        to={`/job-titles/${encodeURIComponent(
+          jobTitle.name,
+        )}/salary-work-times`}
       >
         {jobTitle.name}
       </Link>{' '}


### PR DESCRIPTION
## 這個 PR 是？
薪資工時頁面，表格內容中的「職稱」連結，會因為取值方式錯誤，解析出錯誤的link。

## Screenshots

**before**
`https://www.goodjob.life/salary-work-times/latest`
![2019-06-17 14 10 28](https://user-images.githubusercontent.com/8898129/59582202-06206e80-910a-11e9-8992-4094d0a88ee8.gif)

**after**
![2019-06-17 14 10 07](https://user-images.githubusercontent.com/8898129/59582206-0e78a980-910a-11e9-8b8b-7024ad08d778.gif)

## 我應該如何手動測試？ 

- [ ] `https://www.goodjob.life/salary-work-times/latest`
- [ ] 點擊或觀察任一職稱連結