### PR TITLE
hotfix: 權限區塊導流到面試經驗表單

### DIFF
--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -31,7 +31,7 @@ class BasicPermissionBlock extends React.Component {
   };
 
   static defaultProps = {
-    to: '/share/time-and-salary',
+    to: '/share/interview/step1',
     rootClassName: '',
     simple: false,
   };

--- a/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
+++ b/src/components/common/PermissionBlock/LaborRightsPermissionBlock.js
@@ -86,7 +86,7 @@ class BasicPermissionBlock extends React.Component {
           </P>
           <div className={styles.ctaButtonContainer}>
             <CallToLoginShareButton
-              to="/share/time-and-salary"
+              to="/share/interview/step1"
               notLoginText="立即登入並分享"
               isLoginText="立即分享"
             />

--- a/src/constants/dataProgress.js
+++ b/src/constants/dataProgress.js
@@ -1,2 +1,2 @@
 export const goalNum = 3000;
-export const shareLink = '/share/interview';
+export const shareLink = '/share/interview/step1';


### PR DESCRIPTION

## 這個 PR 是？ <!-- 必填 -->

實驗性的將權限區塊導流到新的面試經驗表單，看看效果如何。

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 薪資工時被檔住的權限區塊連結，是導到面試經驗表單
- [ ] 職場經驗單篇被檔住的權限區塊連結，是導到面試經驗表單
- [ ] 小教室單篇被檔住的權限區塊連結，是導到面試經驗表單
- [ ] 全文搜尋程式碼 `to={` ，跟權限有關的應該都是到面試經驗表單