### PR TITLE
Feat: trigger google optimize at every page

### DIFF
--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -8,6 +8,7 @@ import { PermissionContextProvider } from 'common/permission-context';
 import { FacebookContextProvider } from 'common/facebook';
 
 import App from './App';
+import { activateOptimize } from '../utils/gtm';
 import { GA_ID, PIXEL_ID } from '../config';
 
 const logPageView = location => {
@@ -24,8 +25,12 @@ class Root extends Component {
     ReactPixel.init(PIXEL_ID);
     ReactPixel.pageView();
 
+    // log pageview to Google Analytics
     const { location } = this.props;
     logPageView(location);
+
+    // activate google optimize
+    activateOptimize();
   }
 
   componentDidUpdate(prevProps) {
@@ -33,6 +38,10 @@ class Root extends Component {
     const { location: prevLocation } = prevProps;
     if (location !== prevLocation) {
       logPageView(location);
+
+      // 因為 react 是 SPA，需要在每次 route 改變時
+      // push event 到 window.dataLayer 去觸發 google optimize 實驗
+      activateOptimize();
     }
   }
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -4,7 +4,7 @@
 module.exports = {
   API_HOST: process.env.RAZZLE_API_HOST || 'https://api-dev.goodjob.life',
   FACEBOOK_APP_ID: process.env.RAZZLE_FACEBOOK_APP_ID || '1750608541889151',
-  GA_ID: process.env.RAZZLE_GA_ID || 'UA-79990667-2',
+  GA_ID: process.env.RAZZLE_GA_ID || 'UA-79990667-7',
   GTM_ID: process.env.RAZZLE_GTM_ID || 'GTM-K2MRXLG',
   PIXEL_ID: process.env.RAZZLE_PIXEL_ID || '603414113402034',
   SENTRY_DSN: process.env.RAZZLE_SENTRY_DSN,

--- a/src/utils/gtm.js
+++ b/src/utils/gtm.js
@@ -1,0 +1,30 @@
+/**
+ * trigger event to Google Tag Manager via `window.dataLayer`
+ *
+ * @param {Object} event - GTM event to be push into dataLayer
+ * @see {@link https://developers.google.com/tag-manager/devguide}
+ */
+export const pushDataLayer = event => {
+  if (window.dataLayer) {
+    window.dataLayer.push(event);
+  } else {
+    window.dataLayer = [event];
+  }
+};
+
+/**
+ * Google Optimize 會在 Page Load 檢查是否執行 A/B testing，但因為 SPA 只會發生一
+ * 次 Page Load，所以需要額外送 optimize.active 之類的 event，才能讓 Optimize 知道
+ * 頁面切換。
+ *
+ * 目前在 Root.js 裡面的 componentDidMount & componentDidUpdate 都會 push
+ * `optimize.activate` 事件到 dataLayer，就可以讓 SPA 的 react 可以在每個頁面都能
+ * 觸發 google optimize 的實驗
+ *
+ * @param {string=} customOptimizeEventName - 供 Google Optimize 辨識的 event 名稱，預設為 'optimize.activate'
+ * @see {@link https://support.google.com/optimize/answer/7008840?hl=en}
+ * @see {@link https://developers.google.com/tag-manager/devguide}
+ */
+export const activateOptimize = customOptimizeEventName => {
+  pushDataLayer({ event: `optimize.${customOptimizeEventName || 'activate'}` });
+};


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

[google optimize](https://optimize.google.com/optimize/home/) 是一個專門做 A/B testing 的工具，可以讓使用者不用動程式碼就做出 A/B 兩組 UI (註1)，並且自動追蹤目標數據（例如：面試經驗表單轉換率），去判定 A/B 兩組差異是否顯著。

我已經用 google tag manager 在 local & production 上面都安裝了 google optimize SDK，所以不用再程式碼裡面另外裝。

但因為 React 是個 single page application ，如果使用 google optimize 預設的實驗觸發機制（page load），將無法正常運作。（因為 react 只有在第一頁才有真正的 page load）。因此必須在每一次網址改變時，推送事件到 window.dataLayer 去觸發 google optimize 檢查是否觸發實驗。這個 PR 就是做這件事。

詳見官方文件：https://support.google.com/optimize/answer/7008840?hl=en 有個章節是 `Firing activation in a single page application` ，簡而言之是我們要自己送 event 到 dataLayer 觸發 google optimize。

附註：
1. 太複雜的還是要工程師去動程式碼才能達到。但如果只是隱藏區塊、調整顏色、字體等等，可以用 google optimize 編輯器直接做到。

## Screenshots

如果成功跑起實驗，幾天後會有類似這樣的報表
![screencapture-optimize-google-optimize-home-2019-09-13-11_36_43](https://user-images.githubusercontent.com/3805975/64836092-25506e80-d61b-11e9-9107-c6fc332badbd.png)


## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

建議到 https://optimize.google.com/optimize/home/ 用 goodjob-local 的容器試玩一下！
或是有興趣的話，我可以線上真人語音導覽

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 前後端跑起來，輸入 http://localhost:3000 是可以正常出現網頁的
- [ ] 從隨便一頁進去 local 端網頁，進到面試經驗表單第三步驟，中間面試的問題區塊，應該要是消失的。（因為我已經在 goodjob-local 容器開啟實驗，且 100% 進到 B 組，也就是移除中間面試問題區塊的組）

像這樣：
<img width="877" alt="螢幕快照 2019-09-13 上午11 33 54" src="https://user-images.githubusercontent.com/3805975/64835904-76ac2e00-d61a-11e9-8f81-c566334ca5c4.png">
