### PR TITLE
解決填寫表單appendBlock的覆寫問題

### DIFF
--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -65,7 +65,7 @@ const createBlock = {
   interviewQas: createInterviewQa,
 };
 
-const idCounter = idGenerator();
+let idCounter = idGenerator();
 
 const isBlockRemovable = blocks => R.length(R.keys(blocks)) > 1;
 
@@ -117,9 +117,11 @@ class InterviewForm extends React.Component {
     let defaultFromDraft;
 
     try {
-      defaultFromDraft = JSON.parse(
+      const { __nextId, ...storedDraft } = JSON.parse(
         localStorage.getItem(LS_INTERVIEW_FORM_KEY),
       );
+      defaultFromDraft = storedDraft;
+      idCounter = idGenerator(__nextId);
     } catch (error) {
       defaultFromDraft = null;
     }
@@ -217,7 +219,13 @@ class InterviewForm extends React.Component {
         ...this.state,
         ...updateState,
       };
-      localStorage.setItem(LS_INTERVIEW_FORM_KEY, JSON.stringify(state));
+      localStorage.setItem(
+        LS_INTERVIEW_FORM_KEY,
+        JSON.stringify({
+          ...state,
+          __nextId: idCounter(),
+        }),
+      );
     };
   }
 

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -95,6 +95,13 @@ const defaultForm = {
   interviewSensitiveQuestions: [],
 };
 
+const getMaxId = state => {
+  const ids = [...R.keys(state.sections), ...R.keys(state.interviewQas)];
+  const maxId = R.reduce(R.max, -Infinity, ids);
+  if (maxId === undefined) return -1;
+  return maxId;
+};
+
 class InterviewForm extends React.Component {
   constructor(props) {
     super(props);
@@ -121,7 +128,11 @@ class InterviewForm extends React.Component {
         localStorage.getItem(LS_INTERVIEW_FORM_KEY),
       );
       defaultFromDraft = storedDraft;
-      idCounter = idGenerator(__nextId);
+      idCounter = idGenerator(
+        typeof __nextId !== undefined
+          ? __nextId
+          : getMaxId(storedDraft),
+      );
     } catch (error) {
       defaultFromDraft = null;
     }

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -234,7 +234,7 @@ class InterviewForm extends React.Component {
         LS_INTERVIEW_FORM_KEY,
         JSON.stringify({
           ...state,
-          __nextId: idCounter(),
+          __nextId: idCounter.getCurrent(),
         }),
       );
     };

--- a/src/components/ShareExperience/InterviewForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/index.js
@@ -124,13 +124,13 @@ class InterviewForm extends React.Component {
     let defaultFromDraft;
 
     try {
-      const { __nextId, ...storedDraft } = JSON.parse(
+      const { __idCounterCurrent, ...storedDraft } = JSON.parse(
         localStorage.getItem(LS_INTERVIEW_FORM_KEY),
       );
       defaultFromDraft = storedDraft;
       idCounter = idGenerator(
-        typeof __nextId !== undefined
-          ? __nextId
+        typeof __idCounterCurrent !== undefined
+          ? __idCounterCurrent
           : getMaxId(storedDraft),
       );
     } catch (error) {
@@ -234,7 +234,7 @@ class InterviewForm extends React.Component {
         LS_INTERVIEW_FORM_KEY,
         JSON.stringify({
           ...state,
-          __nextId: idCounter.getCurrent(),
+          __idCounterCurrent: idCounter.getCurrent(),
         }),
       );
     };

--- a/src/components/ShareExperience/InterviewStepsForm/index.js
+++ b/src/components/ShareExperience/InterviewStepsForm/index.js
@@ -142,7 +142,7 @@ class InterviewForm extends React.Component {
     let defaultFromDraft;
 
     try {
-      const { __updatedAt, __nextId, ...storedDraft } = JSON.parse(
+      const { __updatedAt, __idCounterCurrent, ...storedDraft } = JSON.parse(
         localStorage.getItem(LS_INTERVIEW_STEPS_FORM_KEY),
       );
       if (isExpired(__updatedAt)) {
@@ -151,7 +151,9 @@ class InterviewForm extends React.Component {
       } else {
         defaultFromDraft = storedDraft;
         idCounter = idGenerator(
-          __nextId !== undefined ? __nextId : getMaxId(storedDraft),
+          __idCounterCurrent !== undefined
+            ? __idCounterCurrent
+            : getMaxId(storedDraft),
         );
       }
     } catch (error) {
@@ -175,7 +177,7 @@ class InterviewForm extends React.Component {
         LS_INTERVIEW_STEPS_FORM_KEY,
         JSON.stringify({
           ...this.state,
-          __nextId: idCounter.getCurrent(),
+          __idCounterCurrent: idCounter.getCurrent(),
           __updatedAt: Date.now(),
         }),
       );

--- a/src/components/ShareExperience/InterviewStepsForm/index.js
+++ b/src/components/ShareExperience/InterviewStepsForm/index.js
@@ -104,6 +104,13 @@ const defaultForm = {
   interviewSensitiveQuestions: [],
 };
 
+const getMaxId = state => {
+  const ids = [...R.keys(state.sections), ...R.keys(state.interviewQas)];
+  const maxId = R.reduce(R.max, -Infinity, ids);
+  if (maxId === undefined) return -1;
+  return maxId;
+};
+
 const isStepTabActive = step => (match, location) => {
   const matched = location.pathname.match(/step(\d+)$/);
   if (!matched) return false;
@@ -143,7 +150,9 @@ class InterviewForm extends React.Component {
         localStorage.removeItem(LS_INTERVIEW_STEPS_FORM_KEY);
       } else {
         defaultFromDraft = storedDraft;
-        idCounter = idGenerator(__nextId);
+        idCounter = idGenerator(
+          __nextId !== undefined ? __nextId : getMaxId(storedDraft),
+        );
       }
     } catch (error) {
       defaultFromDraft = null;

--- a/src/components/ShareExperience/InterviewStepsForm/index.js
+++ b/src/components/ShareExperience/InterviewStepsForm/index.js
@@ -73,7 +73,7 @@ const createBlock = {
   interviewQas: createInterviewQa,
 };
 
-const idCounter = idGenerator();
+let idCounter = idGenerator();
 
 const experienceSectionId = idCounter();
 const suggestionSectionId = idCounter();
@@ -135,7 +135,7 @@ class InterviewForm extends React.Component {
     let defaultFromDraft;
 
     try {
-      const { __updatedAt, ...storedDraft } = JSON.parse(
+      const { __updatedAt, __nextId, ...storedDraft } = JSON.parse(
         localStorage.getItem(LS_INTERVIEW_STEPS_FORM_KEY),
       );
       if (isExpired(__updatedAt)) {
@@ -143,6 +143,7 @@ class InterviewForm extends React.Component {
         localStorage.removeItem(LS_INTERVIEW_STEPS_FORM_KEY);
       } else {
         defaultFromDraft = storedDraft;
+        idCounter = idGenerator(__nextId);
       }
     } catch (error) {
       defaultFromDraft = null;
@@ -165,6 +166,7 @@ class InterviewForm extends React.Component {
         LS_INTERVIEW_STEPS_FORM_KEY,
         JSON.stringify({
           ...this.state,
+          __nextId: idCounter(),
           __updatedAt: Date.now(),
         }),
       );

--- a/src/components/ShareExperience/InterviewStepsForm/index.js
+++ b/src/components/ShareExperience/InterviewStepsForm/index.js
@@ -175,7 +175,7 @@ class InterviewForm extends React.Component {
         LS_INTERVIEW_STEPS_FORM_KEY,
         JSON.stringify({
           ...this.state,
-          __nextId: idCounter(),
+          __nextId: idCounter.getCurrent(),
           __updatedAt: Date.now(),
         }),
       );

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -60,7 +60,7 @@ const createBlock = {
   sections: createSection,
 };
 
-const idCounter = idGenerator();
+let idCounter = idGenerator();
 
 const isBlockRemovable = blocks => R.length(R.keys(blocks)) > 1;
 
@@ -108,9 +108,11 @@ class WorkExperiencesForm extends React.Component {
     let defaultFromDraft;
 
     try {
-      defaultFromDraft = JSON.parse(
+      const { __nextId, ...storedDraft } = JSON.parse(
         localStorage.getItem(LS_WORK_EXPERIENCES_FORM_KEY),
       );
+      defaultFromDraft = storedDraft;
+      idCounter = idGenerator(__nextId);
     } catch (error) {
       defaultFromDraft = null;
     }
@@ -211,7 +213,13 @@ class WorkExperiencesForm extends React.Component {
         ...this.state,
         ...updateState,
       };
-      localStorage.setItem(LS_WORK_EXPERIENCES_FORM_KEY, JSON.stringify(state));
+      localStorage.setItem(
+        LS_WORK_EXPERIENCES_FORM_KEY,
+        JSON.stringify({
+          ...state,
+          __nextId: idCounter,
+        }),
+      );
     };
   }
 

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -226,7 +226,7 @@ class WorkExperiencesForm extends React.Component {
         LS_WORK_EXPERIENCES_FORM_KEY,
         JSON.stringify({
           ...state,
-          __nextId: idCounter,
+          __nextId: idCounter.getCurrent(),
         }),
       );
     };

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -86,6 +86,13 @@ const defaultForm = {
   },
 };
 
+const getMaxId = state => {
+  const ids = [...R.keys(state.sections)];
+  const maxId = R.max(ids);
+  if (maxId === undefined) return -1;
+  return maxId;
+};
+
 class WorkExperiencesForm extends React.Component {
   constructor(props) {
     super(props);
@@ -112,7 +119,9 @@ class WorkExperiencesForm extends React.Component {
         localStorage.getItem(LS_WORK_EXPERIENCES_FORM_KEY),
       );
       defaultFromDraft = storedDraft;
-      idCounter = idGenerator(__nextId);
+      idCounter = idGenerator(
+        typeof __nextId !== undefined ? __nextId : getMaxId(storedDraft),
+      );
     } catch (error) {
       defaultFromDraft = null;
     }

--- a/src/components/ShareExperience/WorkExperiencesForm/index.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/index.js
@@ -115,12 +115,14 @@ class WorkExperiencesForm extends React.Component {
     let defaultFromDraft;
 
     try {
-      const { __nextId, ...storedDraft } = JSON.parse(
+      const { __idCounterCurrent, ...storedDraft } = JSON.parse(
         localStorage.getItem(LS_WORK_EXPERIENCES_FORM_KEY),
       );
       defaultFromDraft = storedDraft;
       idCounter = idGenerator(
-        typeof __nextId !== undefined ? __nextId : getMaxId(storedDraft),
+        typeof __idCounterCurrent !== undefined
+          ? __idCounterCurrent
+          : getMaxId(storedDraft),
       );
     } catch (error) {
       defaultFromDraft = null;
@@ -226,7 +228,7 @@ class WorkExperiencesForm extends React.Component {
         LS_WORK_EXPERIENCES_FORM_KEY,
         JSON.stringify({
           ...state,
-          __nextId: idCounter.getCurrent(),
+          __idCounterCurrent: idCounter.getCurrent(),
         }),
       );
     };

--- a/src/components/ShareExperience/utils.js
+++ b/src/components/ShareExperience/utils.js
@@ -265,8 +265,8 @@ const portWorkExperiencesFormToRequestFormat = workExperiencesForm => {
   return body;
 };
 
-export const idGenerator = () => {
-  let id = -1;
+export const idGenerator = (initValue = -1) => {
+  let id = initValue;
   return () => {
     id += 1;
     return id;

--- a/src/components/ShareExperience/utils.js
+++ b/src/components/ShareExperience/utils.js
@@ -267,10 +267,12 @@ const portWorkExperiencesFormToRequestFormat = workExperiencesForm => {
 
 export const idGenerator = (initValue = -1) => {
   let id = initValue;
-  return () => {
+  const getter = () => {
     id += 1;
     return id;
   };
+  getter.getCurrent = () => id;
+  return getter;
 };
 
 export const propsWorkExperiencesForm = state => {


### PR DESCRIPTION
Close #730   <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

儲存草稿時，連帶idCounter的值也存起來
重新整理時，恢復idCounter的狀態(idCount值比儲存前+1，但是可以正確運作)

## Screenshots  <!-- 選填，沒有就刪掉 -->

![http://recordit.co/8Tj2xYaf6p.gif](http://recordit.co/8Tj2xYaf6p.gif)
<!-- 可以的話，請提供畫面截圖，如果是 GIF 的話更好 -->

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

因為相關邏輯在`InterviewStepsForm`、`InterviewForm` (目前deprecated)、`WorkExperiencesForm`都有，就一併改

但WorkExperiencesForm測試時發現有其他問題(儲存草稿的bug)，還需要另外研究
不過想說之後會改版，所以我就暫時不深究
目前只確定InterviewStepsForm已經修正
