### PR TITLE
[公司/職稱頁面] 薪時頁面Empty State

### DIFF
--- a/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.js
@@ -2,12 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import { compose } from 'recompose';
-import { P } from 'common/base';
 import FanPageBlock from 'common/FanPageBlock';
 import { withPermission } from 'common/permission-context';
 import Pagination from 'common/Pagination';
 
-import { pageTypeTranslation } from '../../../constants/companyJobTitle';
+import EmptyView from '../EmptyView';
 import WorkingHourBlock from './WorkingHourBlock';
 import renderHelmet from './timeAndSalaryHelmet';
 import ViewLog from './ViewLog';
@@ -51,6 +50,7 @@ class TimeAndSalary extends Component {
       queryParams,
       pageType,
       pageName,
+      tabType,
     } = this.props;
 
     const pageSize = 10;
@@ -99,13 +99,7 @@ class TimeAndSalary extends Component {
               }
             />
           </React.Fragment>
-        )) || (
-          <P size="l" bold className={styles.searchNoResult}>
-            {`尚未有${pageTypeTranslation[pageType]}「
-                {pageName}
-                」的薪時資訊`}
-          </P>
-        )}
+        )) || <EmptyView pageName={pageName} tabType={tabType} />}
         <ViewLog
           pageName={pageName}
           page={page}

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.module.css
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.module.css
@@ -56,17 +56,6 @@ $bold: 700;
   }
 }
 
-.searchNoResult {
-  background-color: #f2f2f2;
-  border: 1px solid border-gray;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding-top: 40px;
-  padding-bottom: 40px;
-  margin-top: 40px;
-}
-
 .heading {
   @mixin heading-style;
   text-align: center;


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

修改薪時頁面的空資料狀態，與其他頁面一致

## Screenshots  <!-- 選填，沒有就刪掉 -->

- 其他頁面
![螢幕快照 2019-08-15 上午10 15 47](https://user-images.githubusercontent.com/7566586/63068432-bb727580-bf45-11e9-84df-57b47f04e2b1.png)

- 薪時頁面(原)
![螢幕快照 2019-08-15 上午10 17 30](https://user-images.githubusercontent.com/7566586/63068535-0ab8a600-bf46-11e9-8a7c-8c724a97ff4f.png)

- 薪時頁面(修正後)
![螢幕快照 2019-08-15 上午10 15 41](https://user-images.githubusercontent.com/7566586/63068457-c88f6480-bf45-11e9-9d42-61d50efbf903.png)


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/companies/鍋大師餐飲股份有限公司/salary-work-times 