### PR TITLE
[公司/職稱頁面] 增強搜尋結果體驗

### DIFF
--- a/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
+++ b/src/components/TimeAndSalary/SearchScreen/SearchScreen.js
@@ -101,14 +101,14 @@ class SearchScreen extends Component {
       if (searchBy === 'company') {
         const companyName = firstDataNameSelector(this.props);
         this.props.history.replace(
-          `/companies/${encodeURIComponent(companyName)}/salary-work-times${
+          `/companies/${encodeURIComponent(companyName)}/overview${
             this.props.location.search
           }`,
         );
       } else if (searchBy === 'job_title') {
         const jobTitle = firstDataNameSelector(this.props);
         this.props.history.replace(
-          `/job-titles/${encodeURIComponent(jobTitle)}/salary-work-times${
+          `/job-titles/${encodeURIComponent(jobTitle)}/overview${
             this.props.location.search
           }`,
         );
@@ -121,14 +121,14 @@ class SearchScreen extends Component {
     if (searchBy === 'company') {
       return `/companies/${encodeURIComponent(
         data.name,
-      )}/salary-work-times${qs.stringify(
+      )}/overview${qs.stringify(
         { ...querySelector(this.props), p: 1 },
         { addQueryPrefix: true },
       )}`;
     } else if (searchBy === 'job_title') {
       return `/job-titles/${encodeURIComponent(
         data.name,
-      )}/salary-work-times${qs.stringify(
+      )}/overview${qs.stringify(
         { ...querySelector(this.props), p: 1 },
         { addQueryPrefix: true },
       )}`;

--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -7,11 +7,7 @@ import styles from './formatter.module.css';
 
 export const getCompany = item => (
   <div>
-    <Link
-      to={`/companies/${encodeURIComponent(
-        item.company.name,
-      )}/salary-work-times`}
-    >
+    <Link to={`/companies/${encodeURIComponent(item.company.name)}/overview`}>
       {item.company.name}
     </Link>
   </div>
@@ -21,11 +17,7 @@ export const getJobTitle = item => {
   const { job_title: jobTitle, sector } = item;
   return (
     <div>
-      <Link
-        to={`/job-titles/${encodeURIComponent(
-          jobTitle.name,
-        )}/salary-work-times`}
-      >
+      <Link to={`/job-titles/${encodeURIComponent(jobTitle.name)}/overview`}>
         {jobTitle.name}
       </Link>{' '}
       <span className={`pM ${styles.sector}`}>{sector}</span>
@@ -34,13 +26,13 @@ export const getJobTitle = item => {
 };
 
 export const getNameAsCompanyName = (o, row) => (
-  <Link to={`/companies/${encodeURIComponent(o.name)}/salary-work-times`}>
+  <Link to={`/companies/${encodeURIComponent(o.name)}/overview`}>
     {o.name} <span className={`pM ${styles.sector}`}>{row.sector}</span>
   </Link>
 );
 
 export const getNameAsJobTitle = (o, row) => (
-  <Link to={`/job-titles/${encodeURIComponent(o.name)}/salary-work-times`}>
+  <Link to={`/job-titles/${encodeURIComponent(o.name)}/overview`}>
     {o.name} <span className={`pM ${styles.sector}`}>{row.sector}</span>
   </Link>
 );


### PR DESCRIPTION
## 這個 PR 是？
把幾個需要的連接從/salary-and-times 換成/overview
1. http://localhost:3000/salary-work-times/latest 公司、職稱連結
2. WorkingHourTable 公司、職稱連結
3. 搜尋到一筆資料的結果導流連結
4. 搜尋到多筆資料後，點擊可能結果連結

## Screenshots 
1. 搜尋到一筆的結果
![2019-08-15 11 26 56](https://user-images.githubusercontent.com/8898129/63070957-ca5e2580-bf4f-11e9-80a2-c740439d29cc.gif)

2. 搜尋到多筆，點擊其中一項結果
![2019-08-15 11 29 29](https://user-images.githubusercontent.com/8898129/63071013-fed1e180-bf4f-11e9-8f56-a764b0bb966c.gif)

3. latest 頁面
![2019-08-15 11 30 44](https://user-images.githubusercontent.com/8898129/63071040-2759db80-bf50-11e9-9b1b-3cbe28988754.gif)

4. 任何working hour table
![2019-08-15 11 31 13](https://user-images.githubusercontent.com/8898129/63071048-39d41500-bf50-11e9-9bbc-6a571793f7be.gif)



## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 對照上面的更改結果，沒多餘改變