### PR TITLE
[公司/職稱頁面] 公司、職稱頁面的經驗結果卡片調整 

### DIFF
--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -123,10 +123,18 @@ const enhance = compose(
   lifecycle({
     componentDidMount() {
       this.props.fetchCompany(this.props.pageName);
+      this.props.fetchPermission();
     },
     componentDidUpdate(prevProps) {
       if (this.props.pageName !== prevProps.pageName) {
         this.props.fetchCompany(this.props.pageName);
+      }
+
+      if (
+        this.props.pageName !== prevProps.pageName ||
+        this.props.pageType !== prevProps.pageType
+      ) {
+        this.props.fetchPermission();
       }
     },
   }),

--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -11,6 +11,7 @@ import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 import NotFound from '../common/NotFound';
+import { withPermission } from 'common/permission-context';
 
 import { tabType, pageType } from '../../constants/companyJobTitle';
 import companyActions from '../../actions/company';
@@ -110,6 +111,7 @@ const ssr = setStatic('fetchData', ({ store: { dispatch }, ...props }) => {
 const enhance = compose(
   ssr,
   withRouteParameter,
+  withPermission,
   withProps(({ match: { params: { companyName } } }) => ({
     pageType: pageType.COMPANY,
     pageName: companyName,

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -6,71 +6,64 @@ import { Heading, P } from 'common/base';
 import i from 'common/icons';
 import styles from './InterviewExperiences.module.css';
 import { formatCreatedAt, formatSalary } from './helper';
-import Label from '../Label';
 import Rating from './Rating';
-import { pageType as PAGE_TYPE } from '../../../constants/companyJobTitle';
 
 const createLinkTo = id => ({
   pathname: `/experiences/${id}`,
   state: { backable: true },
 });
 
-const ExperienceEntry = ({ pageType, data, size }) => {
-  const {
+const SNIPPET_SIZE = 30;
+
+const ExperienceEntry = ({
+  pageType,
+  data: {
     id,
     company: { name: companyName } = {},
     job_title: { name: jobTitle } = {},
-    region,
     created_at: createdAt,
     salary,
-    title,
     overall_rating: overallRating,
-  } = data;
-
-  return (
-    <Link to={createLinkTo(id)} className={cn(styles.container, styles[size])}>
-      <section className={styles.contentWrapper}>
-        <P size="s">{formatCreatedAt(createdAt)}</P>
-
-        <Heading
-          Tag="h2"
-          size={size === 'l' ? 'sl' : 'sm'}
-          className={styles.heading}
-        >
-          {title}
-        </Heading>
-
-        <div className={styles.labels}>
-          {pageType !== PAGE_TYPE.COMPANY && (
-            <Label
-              text={companyName}
-              Icon={i.Company}
-              className={styles.company}
-            />
-          )}
-          {pageType !== PAGE_TYPE.JOB_TITLE && (
-            <Label text={jobTitle} Icon={i.User} className={styles.position} />
-          )}
-          {region && (
-            <Label
-              text={region}
-              Icon={i.Location}
-              className={styles.location}
-            />
-          )}
-          {salary && (
-            <Label
-              className={styles.salary}
-              text={formatSalary(salary)}
-              Icon={i.Coin}
-            />
-          )}
+    sections: [section],
+  },
+  size,
+}) => (
+  <div className={cn(styles.container, styles[size])}>
+    <section className={styles.contentWrapper}>
+      <div className={styles.labels}>
+        <P size="s" className={styles.date}>
+          面試經驗 · {formatCreatedAt(createdAt)}
+        </P>
+        {salary && (
+          <div className={styles.salary}>
+            <i.Coin />
+            {formatSalary(salary)}
+          </div>
+        )}
+        <div className={styles.rating}>
           <Rating rate={overallRating} />
         </div>
-      </section>
-    </Link>
-  );
-};
+      </div>
+
+      <Heading
+        Tag="h2"
+        size={size === 'l' ? 'sl' : 'sm'}
+        className={styles.heading}
+      >
+        {companyName} {jobTitle}
+      </Heading>
+
+      <div className={styles.snippetWrapper}>
+        <span className={styles.snippet}>
+          {section.content.slice(0, SNIPPET_SIZE)}....
+        </span>
+        <Link to={createLinkTo(id)} className={styles.readmore}>
+          閱讀更多
+        </Link>
+      </div>
+    </section>
+  </div>
+);
 
 ExperienceEntry.propTypes = {
   data: PropTypes.object.isRequired,

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -2,10 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import cn from 'classnames';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faLock from '@fortawesome/fontawesome-free-solid/faLock';
+
 import { Heading, P } from 'common/base';
 import i from 'common/icons';
 import styles from './InterviewExperiences.module.css';
-import { formatCreatedAt, formatSalary } from './helper';
+import { formatCreatedAt, formatSalary, formatSalaryRange } from './helper';
 import Rating from './Rating';
 
 const createLinkTo = id => ({
@@ -27,6 +30,7 @@ const ExperienceEntry = ({
     sections: [section],
   },
   size,
+  canViewExperienceDetail,
 }) => (
   <div className={cn(styles.container, styles[size])}>
     <section className={styles.contentWrapper}>
@@ -35,9 +39,22 @@ const ExperienceEntry = ({
           面試經驗 · {formatCreatedAt(createdAt)}
         </P>
         {salary && (
-          <div className={styles.salary}>
-            <i.Coin />
-            {formatSalary(salary)}
+          <div
+            className={cn(styles.salary, {
+              [styles.locked]: !canViewExperienceDetail,
+            })}
+          >
+            {canViewExperienceDetail ? (
+              <React.Fragment>
+                <i.Coin />
+                {formatSalary(salary)}
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                <FontAwesomeIcon icon={faLock} />
+                {formatSalaryRange(salary)}
+              </React.Fragment>
+            )}
           </div>
         )}
         <div className={styles.rating}>
@@ -57,8 +74,13 @@ const ExperienceEntry = ({
         <span className={styles.snippet}>
           {section.content.slice(0, SNIPPET_SIZE)}....
         </span>
-        <Link to={createLinkTo(id)} className={styles.readmore}>
-          閱讀更多
+        <Link
+          to={createLinkTo(id)}
+          className={cn(styles.readmore, {
+            [styles.locked]: !canViewExperienceDetail,
+          })}
+        >
+          {`閱讀更多${canViewExperienceDetail ? '' : '並解鎖'}`}
         </Link>
       </div>
     </section>
@@ -68,6 +90,7 @@ const ExperienceEntry = ({
 ExperienceEntry.propTypes = {
   data: PropTypes.object.isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 ExperienceEntry.defaultProps = {

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
@@ -9,7 +9,14 @@ import ExperienceEntry from './ExperienceEntry';
 
 const pageSize = 10;
 
-const InterviewExperiences = ({ pageType, pageName, tabType, data, page }) => {
+const InterviewExperiences = ({
+  pageType,
+  pageName,
+  tabType,
+  data,
+  page,
+  canViewExperienceDetail,
+}) => {
   if (data.length === 0) {
     return <EmptyView pageName={pageName} tabType={tabType} />;
   }
@@ -17,7 +24,12 @@ const InterviewExperiences = ({ pageType, pageName, tabType, data, page }) => {
   return (
     <Section Tag="main" paddingBottom>
       {visibleData.map(d => (
-        <ExperienceEntry key={d.id} pageType={pageType} data={d} />
+        <ExperienceEntry
+          key={d.id}
+          pageType={pageType}
+          data={d}
+          canViewExperienceDetail={canViewExperienceDetail}
+        />
       ))}
       <Pagination
         totalCount={data.length}
@@ -35,6 +47,7 @@ InterviewExperiences.propTypes = {
   tabType: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.object),
   page: PropTypes.number.isRequired,
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 export default InterviewExperiences;

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.module.css
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.module.css
@@ -51,6 +51,12 @@
       height: 16px;
       fill: #adadad;
     }
+
+    &.locked {
+      svg {
+        color: #ed0d5e;
+      }
+    }
   }
 
   .rating {
@@ -116,6 +122,10 @@
 
     &:hover {
       text-decoration: none;
+    }
+
+    &.locked {
+      color: #ed0d5e;
     }
   }
 }

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.module.css
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.module.css
@@ -12,15 +12,6 @@
     margin-bottom: 0;
   }
 
-  @media (min-width: 1025px) {
-    &:hover {
-      box-shadow: 1px 1px 11px rgba(0, 0, 0, 0.25);
-      .heading {
-        color: link-blue;
-      }
-    }
-  }
-
   @media (max-width: 550px) {
     margin-left: calc(page-gutter-s * -1);
     margin-right: calc(page-gutter-s * -1);
@@ -29,10 +20,45 @@
 }
 
 .contentWrapper {
-  padding: 15px 29px 21px 29px;
+  padding: 16px 28px;
 
   @media (max-width: 1024px) {
     padding: 16px;
+  }
+}
+
+.labels {
+  display: flex;
+
+  .date {
+    flex: 1;
+    color: #adadad;
+  }
+
+  .salary,
+  .rating {
+    margin-left: 35px;
+    display: flex;
+    align-items: center;
+    font-size: 15px;
+    color: #424242;
+  }
+
+  .salary {
+    svg {
+      margin-right: 7px;
+      width: 16px;
+      height: 16px;
+      fill: #adadad;
+    }
+  }
+
+  .rating {
+    svg {
+      cursor: auto;
+      width: 24px;
+      height: 24px;
+    }
   }
 }
 
@@ -50,7 +76,7 @@
   }
 
   .contentWrapper {
-    margin-bottom: 15px;
+    margin-bottom: 5px;
   }
 }
 
@@ -67,32 +93,29 @@
     font-size: 0.9em;
   }
 
-  .labels {
-    color: main-gray;
-    margin-bottom: 0;
-  }
-
-  .company {
-    display: none;
-  }
-
   .heading {
     margin-top: 12px;
     margin-bottom: 12px;
   }
 }
 
-.rateButtons {
-  cursor: auto;
-  display: inline-flex;
-  align-items: center;
+.snippetWrapper {
+  display: flex;
+  align-items: flex-end;
 
-  .rateButton {
-    width: 23px;
-    height: 23px;
+  .snippet {
+    flex: 1;
+    word-break: break-all;
+    padding-right: 1em;
   }
-}
 
-.autoCursor {
-  cursor: auto;
+  .readmore {
+    font-weight: 600;
+    color: #325bbd;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/helper.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/helper.js
@@ -1,4 +1,8 @@
-import { formatSalaryAmount, formatSalaryType } from 'common/formatter';
+import {
+  formatSalaryAmount,
+  formatSalaryAmountRange,
+  formatSalaryType,
+} from 'common/formatter';
 
 export const formatCreatedAt = createdAt => {
   const date = new Date(Date.parse(createdAt));
@@ -15,4 +19,14 @@ export const formatSalary = salary => {
   const { amount, type } = salary;
 
   return `${formatSalaryAmount(amount)} / ${formatSalaryType(type)}`;
+};
+
+export const formatSalaryRange = salary => {
+  if (!salary) {
+    return '';
+  }
+
+  return `${formatSalaryAmountRange(salary)} / ${formatSalaryType(
+    salary.type,
+  )}`;
 };

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
@@ -12,6 +12,7 @@ const InterviewExperiences = ({
   interviewExperiences,
   status,
   page,
+  canViewExperienceDetail,
 }) => (
   <CompanyAndJobTitleWrapper
     pageType={pageType}
@@ -25,6 +26,7 @@ const InterviewExperiences = ({
         tabType={tabType}
         data={interviewExperiences}
         page={page}
+        canViewExperienceDetail={canViewExperienceDetail}
       />
     </StatusRenderer>
   </CompanyAndJobTitleWrapper>
@@ -37,6 +39,7 @@ InterviewExperiences.propTypes = {
   interviewExperiences: PropTypes.arrayOf(PropTypes.object),
   status: PropTypes.string.isRequired,
   page: PropTypes.number.isRequired,
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 export default InterviewExperiences;

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { compose } from 'recompose';
 
-import { withPermission } from 'common/permission-context';
 import { Section } from 'common/base';
 
 import SnippetBlock from './SnippetBlock';
@@ -23,6 +21,7 @@ const Overview = ({
   workExperiences,
   salaryWorkTimes,
   canViewTimeAndSalary,
+  canViewExperienceDetail,
 }) => (
   <Section Tag="main" paddingBottom>
     <SnippetBlock
@@ -50,7 +49,12 @@ const Overview = ({
       tabType={TAB_TYPE.WORK_EXPERIENCE}
     >
       {workExperiences.slice(0, WORK_EXPERIENCES_LIMIT).map(d => (
-        <WorkExperienceEntry key={d.id} pageType={pageType} data={d} />
+        <WorkExperienceEntry
+          key={d.id}
+          pageType={pageType}
+          data={d}
+          canViewExperienceDetail={canViewExperienceDetail}
+        />
       ))}
     </SnippetBlock>
     <SnippetBlock
@@ -63,7 +67,12 @@ const Overview = ({
       tabType={TAB_TYPE.INTERVIEW_EXPERIENCE}
     >
       {interviewExperiences.slice(0, INTERVIEW_EXPERIENCES_LIMIT).map(d => (
-        <InterviewExperienceEntry key={d.id} pageType={pageType} data={d} />
+        <InterviewExperienceEntry
+          key={d.id}
+          pageType={pageType}
+          data={d}
+          canViewExperienceDetail={canViewExperienceDetail}
+        />
       ))}
     </SnippetBlock>
   </Section>
@@ -77,8 +86,7 @@ Overview.propTypes = {
   workExperiences: PropTypes.arrayOf(PropTypes.object),
   salaryWorkTimes: PropTypes.arrayOf(PropTypes.object),
   canViewTimeAndSalary: PropTypes.bool.isRequired,
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
-const hoc = compose(withPermission);
-
-export default hoc(Overview);
+export default Overview;

--- a/src/components/CompanyAndJobTitle/Overview/index.js
+++ b/src/components/CompanyAndJobTitle/Overview/index.js
@@ -13,6 +13,8 @@ const Overview = ({
   salaryWorkTimeStatistics,
   status,
   page,
+  canViewTimeAndSalary,
+  canViewExperienceDetail,
 }) => (
   <CompanyAndJobTitleWrapper
     pageType={pageType}
@@ -29,6 +31,8 @@ const Overview = ({
         salaryWorkTimes={salaryWorkTimes}
         salaryWorkTimeStatistics={salaryWorkTimeStatistics}
         page={page}
+        canViewTimeAndSalary={canViewTimeAndSalary}
+        canViewExperienceDetail={canViewExperienceDetail}
       />
     )}
   </CompanyAndJobTitleWrapper>
@@ -44,6 +48,8 @@ Overview.propTypes = {
   salaryWorkTimeStatistics: PropTypes.object,
   status: PropTypes.string.isRequired,
   page: PropTypes.number.isRequired,
+  canViewTimeAndSalary: PropTypes.bool.isRequired,
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 export default Overview;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -5,79 +5,72 @@ import cn from 'classnames';
 import { Heading, P } from 'common/base';
 import i from 'common/icons';
 import styles from './WorkExperiences.module.css';
-import {
-  formatCreatedAt,
-  formatSalary,
-  formatRecommendToOthers,
-} from './helper';
-import Label from '../Label';
-import { pageType as PAGE_TYPE } from '../../../constants/companyJobTitle';
+import { formatCreatedAt, formatWeekWorkTime, formatSalary } from './helper';
 
 const createLinkTo = id => ({
   pathname: `/experiences/${id}`,
   state: { backable: true },
 });
 
-const ExperienceEntry = ({ pageType, data, size }) => {
-  const {
+const SNIPPET_SIZE = 30;
+
+const ExperienceEntry = ({
+  pageType,
+  data: {
     id,
     company: { name: companyName } = {},
     job_title: { name: jobTitle } = {},
-    region,
     created_at: createdAt,
+    sections: [section],
+    week_work_time: weekWorkTime,
     salary,
-    title,
     recommend_to_others: recommendToOthers,
-  } = data;
-
-  return (
-    <Link to={createLinkTo(id)} className={cn(styles.container, styles[size])}>
-      <section className={styles.contentWrapper}>
-        <P size="s">{formatCreatedAt(createdAt)}</P>
-
-        <Heading
-          Tag="h2"
-          size={size === 'l' ? 'sl' : 'sm'}
-          className={styles.heading}
-        >
-          {title}
-        </Heading>
-
-        <div className={styles.labels}>
-          {pageType !== PAGE_TYPE.COMPANY && (
-            <Label
-              text={companyName}
-              Icon={i.Company}
-              className={styles.company}
-            />
-          )}
-          {pageType !== PAGE_TYPE.JOB_TITLE && (
-            <Label text={jobTitle} Icon={i.User} className={styles.position} />
-          )}
-          {region && (
-            <Label
-              text={region}
-              Icon={i.Location}
-              className={styles.location}
-            />
-          )}
-          {salary && (
-            <Label
-              className={styles.salary}
-              text={formatSalary(salary)}
-              Icon={i.Coin}
-            />
-          )}
-          <Label
-            className={styles.recommendToOthers}
-            text={formatRecommendToOthers(recommendToOthers)}
-            Icon={recommendToOthers === 'yes' ? i.Good : i.Bad}
-          />
+  },
+  size,
+}) => (
+  <div className={cn(styles.container, styles[size])}>
+    <section className={styles.contentWrapper}>
+      <div className={styles.labels}>
+        <P size="s" className={styles.date}>
+          工作經驗 · {formatCreatedAt(createdAt)}
+        </P>
+        {weekWorkTime && (
+          <div className={styles.weekWorkTime}>
+            <i.Clock />
+            {formatWeekWorkTime(weekWorkTime)}
+          </div>
+        )}
+        {salary && (
+          <div className={styles.salary}>
+            <i.Coin />
+            {formatSalary(salary)}
+          </div>
+        )}
+        <div className={styles.recommendToOthers}>
+          {recommendToOthers ? <i.Good /> : <i.Bad />}
+          {recommendToOthers ? '推' : '不推'}
         </div>
-      </section>
-    </Link>
-  );
-};
+      </div>
+
+      <Heading
+        Tag="h2"
+        size={size === 'l' ? 'sl' : 'sm'}
+        className={styles.heading}
+      >
+        {companyName} {jobTitle}
+      </Heading>
+
+      <div className={styles.snippetWrapper}>
+        <span className={styles.snippet}>
+          {section.content.slice(0, SNIPPET_SIZE)}....
+        </span>
+        <Link to={createLinkTo(id)} className={styles.readmore}>
+          閱讀更多
+        </Link>
+      </div>
+    </section>
+  </div>
+);
 
 ExperienceEntry.propTypes = {
   data: PropTypes.object.isRequired,

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -2,10 +2,17 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import cn from 'classnames';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import faLock from '@fortawesome/fontawesome-free-solid/faLock';
 import { Heading, P } from 'common/base';
 import i from 'common/icons';
 import styles from './WorkExperiences.module.css';
-import { formatCreatedAt, formatWeekWorkTime, formatSalary } from './helper';
+import {
+  formatCreatedAt,
+  formatWeekWorkTime,
+  formatSalary,
+  formatSalaryRange,
+} from './helper';
 
 const createLinkTo = id => ({
   pathname: `/experiences/${id}`,
@@ -27,6 +34,7 @@ const ExperienceEntry = ({
     recommend_to_others: recommendToOthers,
   },
   size,
+  canViewExperienceDetail,
 }) => (
   <div className={cn(styles.container, styles[size])}>
     <section className={styles.contentWrapper}>
@@ -34,16 +42,29 @@ const ExperienceEntry = ({
         <P size="s" className={styles.date}>
           工作經驗 · {formatCreatedAt(createdAt)}
         </P>
-        {weekWorkTime && (
+        {weekWorkTime && canViewExperienceDetail && (
           <div className={styles.weekWorkTime}>
             <i.Clock />
             {formatWeekWorkTime(weekWorkTime)}
           </div>
         )}
         {salary && (
-          <div className={styles.salary}>
-            <i.Coin />
-            {formatSalary(salary)}
+          <div
+            className={cn(styles.salary, {
+              [styles.locked]: !canViewExperienceDetail,
+            })}
+          >
+            {canViewExperienceDetail ? (
+              <React.Fragment>
+                <i.Coin />
+                {formatSalary(salary)}
+              </React.Fragment>
+            ) : (
+              <React.Fragment>
+                <FontAwesomeIcon icon={faLock} />
+                {formatSalaryRange(salary)}
+              </React.Fragment>
+            )}
           </div>
         )}
         <div className={styles.recommendToOthers}>
@@ -64,8 +85,13 @@ const ExperienceEntry = ({
         <span className={styles.snippet}>
           {section.content.slice(0, SNIPPET_SIZE)}....
         </span>
-        <Link to={createLinkTo(id)} className={styles.readmore}>
-          閱讀更多
+        <Link
+          to={createLinkTo(id)}
+          className={cn(styles.readmore, {
+            [styles.locked]: !canViewExperienceDetail,
+          })}
+        >
+          {`閱讀更多${canViewExperienceDetail ? '' : '並解鎖'}`}
         </Link>
       </div>
     </section>
@@ -75,6 +101,7 @@ const ExperienceEntry = ({
 ExperienceEntry.propTypes = {
   data: PropTypes.object.isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 ExperienceEntry.defaultProps = {

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
@@ -8,7 +8,14 @@ import Pagination from 'common/Pagination';
 
 const pageSize = 10;
 
-const WorkExperiences = ({ pageType, pageName, tabType, data, page }) => {
+const WorkExperiences = ({
+  pageType,
+  pageName,
+  tabType,
+  data,
+  page,
+  canViewExperienceDetail,
+}) => {
   if (data.length === 0) {
     return <EmptyView pageName={pageName} tabType={tabType} />;
   }
@@ -16,7 +23,12 @@ const WorkExperiences = ({ pageType, pageName, tabType, data, page }) => {
   return (
     <Section Tag="main" paddingBottom>
       {visibleData.map(d => (
-        <ExperienceEntry key={d.id} pageType={pageType} data={d} />
+        <ExperienceEntry
+          key={d.id}
+          pageType={pageType}
+          data={d}
+          canViewExperienceDetail={canViewExperienceDetail}
+        />
       ))}
       <Pagination
         totalCount={data.length}
@@ -34,6 +46,7 @@ WorkExperiences.propTypes = {
   tabType: PropTypes.string.isRequired,
   data: PropTypes.arrayOf(PropTypes.object),
   page: PropTypes.number.isRequired,
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 export default WorkExperiences;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.module.css
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.module.css
@@ -43,7 +43,25 @@
     align-items: center;
     font-size: 15px;
     color: #424242;
+  }
 
+  .salary {
+    svg {
+      margin-right: 7px;
+      width: 16px;
+      height: 16px;
+      fill: #adadad;
+    }
+
+    &.locked {
+      svg {
+        color: #ed0d5e;
+      }
+    }
+  }
+
+  .weekWorkTime,
+  .recommendToOthers {
     svg {
       margin-right: 7px;
       width: 16px;
@@ -107,6 +125,10 @@
 
     &:hover {
       text-decoration: none;
+    }
+
+    &.locked {
+      color: #ed0d5e;
     }
   }
 }

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.module.css
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.module.css
@@ -12,15 +12,6 @@
     margin-bottom: 0;
   }
 
-  @media (min-width: 1025px) {
-    &:hover {
-      box-shadow: 1px 1px 11px rgba(0, 0, 0, 0.25);
-      .heading {
-        color: link-blue;
-      }
-    }
-  }
-
   @media (max-width: 550px) {
     margin-left: calc(page-gutter-s * -1);
     margin-right: calc(page-gutter-s * -1);
@@ -29,10 +20,36 @@
 }
 
 .contentWrapper {
-  padding: 15px 29px 21px 29px;
+  padding: 16px 28px;
 
   @media (max-width: 1024px) {
     padding: 16px;
+  }
+}
+
+.labels {
+  display: flex;
+
+  .date {
+    flex: 1;
+    color: #adadad;
+  }
+
+  .weekWorkTime,
+  .salary,
+  .recommendToOthers {
+    margin-left: 35px;
+    display: flex;
+    align-items: center;
+    font-size: 15px;
+    color: #424242;
+
+    svg {
+      margin-right: 7px;
+      width: 16px;
+      height: 16px;
+      fill: #adadad;
+    }
   }
 }
 
@@ -50,7 +67,7 @@
   }
 
   .contentWrapper {
-    margin-bottom: 15px;
+    margin-bottom: 5px;
   }
 }
 
@@ -67,25 +84,29 @@
     font-size: 0.9em;
   }
 
-  .labels {
-    color: main-gray;
-    margin-bottom: 0;
-  }
-
-  .company {
-    display: none;
-  }
-
   .heading {
     margin-top: 12px;
     margin-bottom: 12px;
   }
 }
 
-.recommendIcon {
-  svg {
-    width: 20px;
-    height: 20px;
-    margin-right: 6.5px;
+.snippetWrapper {
+  display: flex;
+  align-items: flex-end;
+
+  .snippet {
+    flex: 1;
+    word-break: break-all;
+    padding-right: 1em;
+  }
+
+  .readmore {
+    font-weight: 600;
+    color: #325bbd;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }

--- a/src/components/CompanyAndJobTitle/WorkExperiences/helper.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/helper.js
@@ -1,4 +1,8 @@
-import { formatSalaryAmount, formatSalaryType } from 'common/formatter';
+import {
+  formatSalaryAmount,
+  formatSalaryAmountRange,
+  formatSalaryType,
+} from 'common/formatter';
 
 export const formatCreatedAt = createdAt => {
   const date = new Date(Date.parse(createdAt));
@@ -17,6 +21,16 @@ export const formatSalary = salary => {
   const { amount, type } = salary;
 
   return `${formatSalaryAmount(amount)} / ${formatSalaryType(type)}`;
+};
+
+export const formatSalaryRange = salary => {
+  if (!salary) {
+    return '';
+  }
+
+  return `${formatSalaryAmountRange(salary)} / ${formatSalaryType(
+    salary.type,
+  )}`;
 };
 
 export const formatRecommendToOthers = recommendToOthers =>

--- a/src/components/CompanyAndJobTitle/WorkExperiences/helper.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/helper.js
@@ -7,6 +7,8 @@ export const formatCreatedAt = createdAt => {
   return `${year} 年 ${month} 月`;
 };
 
+export const formatWeekWorkTime = weekWorkTime => `${weekWorkTime} 小時 / 週`;
+
 export const formatSalary = salary => {
   if (!salary) {
     return '-';

--- a/src/components/CompanyAndJobTitle/WorkExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/index.js
@@ -11,6 +11,7 @@ const WorkExperiences = ({
   workExperiences,
   status,
   page,
+  canViewExperienceDetail,
 }) => (
   <CompanyAndJobTitleWrapper
     pageType={pageType}
@@ -24,6 +25,7 @@ const WorkExperiences = ({
         tabType={tabType}
         data={workExperiences}
         page={page}
+        canViewExperienceDetail={canViewExperienceDetail}
       />
     </StatusRenderer>
   </CompanyAndJobTitleWrapper>
@@ -36,6 +38,7 @@ WorkExperiences.propTypes = {
   workExperiences: PropTypes.arrayOf(PropTypes.object),
   status: PropTypes.string.isRequired,
   page: PropTypes.number.isRequired,
+  canViewExperienceDetail: PropTypes.bool.isRequired,
 };
 
 export default WorkExperiences;

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -88,7 +88,7 @@ class ExperienceDetail extends Component {
       }),
     }),
     authStatus: PropTypes.string,
-    canViewExperirenceDetail: PropTypes.bool.isRequired,
+    canViewExperienceDetail: PropTypes.bool.isRequired,
     isInspectReportOpen: PropTypes.bool.isRequired,
     toggleReportInspectModal: PropTypes.func.isRequired,
   };
@@ -324,7 +324,7 @@ class ExperienceDetail extends Component {
     const {
       likeExperience,
       likeReply,
-      canViewExperirenceDetail,
+      canViewExperienceDetail,
       isInspectReportOpen,
       toggleReportInspectModal,
     } = this.props;
@@ -375,7 +375,7 @@ class ExperienceDetail extends Component {
                 {this.renderReportZone()}
                 <Article
                   experience={experience}
-                  hideContent={!canViewExperirenceDetail}
+                  hideContent={!canViewExperienceDetail}
                 />
               </Fragment>
             )}

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -11,6 +11,7 @@ import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 import NotFound from '../common/NotFound';
+import { withPermission } from 'common/permission-context';
 
 import { tabType, pageType } from '../../constants/companyJobTitle';
 import jobTitleActions from '../../actions/jobTitle';
@@ -111,6 +112,7 @@ const ssr = setStatic('fetchData', ({ store: { dispatch }, ...props }) => {
 const enhance = compose(
   ssr,
   withRouteParameter,
+  withPermission,
   withProps(({ match: { params: { jobTitle } } }) => ({
     pageType: pageType.JOB_TITLE,
     pageName: jobTitle,

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -124,10 +124,18 @@ const enhance = compose(
   lifecycle({
     componentDidMount() {
       this.props.fetchJobTitle(this.props.pageName);
+      this.props.fetchPermission();
     },
     componentDidUpdate(prevProps) {
       if (this.props.pageName !== prevProps.pageName) {
         this.props.fetchJobTitle(this.props.pageName);
+      }
+
+      if (
+        this.props.pageName !== prevProps.pageName ||
+        this.props.pageType !== prevProps.pageType
+      ) {
+        this.props.fetchPermission();
       }
     },
   }),

--- a/src/components/common/formatter.js
+++ b/src/components/common/formatter.js
@@ -1,6 +1,37 @@
 export const formatSalaryAmount = amount =>
   amount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
+const getSalaryAmountRangeSize = type => {
+  switch (type) {
+    case 'year':
+      return 720000;
+    case 'month':
+      return 60000;
+    case 'day':
+      return 2000;
+    case 'hour':
+      return 100;
+    default:
+      return 10000;
+  }
+};
+
+const getSalaryAmountRange = salary => {
+  const rangeSize = getSalaryAmountRangeSize(salary.type);
+  return [
+    Math.floor(salary.amount / rangeSize) * rangeSize,
+    Math.ceil(salary.amount / rangeSize) * rangeSize,
+  ];
+};
+
+export const formatSalaryAmountRange = salary => {
+  if (!salary) {
+    return '-';
+  }
+  const [head, tail] = getSalaryAmountRange(salary);
+  return `${formatSalaryAmount(head)} ~ ${formatSalaryAmount(tail)}`;
+};
+
 export const formatSalaryType = type => {
   switch (type) {
     case 'year':

--- a/src/components/common/icons/index.js
+++ b/src/components/common/icons/index.js
@@ -3,6 +3,7 @@ import ArrowGo from './ArrowGo';
 import ArrowLeft from './ArrowLeft';
 import Bad from './Bad';
 import Checked from './Checked';
+import Clock from './Clock';
 import Coin from './Coin';
 import Comment from './Comment';
 import Company from './Company';
@@ -28,6 +29,7 @@ const icons = {
   ArrowLeft,
   Bad,
   Checked,
+  Clock,
   Coin,
   Comment,
   Company,

--- a/src/components/common/permission-context/PermissionContext.js
+++ b/src/components/common/permission-context/PermissionContext.js
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default React.createContext({
   canViewLaborRightsSingle: true,
-  canViewExperirenceDetail: true,
+  canViewExperienceDetail: true,
   canViewTimeAndSalary: true,
   setCanView: () => {},
 });

--- a/src/components/common/permission-context/PermissionContextProvider.js
+++ b/src/components/common/permission-context/PermissionContextProvider.js
@@ -11,7 +11,7 @@ class PermissionContextProvider extends Component {
 
     this.state = {
       canViewLaborRightsSingle: true,
-      canViewExperirenceDetail: true,
+      canViewExperienceDetail: true,
       canViewTimeAndSalary: true,
       setCanView: this.setCanView,
     };

--- a/src/components/common/permission-context/withPermission.js
+++ b/src/components/common/permission-context/withPermission.js
@@ -36,6 +36,8 @@ const withPermission = compose(
         const laborRightsSingleRegex = /\/labor-rights\/.+/;
         const experienceDetailRegex = /\/experiences\/.+/;
         const salaryWorkTimeRegex = /\/salary-work-times.*/;
+        const companyRegex = /\/companies\/.+/;
+        const jobTitleRegex = /\/job-titles\/.+/;
 
         // 根據路徑，去更新相關的觀看權限 state
         if (laborRightsSingleRegex.test(pathname)) {
@@ -69,6 +71,20 @@ const withPermission = compose(
           } else {
             setCanView({ canViewTimeAndSalary: hasPermission });
             return;
+          }
+        } else if (
+          companyRegex.test(pathname) ||
+          jobTitleRegex.test(pathname)
+        ) {
+          // 假如是公司頁面或職稱頁面，依據 localStorage 和權限更新 state。
+          const viewedExperienceDetail = localStorage.getItem(
+            'viewedExperienceDetail',
+          );
+
+          if (viewedExperienceDetail === null) {
+            setCanView({ canViewExperienceDetail: true });
+          } else {
+            setCanView({ canViewExperienceDetail: hasPermission });
           }
         }
       }

--- a/src/components/common/permission-context/withPermission.js
+++ b/src/components/common/permission-context/withPermission.js
@@ -44,16 +44,16 @@ const withPermission = compose(
           return;
         } else if (experienceDetailRegex.test(pathname)) {
           // 假如是單篇經驗分享頁，localStorage 沒值的話，不更新觀看權限 state。因此不會做阻擋，但是馬上就更新 localStorage。
-          const viewedExperirenceDetail = localStorage.getItem(
-            'viewedExperirenceDetail',
+          const viewedExperienceDetail = localStorage.getItem(
+            'viewedExperienceDetail',
           );
 
-          if (viewedExperirenceDetail === null) {
-            localStorage.setItem('viewedExperirenceDetail', true);
-            setCanView({ canViewExperirenceDetail: true });
+          if (viewedExperienceDetail === null) {
+            localStorage.setItem('viewedExperienceDetail', true);
+            setCanView({ canViewExperienceDetail: true });
             return;
           } else {
-            setCanView({ canViewExperirenceDetail: hasPermission });
+            setCanView({ canViewExperienceDetail: hasPermission });
             return;
           }
         } else if (salaryWorkTimeRegex.test(pathname)) {


### PR DESCRIPTION
Close #772    <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個PR做了什麼？

總覽 / 面試 / 工作 頁面的card修改UI，不同權限會有不同顯示

## Screenshots  <!-- 選填，沒有就刪掉 -->

![](http://g.recordit.co/eYStSHdurT.gif)

## 我應該如何手動測試？ <!-- 必填 -->

以下為公司/職稱有card的頁面：
http://localhost:3000/job-titles/軟體工程師/overview
http://localhost:3000/job-titles/軟體工程師/work-experiences
http://localhost:3000/job-titles/軟體工程師/interview-experiences
http://localhost:3000/companies/全家便利商店股份有限公司/overview
http://localhost:3000/companies/全家便利商店股份有限公司/work-experiences
http://localhost:3000/companies/全家便利商店股份有限公司/interview-experiences

**未登入**
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入：應看到完整card
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+點進某一篇+上一頁：應看到card權限被鎖

**登入&沒權限**
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+登入&沒權限：應看到完整card
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+登入&沒權限+點進某一篇+上一頁：應看到card權限被鎖
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+點進某一篇+登入&沒權限+上一頁：應看到card權限被鎖

**登入&有權限**
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+登入&有權限：應看到完整card
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+登入&有權限+點進某一篇+上一頁：應看到完整card
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+點進某一篇+登入&有權限+上一頁：應看到完整card

**登入&登出**
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+登入+登出：應看到完整card
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+登入+點進某一篇+登出+上一頁：應看到card權限被鎖
- [ ] 刪除localStorage的`viewedExperienceDetail`&未登入+點進某一篇+登入+登出+上一頁：應看到card權限被鎖
