### PR TITLE
Handle erros on ExperienceDetail page

### DIFF
--- a/src/actions/experienceDetail.js
+++ b/src/actions/experienceDetail.js
@@ -1,5 +1,6 @@
 import fetchingStatus from '../constants/status';
 import { tokenSelector } from '../selectors/authSelector';
+import { UiNotFoundError } from 'utils/errors';
 
 export const SET_EXPERIENCE = '@@experienceDetail/SET_EXPERIENCE';
 export const SET_EXPERIENCE_STATUS = '@@experienceDetail/SET_EXPERIENCE_STATUS';
@@ -144,16 +145,27 @@ export const fetchExperience = id => (dispatch, getState, { api }) => {
 
   return api.experiences
     .getExperience({ id, token })
-    .then(result => {
-      dispatch(setExperience(result));
+    .then(experience => {
+      if (experience === null) {
+        return dispatch({
+          type: SET_EXPERIENCE,
+          experienceStatus: fetchingStatus.ERROR,
+          experienceError: new UiNotFoundError(),
+          experience: null,
+        });
+      }
+
+      const { id, ...rest } = experience;
+      dispatch(setExperience({ _id: id, ...rest }));
     })
     .catch(error => {
       dispatch({
         type: SET_EXPERIENCE,
         experienceStatus: fetchingStatus.ERROR,
         experienceError: error,
-        experience: {},
+        experience: null,
       });
+      throw error;
     });
 };
 

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -91,9 +91,7 @@ export const getExperience = ({ id, token }) =>
     query: getExperienceQuery,
     variables: { id },
     token,
-  })
-    .then(data => data.experience)
-    .then(({ id, ...rest }) => ({ _id: id, ...rest }));
+  }).then(data => data.experience);
 
 export const newExperienceSearchBy = ({ body }) =>
   fetchUtil('/graphql').post({ body });

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -22,7 +22,7 @@ import ReportSuccessFeedback from './ReportForm/ReportSuccessFeedback';
 import ExperienceHeading from './Heading';
 import ReportInspectModal from './ReactionZone/ReportInspectModal';
 
-import status from '../../constants/status';
+import { isFetching, isFetched, isError } from '../../constants/status';
 import { fetchExperience } from '../../actions/experienceDetail';
 import ReportFormContainer from '../../containers/ExperienceDetail/ReportFormContainer';
 
@@ -208,49 +208,48 @@ class ExperienceDetail extends Component {
   };
 
   renderHelmet = () => {
-    if (this.props.experienceDetail) {
-      const experience = this.props.experienceDetail.toJS().experience;
-      if ('_id' in experience) {
-        const id = experience._id;
-        const title = experience.title;
-        const company = experience.company.name;
-        const jobTitle = experience.job_title;
-        const type = experience.type;
-        const subtitle = experience.sections[0].subtitle
-          ? experience.sections[0].subtitle.replace(/(\r\n|\n|\r)/gm, ' ')
-          : '';
-        const content = experience.sections[0].content.replace(
-          /(\r\n|\n|\r)/gm,
-          ' ',
-        );
-        const mapping = {
-          interview: '面試經驗分享',
-          work: '工作經驗分享',
-          intern: '實習經驗分享',
-        };
-        const description = `${company} ${jobTitle} 的${
-          mapping[type]
-        }。 ${subtitle}：${content}`;
-        return (
-          <Helmet>
-            <title itemProp="name" lang="zh-TW">
-              {title}
-            </title>
-            <meta name="description" content={description} />
-            <meta property="og:title" content={formatTitle(title, SITE_NAME)} />
-            <meta property="og:description" content={description} />
-            <meta
-              property="og:url"
-              content={formatCanonicalPath(`/experiences/${id}`)}
-            />
-            <link
-              rel="canonical"
-              href={formatCanonicalPath(`/experiences/${id}`)}
-            />
-          </Helmet>
-        );
-      }
-      return null;
+    const data = this.props.experienceDetail.toJS();
+    const { experience, experienceStatus } = data;
+
+    if (isFetched(experienceStatus)) {
+      const id = experience._id;
+      const title = experience.title;
+      const company = experience.company.name;
+      const jobTitle = experience.job_title;
+      const type = experience.type;
+      const subtitle = experience.sections[0].subtitle
+        ? experience.sections[0].subtitle.replace(/(\r\n|\n|\r)/gm, ' ')
+        : '';
+      const content = experience.sections[0].content.replace(
+        /(\r\n|\n|\r)/gm,
+        ' ',
+      );
+      const mapping = {
+        interview: '面試經驗分享',
+        work: '工作經驗分享',
+        intern: '實習經驗分享',
+      };
+      const description = `${company} ${jobTitle} 的${
+        mapping[type]
+      }。 ${subtitle}：${content}`;
+      return (
+        <Helmet>
+          <title itemProp="name" lang="zh-TW">
+            {title}
+          </title>
+          <meta name="description" content={description} />
+          <meta property="og:title" content={formatTitle(title, SITE_NAME)} />
+          <meta property="og:description" content={description} />
+          <meta
+            property="og:url"
+            content={formatCanonicalPath(`/experiences/${id}`)}
+          />
+          <link
+            rel="canonical"
+            href={formatCanonicalPath(`/experiences/${id}`)}
+          />
+        </Helmet>
+      );
     }
     return null;
   };
@@ -283,7 +282,7 @@ class ExperienceDetail extends Component {
     const replies = this.props.replies.toJS();
     const repliesStatus = this.props.repliesStatus;
 
-    if (experienceError) {
+    if (isError(experienceStatus)) {
       if (isUiNotFoundError(experienceError)) {
         return <NotFound />;
       }
@@ -296,7 +295,7 @@ class ExperienceDetail extends Component {
         <Section bg="white" paddingBottom pageTop>
           <Wrapper size="l">
             {/* 文章區塊  */}
-            {experienceStatus === status.FETCHING ? (
+            {!isFetched(experienceStatus) ? (
               <Loader />
             ) : (
               <Fragment>
@@ -323,12 +322,16 @@ class ExperienceDetail extends Component {
               isOpen={isInspectReportOpen}
               toggleReportInspectModal={toggleReportInspectModal}
             />
-
-            <LikeZone experience={experience} likeExperience={likeExperience} />
+            {isFetched(experienceStatus) && (
+              <LikeZone
+                experience={experience}
+                likeExperience={likeExperience}
+              />
+            )}
           </Wrapper>
           <Wrapper size="s">
             <ScrollElement name={COMMENT_ZONE} />
-            {repliesStatus === status.FETCHING ? (
+            {isFetching(repliesStatus) ? (
               <Loader size="s" />
             ) : (
               <MessageBoard

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -287,6 +287,7 @@ class ExperienceDetail extends Component {
       if (isUiNotFoundError(experienceError)) {
         return <NotFound />;
       }
+      return null;
     }
 
     return (

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -251,7 +251,7 @@ class ExperienceDetail extends Component {
       const id = experience._id;
       const title = experience.title;
       const company = experience.company.name;
-      const jobTitle = experience.job_title;
+      const jobTitle = experience.job_title.name;
       const type = experience.type;
       const subtitle = experience.sections[0].subtitle
         ? experience.sections[0].subtitle.replace(/(\r\n|\n|\r)/gm, ' ')

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -12,6 +12,7 @@ import { Wrapper, Section } from 'common/base';
 import Modal from 'common/Modal';
 import NotFound from 'common/NotFound';
 import { withPermission } from 'common/permission-context';
+import { isUiNotFoundError } from 'utils/errors';
 
 import Article from './Article';
 import MessageBoard from '../../containers/ExperienceDetail/MessageBoard';
@@ -283,18 +284,8 @@ class ExperienceDetail extends Component {
     const repliesStatus = this.props.repliesStatus;
 
     if (experienceError) {
-      switch (experienceError.statusCode) {
-        case 403:
-          return (
-            <NotFound
-              heading="本篇文章已經被原作者隱藏，目前無法查看"
-              status={403}
-            />
-          );
-        case 404:
-          return <NotFound />;
-        default:
-          return null;
+      if (isUiNotFoundError(experienceError)) {
+        return <NotFound />;
       }
     }
 

--- a/src/reducers/experienceDetail.js
+++ b/src/reducers/experienceDetail.js
@@ -12,7 +12,7 @@ import {
 const preloadedState = fromJS({
   experienceStatus: fetchingStatus.UNFETCHED,
   experienceError: null,
-  experience: {},
+  experience: null,
   repliesExperienceId: null,
   replyStatus: fetchingStatus.UNFETCHED,
   replyError: null,

--- a/src/utils/errors/graphqlError.js
+++ b/src/utils/errors/graphqlError.js
@@ -1,0 +1,24 @@
+import R from 'ramda';
+
+const mapErrorMessages = R.compose(
+  R.join(', '),
+  R.map(R.prop('message')),
+);
+
+const mapErrorCodes = R.map(R.props(['extensions', 'code']));
+const mapErrorPaths = R.map(R.prop('path'));
+
+class GraphqlError extends Error {
+  constructor(errors) {
+    const message = `GraphqlError: ${mapErrorMessages(errors)}`;
+    super(message);
+
+    this.name = 'GraphqlError';
+    this.codes = mapErrorCodes(errors);
+    this.paths = mapErrorPaths(errors);
+    Error.captureStackTrace(this, GraphqlError);
+  }
+}
+
+export default GraphqlError;
+export const isGraphqlError = R.propEq('name', 'GraphqlError');

--- a/src/utils/errors/index.js
+++ b/src/utils/errors/index.js
@@ -1,2 +1,7 @@
 import HttpError, { isHttpError } from './httpError';
+import GraphqlError, { isGraphqlError } from './graphqlError';
+import UiNotFoundError, { isUiNotFoundError } from './uiNotFoundError';
+
 export { HttpError, isHttpError };
+export { GraphqlError, isGraphqlError };
+export { UiNotFoundError, isUiNotFoundError };

--- a/src/utils/errors/uiNotFoundError.js
+++ b/src/utils/errors/uiNotFoundError.js
@@ -1,0 +1,13 @@
+import R from 'ramda';
+
+class UiNotFoundError extends Error {
+  constructor(message) {
+    super(message);
+
+    this.name = 'UiNotFoundError';
+    Error.captureStackTrace(this, UiNotFoundError);
+  }
+}
+
+export default UiNotFoundError;
+export const isUiNotFoundError = R.propEq('name', 'UiNotFoundError');

--- a/src/utils/graphqlClient.js
+++ b/src/utils/graphqlClient.js
@@ -1,21 +1,12 @@
-import { map, prop, compose, join } from 'ramda';
+import { GraphqlError } from 'utils/errors';
 import fetchUtil from './fetchUtil';
 
 const fetch = fetchUtil('/graphql');
 
-const mapErrorMessages = compose(
-  join(', '),
-  map(prop('message')),
-);
-
 const graphqlClient = ({ variables, query, options, token }) =>
   fetch.post({ body: { query, variables }, token, options }).then(response => {
     if (response.errors) {
-      return Promise.reject(
-        new Error(
-          `Graphql Server Errors: ${mapErrorMessages(response.errors)}`,
-        ),
-      );
+      throw new GraphqlError(response.errors);
     }
     return response.data;
   });


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

整理了常見的 Error

1. HttpError, GraphqlError 是做 http query, graphql Query 時產生的 Error，可能是有辦法處理的，也可能是不預期的
2. UiXXXError 是已知可以呈現在 UI 的錯誤

錯誤處理流程如下：

```
HttpError, GraphqlError ==> 如果是已知的錯誤 ==> 轉為 Action, 並停止拋出
                        ==> 如果是無法處理的錯誤 ==> 拋出，讓 Sentry 可以接到
```