### PR TITLE
[公司職稱頁面] 統一Tab風格

### DIFF
--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -4,6 +4,7 @@ import { toPairs, compose, map } from 'ramda';
 
 import Heading from 'common/base/Heading';
 import StaticHelmet from 'common/StaticHelmet';
+import FanPageBlock from 'common/FanPageBlock';
 
 import {
   tabTypeTranslation,
@@ -12,6 +13,7 @@ import {
 
 import BreadCrumb from './BreadCrumb';
 import TabLinkGroup from './TabLinkGroup';
+import styles from './CompanyAndJobTitleWrapper.module.css';
 
 const CompanyAndJobTitleWrapper = ({
   children,
@@ -54,6 +56,7 @@ const CompanyAndJobTitleWrapper = ({
         }}
       />
       {children}
+      <FanPageBlock className={styles.fanPageBlock} />
     </div>
   );
 };

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
@@ -1,0 +1,3 @@
+.fanPageBlock {
+  margin-bottom: 60px;
+}

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Pagination from 'common/Pagination';
+import { Section } from 'common/base';
+
 import EmptyView from '../EmptyView';
 import ExperienceEntry from './ExperienceEntry';
 
@@ -13,7 +15,7 @@ const InterviewExperiences = ({ pageType, pageName, tabType, data, page }) => {
   }
   const visibleData = data.slice((page - 1) * pageSize, page * pageSize);
   return (
-    <React.Fragment>
+    <Section Tag="main" paddingBottom>
       {visibleData.map(d => (
         <ExperienceEntry key={d.id} pageType={pageType} data={d} />
       ))}
@@ -23,7 +25,7 @@ const InterviewExperiences = ({ pageType, pageName, tabType, data, page }) => {
         currentPage={page}
         createPageLinkTo={page => `?p=${page}`}
       />
-    </React.Fragment>
+    </Section>
   );
 };
 

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { compose } from 'recompose';
 
 import { withPermission } from 'common/permission-context';
+import { Section } from 'common/base';
 
 import SnippetBlock from './SnippetBlock';
 import WorkingHourTable from '../TimeAndSalary/WorkingHourTable';
 import WorkExperienceEntry from '../WorkExperiences/ExperienceEntry';
 import InterviewExperienceEntry from '../InterviewExperiences/ExperienceEntry';
-import styles from './Overview.module.css';
 
 const SALARY_WORK_TIMES_LIMIT = 5;
 const WORK_EXPERIENCES_LIMIT = 3;
@@ -23,7 +23,7 @@ const Overview = ({
   salaryWorkTimes,
   canViewTimeAndSalary,
 }) => (
-  <div className={styles.container}>
+  <Section Tag="main" paddingBottom>
     <SnippetBlock
       title="薪水&加班狀況"
       linkText={`查看 ${salaryWorkTimes.length} 筆完整的薪水、加班數據資料 >>`}
@@ -62,7 +62,7 @@ const Overview = ({
         <InterviewExperienceEntry key={d.id} pageType={pageType} data={d} />
       ))}
     </SnippetBlock>
-  </div>
+  </Section>
 );
 
 Overview.propTypes = {

--- a/src/components/CompanyAndJobTitle/Overview/Overview.module.css
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.module.css
@@ -1,7 +1,3 @@
-.container {
-  margin-bottom: 160px;
-}
-
 .snippet {
   .title {
     font-size: 22px;

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import { compose } from 'recompose';
-import FanPageBlock from 'common/FanPageBlock';
 import { withPermission } from 'common/permission-context';
 import Pagination from 'common/Pagination';
 
@@ -105,7 +104,6 @@ class TimeAndSalary extends Component {
           page={page}
           contentIds={currentData.map(i => i.id)}
         />
-        <FanPageBlock className={styles.fanPageBlock} />
       </section>
     );
   }

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.js
@@ -4,12 +4,12 @@ import qs from 'qs';
 import { compose } from 'recompose';
 import { withPermission } from 'common/permission-context';
 import Pagination from 'common/Pagination';
+import { Section } from 'common/base';
 
 import EmptyView from '../EmptyView';
 import WorkingHourBlock from './WorkingHourBlock';
 import renderHelmet from './timeAndSalaryHelmet';
 import ViewLog from './ViewLog';
-import styles from './TimeAndSalary.module.css';
 
 class TimeAndSalary extends Component {
   static propTypes = {
@@ -67,7 +67,7 @@ class TimeAndSalary extends Component {
     );
 
     return (
-      <section className={styles.searchResult}>
+      <Section Tag="main" paddingBottom>
         {renderHelmet({
           title,
           pathname,
@@ -104,7 +104,7 @@ class TimeAndSalary extends Component {
           page={page}
           contentIds={currentData.map(i => i.id)}
         />
-      </section>
+      </Section>
     );
   }
 }

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.module.css
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.module.css
@@ -47,15 +47,6 @@ $bold: 700;
   }
 }
 
-.searchResult {
-  margin-bottom: $block-gutter-l;
-  .heading {
-    @media (max-width: $below-mobile) {
-      font-size: 1.5em;
-    }
-  }
-}
-
 .heading {
   @mixin heading-style;
   text-align: center;

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.module.css
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/TimeAndSalary.module.css
@@ -64,7 +64,3 @@ $bold: 700;
     margin-bottom: $block-gutter-s;
   }
 }
-
-.fanPageBlock {
-  margin-top: 60px;
-}

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ExperienceEntry from './ExperienceEntry';
 import EmptyView from '../EmptyView';
+
+import { Section } from 'common/base';
 import Pagination from 'common/Pagination';
 
 const pageSize = 10;
@@ -12,7 +14,7 @@ const WorkExperiences = ({ pageType, pageName, tabType, data, page }) => {
   }
   const visibleData = data.slice((page - 1) * pageSize, page * pageSize);
   return (
-    <React.Fragment>
+    <Section Tag="main" paddingBottom>
       {visibleData.map(d => (
         <ExperienceEntry key={d.id} pageType={pageType} data={d} />
       ))}
@@ -22,7 +24,7 @@ const WorkExperiences = ({ pageType, pageName, tabType, data, page }) => {
         currentPage={page}
         createPageLinkTo={page => `?p=${page}`}
       />
-    </React.Fragment>
+    </Section>
   );
 };
 

--- a/src/components/common/facebook/FacebookWrapper.js
+++ b/src/components/common/facebook/FacebookWrapper.js
@@ -9,6 +9,12 @@ class FacebookWrapper extends Component {
     this.handleContainer = this.handleContainer.bind(this);
   }
 
+  componentDidMount() {
+    if (this.props.FB && this.container) {
+      this.props.FB.XFBML.parse(this.container);
+    }
+  }
+
   // 讓 FB 重新 parse children
   componentDidUpdate() {
     // if FB instance


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

把`FanPage`放在`CompanyAndJobTitleWrapper`底下
並且把不同Tab的Component Wrapper統一成`<Section>...</Section>`

## Screenshots  <!-- 選填，沒有就刪掉 -->

Before:
![Before](https://user-images.githubusercontent.com/7566586/63077652-a14b8e00-bf6b-11e9-94e3-58654b4b6397.png)

After:
![After](https://user-images.githubusercontent.com/7566586/63077656-a3155180-bf6b-11e9-9eb1-e3722d4eb31a.png)

