### PR TITLE
解決公司職稱頁面沒有 SSR 的問題

### DIFF
--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -5,7 +5,7 @@ import { createStructuredSelector } from 'reselect';
 import { withProps, lifecycle, compose, setStatic } from 'recompose';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import Overview from '../CompanyAndJobTitle/Overview';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
@@ -32,6 +32,13 @@ const getCompanyNameFromParams = R.compose(
 
 const CompanyPageProvider = props => (
   <Switch>
+    <Route
+      path="/companies/:companyName"
+      exact
+      render={({ location: { pathname } }) => (
+        <Redirect to={`${pathname}/overview`} />
+      )}
+    />
     <Route
       path="/companies/:companyName/overview"
       exact

--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -5,8 +5,13 @@ import { createStructuredSelector } from 'reselect';
 import { withProps, lifecycle, compose, setStatic } from 'recompose';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { Switch, Route } from 'react-router-dom';
+import Overview from '../CompanyAndJobTitle/Overview';
+import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
+import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
+import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 
-import { pageType } from '../../constants/companyJobTitle';
+import { tabType, pageType } from '../../constants/companyJobTitle';
 import companyActions from '../../actions/company';
 import {
   interviewExperiences,
@@ -25,38 +30,46 @@ const getCompanyNameFromParams = R.compose(
   paramsSelector,
 );
 
-const CompanyPageProvider = ({
-  children,
-  pageType,
-  pageName,
-  tabType,
-  interviewExperiences,
-  workExperiences,
-  salaryWorkTimes,
-  salaryWorkTimeStatistics,
-  status,
-  page,
-}) => (
-  <React.Fragment>
-    {children({
-      pageType,
-      pageName,
-      tabType,
-      interviewExperiences,
-      workExperiences,
-      salaryWorkTimes,
-      salaryWorkTimeStatistics,
-      status,
-      page,
-    })}
-  </React.Fragment>
+const CompanyPageProvider = props => (
+  <Switch>
+    <Route
+      path="/companies/:companyName/overview"
+      exact
+      render={() => <Overview {...props} tabType={tabType.OVERVIEW} />}
+    />
+    <Route
+      path="/companies/:companyName/salary-work-times"
+      exact
+      render={() => (
+        <CompanyJobTitleTimeAndSalary
+          {...props}
+          tabType={tabType.TIME_AND_SALARY}
+        />
+      )}
+    />
+    <Route
+      path="/companies/:companyName/interview-experiences"
+      exact
+      render={() => (
+        <InterviewExperiences
+          {...props}
+          tabType={tabType.INTERVIEW_EXPERIENCE}
+        />
+      )}
+    />
+    <Route
+      path="/companies/:companyName/work-experiences"
+      exact
+      render={() => (
+        <WorkExperiences {...props} tabType={tabType.WORK_EXPERIENCE} />
+      )}
+    />
+  </Switch>
 );
 
 CompanyPageProvider.propTypes = {
-  children: PropTypes.func.isRequired,
   pageType: PropTypes.string.isRequired,
   pageName: PropTypes.string.isRequired,
-  tabType: PropTypes.string.isRequired,
   interviewExperiences: PropTypes.arrayOf(PropTypes.object),
   workExperiences: PropTypes.arrayOf(PropTypes.object),
   salaryWorkTimes: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -10,6 +10,7 @@ import Overview from '../CompanyAndJobTitle/Overview';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
+import NotFound from '../common/NotFound';
 
 import { tabType, pageType } from '../../constants/companyJobTitle';
 import companyActions from '../../actions/company';
@@ -71,6 +72,7 @@ const CompanyPageProvider = props => (
         <WorkExperiences {...props} tabType={tabType.WORK_EXPERIENCE} />
       )}
     />
+    <Route component={NotFound} />
   </Switch>
 );
 

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -5,7 +5,7 @@ import { createStructuredSelector } from 'reselect';
 import { withProps, lifecycle, compose, setStatic } from 'recompose';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { Switch, Route } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 import Overview from '../CompanyAndJobTitle/Overview';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
@@ -33,6 +33,13 @@ const getJobTitleFromParams = R.compose(
 
 const JobTitlePageProvider = props => (
   <Switch>
+    <Route
+      path="/job-titles/:jobTitle"
+      exact
+      render={({ location: { pathname } }) => (
+        <Redirect to={`${pathname}/overview`} />
+      )}
+    />
     <Route
       path="/job-titles/:jobTitle/overview"
       exact

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -5,8 +5,13 @@ import { createStructuredSelector } from 'reselect';
 import { withProps, lifecycle, compose, setStatic } from 'recompose';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
+import { Switch, Route } from 'react-router-dom';
+import Overview from '../CompanyAndJobTitle/Overview';
+import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
+import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
+import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 
-import { pageType } from '../../constants/companyJobTitle';
+import { tabType, pageType } from '../../constants/companyJobTitle';
 import jobTitleActions from '../../actions/jobTitle';
 import {
   interviewExperiences,
@@ -26,38 +31,46 @@ const getJobTitleFromParams = R.compose(
   paramsSelector,
 );
 
-const JobTitlePageProvider = ({
-  children,
-  pageType,
-  pageName,
-  tabType,
-  interviewExperiences,
-  workExperiences,
-  salaryWorkTimes,
-  salaryWorkTimeStatistics,
-  status,
-  page,
-}) => (
-  <React.Fragment>
-    {children({
-      pageType,
-      pageName,
-      tabType,
-      interviewExperiences,
-      workExperiences,
-      salaryWorkTimes,
-      salaryWorkTimeStatistics,
-      status,
-      page,
-    })}
-  </React.Fragment>
+const JobTitlePageProvider = props => (
+  <Switch>
+    <Route
+      path="/job-titles/:jobTitle/overview"
+      exact
+      render={() => <Overview {...props} tabType={tabType.OVERVIEW} />}
+    />
+    <Route
+      path="/job-titles/:jobTitle/salary-work-times"
+      exact
+      render={() => (
+        <CompanyJobTitleTimeAndSalary
+          {...props}
+          tabType={tabType.TIME_AND_SALARY}
+        />
+      )}
+    />
+    <Route
+      path="/job-titles/:jobTitle/interview-experiences"
+      exact
+      render={() => (
+        <InterviewExperiences
+          {...props}
+          tabType={tabType.INTERVIEW_EXPERIENCE}
+        />
+      )}
+    />
+    <Route
+      path="/job-titles/:jobTitle/work-experiences"
+      exact
+      render={() => (
+        <WorkExperiences {...props} tabType={tabType.WORK_EXPERIENCE} />
+      )}
+    />
+  </Switch>
 );
 
 JobTitlePageProvider.propTypes = {
-  children: PropTypes.func.isRequired,
   pageType: PropTypes.string.isRequired,
   pageName: PropTypes.string.isRequired,
-  tabType: PropTypes.string.isRequired,
   interviewExperiences: PropTypes.arrayOf(PropTypes.object),
   workExperiences: PropTypes.arrayOf(PropTypes.object),
   salaryWorkTimes: PropTypes.arrayOf(PropTypes.object),

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -96,7 +96,7 @@ const mapDispatchToProps = dispatch =>
 
 const ssr = setStatic('fetchData', ({ store: { dispatch }, ...props }) => {
   const jobTitle = getJobTitleFromParams(props);
-  return dispatch(jobTitleActions.fetchCompany(jobTitle));
+  return dispatch(jobTitleActions.fetchJobTitle(jobTitle));
 });
 
 const enhance = compose(

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -10,6 +10,7 @@ import Overview from '../CompanyAndJobTitle/Overview';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
+import NotFound from '../common/NotFound';
 
 import { tabType, pageType } from '../../constants/companyJobTitle';
 import jobTitleActions from '../../actions/jobTitle';
@@ -72,6 +73,7 @@ const JobTitlePageProvider = props => (
         <WorkExperiences {...props} tabType={tabType.WORK_EXPERIENCE} />
       )}
     />
+    <Route component={NotFound} />
   </Switch>
 );
 

--- a/src/routes.js
+++ b/src/routes.js
@@ -29,12 +29,6 @@ import Redirect from 'common/routing/Redirect';
 import VerificationPage from './components/EmailVerification/VerificationPage';
 import CompanyPageProvider from './components/Company/CompanyPageProvider';
 import JobTitlePageProvider from './components/JobTitle/JobTitlePageProvider';
-import Overview from './components/CompanyAndJobTitle/Overview';
-import InterviewExperiences from './components/CompanyAndJobTitle/InterviewExperiences';
-import WorkExperiences from './components/CompanyAndJobTitle/WorkExperiences';
-import CompanyJobTitleTimeAndSalary from './components/CompanyAndJobTitle/TimeAndSalary';
-
-import { tabType } from './constants/companyJobTitle';
 
 const routes = [
   {
@@ -215,47 +209,22 @@ const routes = [
       {
         path: '/companies/:companyName/overview',
         exact: true,
-        render: routeProps => (
-          <CompanyPageProvider {...routeProps} tabType={tabType.OVERVIEW}>
-            {Overview}
-          </CompanyPageProvider>
-        ),
+        component: CompanyPageProvider,
       },
       {
         path: '/companies/:companyName/salary-work-times',
         exact: true,
-        render: routeProps => (
-          <CompanyPageProvider
-            {...routeProps}
-            tabType={tabType.TIME_AND_SALARY}
-          >
-            {CompanyJobTitleTimeAndSalary}
-          </CompanyPageProvider>
-        ),
+        component: CompanyPageProvider,
       },
       {
         path: '/companies/:companyName/interview-experiences',
         exact: true,
-        render: routeProps => (
-          <CompanyPageProvider
-            {...routeProps}
-            tabType={tabType.INTERVIEW_EXPERIENCE}
-          >
-            {InterviewExperiences}
-          </CompanyPageProvider>
-        ),
+        component: CompanyPageProvider,
       },
       {
         path: '/companies/:companyName/work-experiences',
         exact: true,
-        render: routeProps => (
-          <CompanyPageProvider
-            {...routeProps}
-            tabType={tabType.WORK_EXPERIENCE}
-          >
-            {WorkExperiences}
-          </CompanyPageProvider>
-        ),
+        component: CompanyPageProvider,
       },
       {
         component: NotFound,
@@ -276,47 +245,22 @@ const routes = [
       {
         path: '/job-titles/:jobTitle/overview',
         exact: true,
-        render: routeProps => (
-          <JobTitlePageProvider {...routeProps} tabType={tabType.OVERVIEW}>
-            {Overview}
-          </JobTitlePageProvider>
-        ),
+        component: JobTitlePageProvider,
       },
       {
         path: '/job-titles/:jobTitle/salary-work-times',
         exact: true,
-        render: routeProps => (
-          <JobTitlePageProvider
-            {...routeProps}
-            tabType={tabType.TIME_AND_SALARY}
-          >
-            {CompanyJobTitleTimeAndSalary}
-          </JobTitlePageProvider>
-        ),
+        component: JobTitlePageProvider,
       },
       {
         path: '/job-titles/:jobTitle/interview-experiences',
         exact: true,
-        render: routeProps => (
-          <JobTitlePageProvider
-            {...routeProps}
-            tabType={tabType.INTERVIEW_EXPERIENCE}
-          >
-            {InterviewExperiences}
-          </JobTitlePageProvider>
-        ),
+        component: JobTitlePageProvider,
       },
       {
         path: '/job-titles/:jobTitle/work-experiences',
         exact: true,
-        render: routeProps => (
-          <JobTitlePageProvider
-            {...routeProps}
-            tabType={tabType.WORK_EXPERIENCE}
-          >
-            {WorkExperiences}
-          </JobTitlePageProvider>
-        ),
+        component: JobTitlePageProvider,
       },
       {
         component: NotFound,

--- a/src/routes.js
+++ b/src/routes.js
@@ -201,29 +201,6 @@ const routes = [
     routes: [
       {
         path: '/companies/:companyName',
-        exact: true,
-        render: ({ location: { pathname } }) => (
-          <Redirect to={`${pathname}/overview`} />
-        ),
-      },
-      {
-        path: '/companies/:companyName/overview',
-        exact: true,
-        component: CompanyPageProvider,
-      },
-      {
-        path: '/companies/:companyName/salary-work-times',
-        exact: true,
-        component: CompanyPageProvider,
-      },
-      {
-        path: '/companies/:companyName/interview-experiences',
-        exact: true,
-        component: CompanyPageProvider,
-      },
-      {
-        path: '/companies/:companyName/work-experiences',
-        exact: true,
         component: CompanyPageProvider,
       },
       {
@@ -237,29 +214,6 @@ const routes = [
     routes: [
       {
         path: '/job-titles/:jobTitle',
-        exact: true,
-        render: ({ location: { pathname } }) => (
-          <Redirect to={`${pathname}/overview`} />
-        ),
-      },
-      {
-        path: '/job-titles/:jobTitle/overview',
-        exact: true,
-        component: JobTitlePageProvider,
-      },
-      {
-        path: '/job-titles/:jobTitle/salary-work-times',
-        exact: true,
-        component: JobTitlePageProvider,
-      },
-      {
-        path: '/job-titles/:jobTitle/interview-experiences',
-        exact: true,
-        component: JobTitlePageProvider,
-      },
-      {
-        path: '/job-titles/:jobTitle/work-experiences',
-        exact: true,
         component: JobTitlePageProvider,
       },
       {


### PR DESCRIPTION
Close #763 

## 這個 PR 是？ <!-- 必填 -->

這個 PR 暫時解決公司職稱頁面沒有 SSR 的問題

1) `routes.js` 用 component 而不是 render，
在 SSR 的處理中，如果有 static property fetchData，就會運作

## Screenshots  <!-- 選填，沒有就刪掉 -->

![image](https://user-images.githubusercontent.com/1908007/63206259-c19e5880-c0e3-11e9-8751-a17bb7e76dc3.png)

如上圖，可以看到 window.__data 是由 server side 填入，window.__data 會作為一開始的 initial state 給 redux store

![image](https://user-images.githubusercontent.com/1908007/63206270-0e822f00-c0e4-11e9-8d11-dd06c994e368.png)

如上圖，也可以看到 html 原始碼是有資料的（eg: 323 筆）

代表 SSR Render 成功