### PR TITLE
feat: tracking viewing experience detail log

### DIFF
--- a/src/actions/viewLog.js
+++ b/src/actions/viewLog.js
@@ -9,3 +9,13 @@ export const viewSalaryWorkTimes = ({ contentIds, referrer }) => (
   const token = tokenSelector(state);
   return api.viewLog.viewSalaryWorkTimes({ token, contentIds, referrer });
 };
+
+export const viewExperiences = ({ contentIds, referrer }) => (
+  dispatch,
+  getState,
+  { api },
+) => {
+  const state = getState();
+  const token = tokenSelector(state);
+  return api.viewLog.viewExperiences({ token, contentIds, referrer });
+};

--- a/src/apis/viewLogApi.js
+++ b/src/apis/viewLogApi.js
@@ -1,5 +1,8 @@
 import graphqlClient from 'utils/graphqlClient';
-import { viewSalaryWorkTimes as viewSalaryWorkTimesGql } from 'graphql/viewLog';
+import {
+  viewSalaryWorkTimes as viewSalaryWorkTimesGql,
+  viewExperiences as viewExperiencesGql,
+} from 'graphql/viewLog';
 
 const viewSalaryWorkTimes = ({ token, contentIds, referrer = null }) =>
   graphqlClient({
@@ -13,6 +16,19 @@ const viewSalaryWorkTimes = ({ token, contentIds, referrer = null }) =>
     },
   });
 
+const viewExperiences = ({ token, contentIds, referrer = null }) =>
+  graphqlClient({
+    query: viewExperiencesGql,
+    token,
+    variables: {
+      input: {
+        content_ids: contentIds,
+        referrer,
+      },
+    },
+  });
+
 export default {
   viewSalaryWorkTimes,
+  viewExperiences,
 };

--- a/src/components/ExperienceDetail/ViewLog.js
+++ b/src/components/ExperienceDetail/ViewLog.js
@@ -1,0 +1,35 @@
+import { Component } from 'react';
+import PropTypes from 'prop-types';
+
+class ViewLog extends Component {
+  static propTypes = {
+    experienceId: PropTypes.string.isRequired,
+    viewExperiences: PropTypes.func.isRequired,
+  };
+
+  componentDidMount() {
+    const { experienceId } = this.props;
+    if (experienceId) {
+      const contentIds = [experienceId];
+      const referrer = window.location.href;
+
+      this.props.viewExperiences({ contentIds, referrer });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { experienceId } = this.props;
+    if (prevProps.experienceId !== experienceId && experienceId) {
+      const contentIds = [experienceId];
+      const referrer = window.location.href;
+
+      this.props.viewExperiences({ contentIds, referrer });
+    }
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default ViewLog;

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -30,6 +30,7 @@ import ReactionZoneStyles from './ReactionZone/ReactionZone.module.css';
 import { isFetching, isFetched, isError } from '../../constants/status';
 import { fetchExperience } from '../../actions/experienceDetail';
 import ReportFormContainer from '../../containers/ExperienceDetail/ReportFormContainer';
+import ViewLog from '../../containers/ExperienceDetail/ViewLog';
 
 import { formatTitle, formatCanonicalPath } from '../../utils/helmetHelper';
 import { SITE_NAME } from '../../constants/helmetData';
@@ -412,6 +413,7 @@ class ExperienceDetail extends Component {
         >
           {this.renderModalChildren(modalType, modalPayload)}
         </Modal>
+        {isFetched(experienceStatus) && <ViewLog experienceId={id} />}
       </main>
     );
   }

--- a/src/containers/ExperienceDetail/ViewLog.js
+++ b/src/containers/ExperienceDetail/ViewLog.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import ViewLog from '../../components/ExperienceDetail/ViewLog';
+import { viewExperiences } from '../../actions/viewLog';
+
+const mapStateToProps = state => ({});
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators({ viewExperiences }, dispatch);
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ViewLog);

--- a/src/graphql/viewLog.js
+++ b/src/graphql/viewLog.js
@@ -5,3 +5,11 @@ export const viewSalaryWorkTimes = `
     }
   }
 `;
+
+export const viewExperiences = `
+  mutation ViewExperiences($input: ViewExperiencesInput!) {
+    viewExperiences(input: $input) {
+      status
+    }
+  }
+`;


### PR DESCRIPTION
Close #740 

## 這個 PR 是？ <!-- 必填 -->

送職場經驗單篇 view log

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 後端起最新的 master，然後 `docker-compose up`
- [ ] 前端跑起來 `RAZZLE_API_HOST="http://localhost:12000" yarn start`
- [ ] 打開 network tab，開一個職場經驗單篇頁面，搜尋 graphql 應該要有 viewExperiences 的 API，且 status: ok