### PR TITLE
Feat: improve experience detail SEO

### DIFF
--- a/src/components/ExperienceDetail/Heading/index.js
+++ b/src/components/ExperienceDetail/Heading/index.js
@@ -4,6 +4,7 @@ import { Heading, P } from 'common/base';
 import cn from 'classnames';
 
 import styles from './Heading.module.css';
+import { companyNameSelector, jobTitleSelector } from '../experienceSelector';
 
 const formatType = type => {
   switch (type) {
@@ -18,22 +19,14 @@ const formatType = type => {
   }
 };
 
-const formatComapny = company => {
-  if (company) {
-    return typeof company.name === 'string'
-      ? company.name
-      : company.name.join(' / ');
-  }
-  return null;
-};
-
 const ExperienceHeading = ({ experience, className }) => (
   <div className={cn(styles.heading, className)}>
     <P Tag="h2" size="l" className={styles.badge}>
       {experience && formatType(experience.type)}
     </P>
     <Heading size="l">
-      {(experience && formatComapny(experience.company)) || ''}
+      {experience &&
+        `${companyNameSelector(experience)} ${jobTitleSelector(experience)}`}
     </Heading>
   </div>
 );

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -88,9 +88,7 @@ const interviewMetaDescriptionSelector = (experience, maxLength) => {
       content += `面試結果：${interview_result}。`;
     }
     if (salaryAmount && salaryType) {
-      content += `薪水：每個${
-        salaryMapping[salaryType]
-      }新台幣 ${salaryAmount} 元。`;
+      content += `薪水：每個${salaryMapping[salaryType]}新台幣 ${salaryAmount} 元。`;
     }
     if (sections) {
       for (let section of sections) {
@@ -124,9 +122,7 @@ const workMetaDescriptionSelector = (experience, maxLength) => {
       content += `每週工時：${experience.week_work_time} 小時。`;
     }
     if (salaryAmount && salaryType) {
-      content += `薪水：每個${
-        salaryMapping[salaryType]
-      }新台幣 ${salaryAmount} 元。`;
+      content += `薪水：每個${salaryMapping[salaryType]}新台幣 ${salaryAmount} 元。`;
     }
     if (sections) {
       for (let section of sections) {
@@ -154,9 +150,7 @@ const internMetaDescriptionSelector = (experience, maxLength) => {
       content += `學歷：${experience.education}。`;
     }
     if (salaryAmount && salaryType) {
-      content += `實習薪水：每個${
-        salaryMapping[salaryType]
-      }新台幣 ${salaryAmount} 元。`;
+      content += `實習薪水：每個${salaryMapping[salaryType]}新台幣 ${salaryAmount} 元。`;
     }
     if (sections) {
       for (let section of sections) {

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -13,7 +13,17 @@ const salaryMapping = {
   hour: '小時',
 };
 
-export const companyNameSelector = R.pathOr(null, ['company', 'name']);
+const formatCompany = name => {
+  if (name) {
+    return typeof name === 'string' ? name : name.join(' / ');
+  }
+  return null;
+};
+
+export const companyNameSelector = R.compose(
+  formatCompany,
+  R.pathOr(null, ['company', 'name']),
+);
 export const jobTitleSelector = R.pathOr(null, ['job_title', 'name']);
 export const typeSelector = experience =>
   R.propOr(null, experience.type, typeMapping);

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -49,20 +49,20 @@ export const metaTitleSelector = experience => {
   )} ${typeSelector(experience)} ${dateSelector(experience)}`;
 };
 
-export const metaDescriptionSelector = (experience, maxLength) => {
+export const metaDescriptionSelector = experience => {
   if (experience) {
     if (experience.type === 'interview') {
-      return interviewMetaDescriptionSelector(experience, maxLength);
+      return interviewMetaDescriptionSelector(experience);
     } else if (experience.type === 'work') {
-      return workMetaDescriptionSelector(experience, maxLength);
+      return workMetaDescriptionSelector(experience);
     } else if (experience.type === 'intern') {
-      return internMetaDescriptionSelector(experience, maxLength);
+      return internMetaDescriptionSelector(experience);
     }
   }
   return null;
 };
 
-const interviewMetaDescriptionSelector = (experience, maxLength) => {
+const interviewMetaDescriptionSelector = experience => {
   if (experience) {
     let content = '';
     const {
@@ -98,12 +98,12 @@ const interviewMetaDescriptionSelector = (experience, maxLength) => {
         )}。`;
       }
     }
-    return maxLength < 0 ? content : content.slice(0, maxLength);
+    return content;
   }
   return null;
 };
 
-const workMetaDescriptionSelector = (experience, maxLength) => {
+const workMetaDescriptionSelector = experience => {
   if (experience) {
     let content = '';
     const { region, experience_in_year, sections } = experience;
@@ -132,12 +132,12 @@ const workMetaDescriptionSelector = (experience, maxLength) => {
         )}。`;
       }
     }
-    return maxLength < 0 ? content : content.slice(0, maxLength);
+    return content;
   }
   return null;
 };
 
-const internMetaDescriptionSelector = (experience, maxLength) => {
+const internMetaDescriptionSelector = experience => {
   if (experience) {
     let content = '';
     const { region, sections } = experience;
@@ -160,7 +160,7 @@ const internMetaDescriptionSelector = (experience, maxLength) => {
         )}。`;
       }
     }
-    return maxLength < 0 ? content : content.slice(0, maxLength);
+    return content;
   }
   return null;
 };

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -1,0 +1,98 @@
+import R from 'ramda';
+
+const typeMapping = {
+  interview: '面試經驗分享',
+  work: '工作經驗分享',
+  intern: '實習經驗分享',
+};
+
+const salaryMapping = {
+  year: '年',
+  month: '月',
+  day: '日',
+  hour: '小時',
+};
+
+export const companyNameSelector = R.pathOr(null, ['company', 'name']);
+export const jobTitleSelector = R.pathOr(null, ['job_title', 'name']);
+export const typeSelector = experience =>
+  R.propOr(null, experience.type, typeMapping);
+export const dateSelector = experience => {
+  if (experience.created_at) {
+    const t = new Date(experience.created_at);
+    return `${t.getFullYear()}.${t.getMonth() + 1}.${t.getDate()}`;
+  } else {
+    return null;
+  }
+};
+export const interviewYearSelector = R.pathOr(null, ['interview_time', 'year']);
+export const interviewMonthSelector = R.pathOr(null, [
+  'interview_time',
+  'month',
+]);
+export const salaryAmountSelector = R.pathOr(null, ['salary', 'amount']);
+export const salaryTypeSelector = R.pathOr(null, ['salary', 'type']);
+
+export const metaTitleSelector = experience => {
+  return `${companyNameSelector(experience)} ${jobTitleSelector(
+    experience,
+  )} ${typeSelector(experience)} ${dateSelector(experience)}`;
+};
+
+export const metaDescriptionSelector = (experience, maxLength) => {
+  if (experience) {
+    if (experience.type === 'interview') {
+      return interviewMetaDescriptionSelector(experience, maxLength);
+    } else if (experience.type === 'work') {
+      return null;
+      // return workMetaDescriptionSelector(experience, maxLength);
+    } else if (experience.type === 'intern') {
+      return null;
+      // return internMetaDescriptionSelector(experience, maxLength);
+    }
+  }
+  return null;
+};
+
+const interviewMetaDescriptionSelector = (experience, maxLength) => {
+  if (experience) {
+    let content = '';
+    const {
+      region,
+      experience_in_year,
+      interview_result,
+      sections,
+    } = experience;
+    const interviewYear = interviewYearSelector(experience);
+    const interviewMonth = interviewMonthSelector(experience);
+    const salaryAmount = salaryAmountSelector(experience);
+    const salaryType = salaryTypeSelector(experience);
+    if (region) {
+      content += `面試地區：${region}。`;
+    }
+    if (experience.experience_in_year) {
+      content += `相關職務工作經驗：${experience_in_year} 年。`;
+    }
+    if (interviewYear && interviewMonth) {
+      content += `面試時間：${interviewYear} 年 ${interviewMonth} 月。`;
+    }
+    if (interview_result) {
+      content += `面試結果：${interview_result}。`;
+    }
+    if (salaryAmount && salaryType) {
+      content += `薪水：每個${
+        salaryMapping[salaryType]
+      }新台幣 ${salaryAmount} 元。`;
+    }
+    if (sections) {
+      for (let section of sections) {
+        content += `${section.subtitle}：${section.content.replace(
+          /(\r\n|\n|\r)/gm,
+          ' ',
+        )}。`;
+      }
+    }
+    return maxLength < 0 ? content : content.slice(0, maxLength);
+  }
+  return null;
+};

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -1,9 +1,9 @@
 import R from 'ramda';
 
 const typeMapping = {
-  interview: '面試經驗分享',
-  work: '工作經驗分享',
-  intern: '實習經驗分享',
+  interview: '面試經驗',
+  work: '工作心得',
+  intern: '實習心得',
 };
 
 const salaryMapping = {

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -44,8 +44,7 @@ export const metaDescriptionSelector = (experience, maxLength) => {
     if (experience.type === 'interview') {
       return interviewMetaDescriptionSelector(experience, maxLength);
     } else if (experience.type === 'work') {
-      return null;
-      // return workMetaDescriptionSelector(experience, maxLength);
+      return workMetaDescriptionSelector(experience, maxLength);
     } else if (experience.type === 'intern') {
       return null;
       // return internMetaDescriptionSelector(experience, maxLength);
@@ -78,6 +77,42 @@ const interviewMetaDescriptionSelector = (experience, maxLength) => {
     }
     if (interview_result) {
       content += `面試結果：${interview_result}。`;
+    }
+    if (salaryAmount && salaryType) {
+      content += `薪水：每個${
+        salaryMapping[salaryType]
+      }新台幣 ${salaryAmount} 元。`;
+    }
+    if (sections) {
+      for (let section of sections) {
+        content += `${section.subtitle}：${section.content.replace(
+          /(\r\n|\n|\r)/gm,
+          ' ',
+        )}。`;
+      }
+    }
+    return maxLength < 0 ? content : content.slice(0, maxLength);
+  }
+  return null;
+};
+
+const workMetaDescriptionSelector = (experience, maxLength) => {
+  if (experience) {
+    let content = '';
+    const { region, experience_in_year, sections } = experience;
+    const salaryAmount = salaryAmountSelector(experience);
+    const salaryType = salaryTypeSelector(experience);
+    if (region) {
+      content += `工作地區：${region}。`;
+    }
+    if (experience.experience_in_year) {
+      content += `相關職務工作經驗：${experience_in_year} 年。`;
+    }
+    if (experience.education) {
+      content += `最高學歷：${experience.education}。`;
+    }
+    if (experience.week_work_time) {
+      content += `每週工時：${experience.week_work_time} 小時。`;
     }
     if (salaryAmount && salaryType) {
       content += `薪水：每個${

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -46,8 +46,7 @@ export const metaDescriptionSelector = (experience, maxLength) => {
     } else if (experience.type === 'work') {
       return workMetaDescriptionSelector(experience, maxLength);
     } else if (experience.type === 'intern') {
-      return null;
-      // return internMetaDescriptionSelector(experience, maxLength);
+      return internMetaDescriptionSelector(experience, maxLength);
     }
   }
   return null;
@@ -116,6 +115,36 @@ const workMetaDescriptionSelector = (experience, maxLength) => {
     }
     if (salaryAmount && salaryType) {
       content += `薪水：每個${
+        salaryMapping[salaryType]
+      }新台幣 ${salaryAmount} 元。`;
+    }
+    if (sections) {
+      for (let section of sections) {
+        content += `${section.subtitle}：${section.content.replace(
+          /(\r\n|\n|\r)/gm,
+          ' ',
+        )}。`;
+      }
+    }
+    return maxLength < 0 ? content : content.slice(0, maxLength);
+  }
+  return null;
+};
+
+const internMetaDescriptionSelector = (experience, maxLength) => {
+  if (experience) {
+    let content = '';
+    const { region, sections } = experience;
+    const salaryAmount = salaryAmountSelector(experience);
+    const salaryType = salaryTypeSelector(experience);
+    if (region) {
+      content += `實習地區：${region}。`;
+    }
+    if (experience.education) {
+      content += `學歷：${experience.education}。`;
+    }
+    if (salaryAmount && salaryType) {
+      content += `實習薪水：每個${
         salaryMapping[salaryType]
       }新台幣 ${salaryAmount} 元。`;
     }

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -39,6 +39,10 @@ import authStatus from '../../constants/authStatus';
 import { COMMENT_ZONE } from '../../constants/formElements';
 
 import { paramsSelector } from 'common/routing/selectors';
+import {
+  metaTitleSelector,
+  metaDescriptionSelector,
+} from './experienceSelector';
 
 import LikeZone from '../../containers/ExperienceDetail/LikeZone';
 import styles from './ExperienceDetail.module.css';
@@ -249,23 +253,8 @@ class ExperienceDetail extends Component {
 
     if (isFetched(experienceStatus)) {
       const id = experience._id;
-      const title = experience.title;
-      const company = experience.company.name;
-      const jobTitle = experience.job_title.name;
-      const type = experience.type;
-      const subtitle = experience.sections[0].subtitle
-        ? experience.sections[0].subtitle.replace(/(\r\n|\n|\r)/gm, ' ')
-        : '';
-      const content = experience.sections[0].content.replace(
-        /(\r\n|\n|\r)/gm,
-        ' ',
-      );
-      const mapping = {
-        interview: '面試經驗分享',
-        work: '工作經驗分享',
-        intern: '實習經驗分享',
-      };
-      const description = `${company} ${jobTitle} 的${mapping[type]}。 ${subtitle}：${content}`;
+      const title = metaTitleSelector(experience);
+      const description = metaDescriptionSelector(experience, 160);
       return (
         <Helmet>
           <title itemProp="name" lang="zh-TW">

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -254,7 +254,8 @@ class ExperienceDetail extends Component {
     if (isFetched(experienceStatus)) {
       const id = experience._id;
       const title = metaTitleSelector(experience);
-      const description = metaDescriptionSelector(experience, 160);
+      let description = metaDescriptionSelector(experience);
+      description = description.slice(0, 160);
       return (
         <Helmet>
           <title itemProp="name" lang="zh-TW">

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -23,6 +23,7 @@ query($id:ID!) {
     }
     like_count
     liked
+    created_at
 
     ...on InterviewExperience {
       interview_time {


### PR DESCRIPTION
part of #637 

## 這個 PR 是？ <!-- 必填 -->

優化經驗分享頁的 SEO：
1. meta title 改為 `[公司] [職稱] [種類] [時間]`
2. meta description 改為各種固定欄位＋sections 所有內容串起來後，再做 slice 取前面一段。  
3. 文章的標題改為 `[種類] [公司] [職稱]` 

為什麼要這麼做？ 請見背景知識

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="769" alt="螢幕快照 2019-07-30 上午12 30 36" src="https://user-images.githubusercontent.com/3805975/62065332-58a08f00-b261-11e9-8f43-e8079d608dfb.png">
<img width="606" alt="螢幕快照 2019-07-30 上午12 30 43" src="https://user-images.githubusercontent.com/3805975/62065333-58a08f00-b261-11e9-9116-675519db6ac2.png">
<img width="264" alt="螢幕快照 2019-07-30 上午12 31 23" src="https://user-images.githubusercontent.com/3805975/62065378-6b1ac880-b261-11e9-9a24-65c52110647b.png">


## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

根據 google 官方 [SEO guide](https://support.google.com/webmasters/answer/7451184?hl=en#understand_your_content)，我們可以知道：
### 針對 title 
1. 不同頁面的 title 要盡可能不一樣

所以我把職稱和時間都加進去，避免原本公司一樣的話，title 就會一樣。

### 針對 description
1. 不同頁面的 meta description 要盡可能不一樣
2. 對使用者決定是否點進去看有幫助
3. 避免將所有內容複製貼上到 description（網路上有不少文章建議長度 130 字元～ 160 字元）

所以我嘗試把一些固定、且使用者可能會想知道的欄位放進去，並且把所有 sections 考慮進去。最後避免內容過長，僅擷取前面 160 字元。

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

1. by commit 
2. 很多 Ramda 的用法可能還沒那麼成熟，請鞭小力點。先求正確無誤。

## 我應該如何手動測試？ <!-- 必填 -->

#### 資料準備
- [ ] 想辦法從 production dump 取得一篇實習心得
- [ ] 建立一篇工作心得，盡可能把所有欄位填入
- [ ] 建立一篇面試經驗，盡可能把所有欄位填入

#### 測試
- [ ] 打開實習心得，在 chrome dev tools 查看 title, og:title, description, og:description 這幾個 meta 欄位是否正確。UI 上顯示的標題是否正確。
- [ ] 打開工作心得，在 chrome dev tools 查看 title, og:title, description, og:description 這幾個 meta 欄位是否正確。UI 上顯示的標題是否正確。
- [ ] 打開面試經驗，在 chrome dev tools 查看 title, og:title, description, og:description 這幾個 meta 欄位是否正確。UI 上顯示的標題是否正確。
