### PR TITLE
[公司職稱頁面] 修正經驗單篇的返回列表按鈕

### DIFF
--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -10,12 +10,12 @@ import Label from '../Label';
 import Rating from './Rating';
 import { pageType as PAGE_TYPE } from '../../../constants/companyJobTitle';
 
-const createLinkTo = (id, backable) => ({
+const createLinkTo = id => ({
   pathname: `/experiences/${id}`,
-  state: { backable },
+  state: { backable: true },
 });
 
-const ExperienceEntry = ({ pageType, data, size, backable }) => {
+const ExperienceEntry = ({ pageType, data, size }) => {
   const {
     id,
     company: { name: companyName } = {},
@@ -28,10 +28,7 @@ const ExperienceEntry = ({ pageType, data, size, backable }) => {
   } = data;
 
   return (
-    <Link
-      to={createLinkTo(id, backable)}
-      className={cn(styles.container, styles[size])}
-    >
+    <Link to={createLinkTo(id)} className={cn(styles.container, styles[size])}>
       <section className={styles.contentWrapper}>
         <P size="s">{formatCreatedAt(createdAt)}</P>
 
@@ -78,12 +75,10 @@ const ExperienceEntry = ({ pageType, data, size, backable }) => {
 ExperienceEntry.propTypes = {
   data: PropTypes.object.isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
-  backable: PropTypes.bool,
 };
 
 ExperienceEntry.defaultProps = {
   size: 'm',
-  backable: false,
 };
 
 export default ExperienceEntry;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -13,12 +13,12 @@ import {
 import Label from '../Label';
 import { pageType as PAGE_TYPE } from '../../../constants/companyJobTitle';
 
-const createLinkTo = (id, backable) => ({
+const createLinkTo = id => ({
   pathname: `/experiences/${id}`,
-  state: { backable },
+  state: { backable: true },
 });
 
-const ExperienceEntry = ({ pageType, data, size, backable }) => {
+const ExperienceEntry = ({ pageType, data, size }) => {
   const {
     id,
     company: { name: companyName } = {},
@@ -31,10 +31,7 @@ const ExperienceEntry = ({ pageType, data, size, backable }) => {
   } = data;
 
   return (
-    <Link
-      to={createLinkTo(id, backable)}
-      className={cn(styles.container, styles[size])}
-    >
+    <Link to={createLinkTo(id)} className={cn(styles.container, styles[size])}>
       <section className={styles.contentWrapper}>
         <P size="s">{formatCreatedAt(createdAt)}</P>
 
@@ -85,12 +82,10 @@ const ExperienceEntry = ({ pageType, data, size, backable }) => {
 ExperienceEntry.propTypes = {
   data: PropTypes.object.isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
-  backable: PropTypes.bool,
 };
 
 ExperienceEntry.defaultProps = {
   size: 'm',
-  backable: false,
 };
 
 export default ExperienceEntry;


### PR DESCRIPTION
#759 

## 這個 PR 是？ <!-- 必填 -->

經驗的「返回列表」都是回到職場經驗，而非真的上一頁
要修正成真正的上一頁

## Screenshots  <!-- 選填，沒有就刪掉 -->

Before
![http://g.recordit.co/ZAlk5rpV4X.gif](http://g.recordit.co/ZAlk5rpV4X.gif)

After
![http://g.recordit.co/oM76YPqDxu.gif](http://g.recordit.co/oM76YPqDxu.gif)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] https://www-dev.goodjob.life/job-titles/工程師/interview-experiences 隨便點一篇進去，再按「返回列表」
