### PR TITLE
Refactor: chart RWD style

### DIFF
--- a/src/components/CompanyAndJobTitle/Overview/SummaryBlock.js
+++ b/src/components/CompanyAndJobTitle/Overview/SummaryBlock.js
@@ -19,7 +19,7 @@ const SummaryBlock = ({
           <CompanyDistributionChart data={salaryDistribution} />
         </div>
         <div className={styles.barChartSm}>
-          <CompanyDistributionChart data={salaryDistribution} width={300} />
+          <CompanyDistributionChart data={salaryDistribution} />
         </div>
       </React.Fragment>
     )}
@@ -29,7 +29,7 @@ const SummaryBlock = ({
           <JobTitleDistrubitionChart data={jobAverageSalaries} />
         </div>
         <div className={styles.barChartSm}>
-          <JobTitleDistrubitionChart data={jobAverageSalaries} width={300} />
+          <JobTitleDistrubitionChart data={jobAverageSalaries} />
         </div>
       </React.Fragment>
     )}

--- a/src/components/CompanyAndJobTitle/Overview/SummaryBlock.module.css
+++ b/src/components/CompanyAndJobTitle/Overview/SummaryBlock.module.css
@@ -13,6 +13,12 @@
     padding: 20px;
   }
 
+  .barChart {
+    flex: 1;
+    max-width: 547px;
+    height: 265px;
+  }
+
   .barChartSm {
     display: none;
   }
@@ -31,6 +37,8 @@
 
     .barChartSm {
       display: block;
+      width: 100%;
+      height: 265px;
     }
 
     .averageWeekWorkTime {

--- a/src/components/LandingPage/SummarySection.js
+++ b/src/components/LandingPage/SummarySection.js
@@ -24,7 +24,11 @@ const SummarySection = ({
 
   return (
     <div className={styles.summarySection}>
-      <Carousel selectedIndex={selectedIndex} onSelectIndex={setSelectedIndex}>
+      <Carousel
+        selectedIndex={selectedIndex}
+        onSelectIndex={setSelectedIndex}
+        className={styles.carousel}
+      >
         {dataPairs.map(
           ([companyAverageSalary, jobTitleSalaryDistribution], i) => (
             <CarouselPage key={i}>
@@ -43,24 +47,6 @@ const SummarySection = ({
                         }
                       />
                     </div>
-                    <div className={styles.barChartMed}>
-                      <JobTitleDistributionChart
-                        data={
-                          companyAverageSalary.salary_work_time_statistics
-                            .job_average_salaries
-                        }
-                        width={360}
-                      />
-                    </div>
-                    <div className={styles.barChartSm}>
-                      <JobTitleDistributionChart
-                        data={
-                          companyAverageSalary.salary_work_time_statistics
-                            .job_average_salaries
-                        }
-                        width={300}
-                      />
-                    </div>
                   </React.Fragment>
                 </ChartWrapper>
                 <ChartWrapper
@@ -74,22 +60,6 @@ const SummarySection = ({
                         data={
                           jobTitleSalaryDistribution.salary_distribution.bins
                         }
-                      />
-                    </div>
-                    <div className={styles.barChartMed}>
-                      <CompanyDistributionChart
-                        data={
-                          jobTitleSalaryDistribution.salary_distribution.bins
-                        }
-                        width={360}
-                      />
-                    </div>
-                    <div className={styles.barChartSm}>
-                      <CompanyDistributionChart
-                        data={
-                          jobTitleSalaryDistribution.salary_distribution.bins
-                        }
-                        width={300}
                       />
                     </div>
                   </React.Fragment>

--- a/src/components/LandingPage/SummarySection.module.css
+++ b/src/components/LandingPage/SummarySection.module.css
@@ -4,28 +4,34 @@
   display: flex;
   justify-content: center;
 
-  padding: 30px 24px;
+  padding: 30px 0px;
 
   border-bottom: solid 1px border-gray;
-  @media (min-width: above-small) {
+  @media (min-width: above-desktop) {
     padding-top: 72px;
     padding-bottom: 56px;
   }
+}
+
+.carousel {
+  width: 100%;
 }
 
 .page {
   display: flex;
   flex-direction: column;
 
-  @media (min-width: above-small) {
+  @media (min-width: above-desktop) {
     flex-direction: row;
+    justify-content: space-between;
   }
 
   .chartWrapper {
     &:not(:last-child) {
       margin-bottom: 48px;
     }
-    @media (min-width: above-small) {
+    @media (min-width: above-desktop) {
+      flex: 1;
       &:not(:last-child) {
         margin-right: 46px;
       }
@@ -33,45 +39,7 @@
   }
 }
 
-/*sm*/
 .barChart {
-  display: none;
-}
-
-.barChartSm {
-  display: block;
-}
-
-.barChartMed {
-  display: none;
-}
-
-/*med*/
-@media (min-width: above-small) and (max-width: below-medium) {
-  .barChartMed {
-    display: block;
-  }
-
-  .barChartSm {
-    display: none;
-  }
-
-  .barChart {
-    display: none;
-  }
-}
-
-/*above medium*/
-@media (min-width: above-medium) {
-  .barChartMed {
-    display: none;
-  }
-
-  .barChartSm {
-    display: none;
-  }
-
-  .barChart {
-    display: block;
-  }
+  width: 100%;
+  height: 265px;
 }

--- a/src/components/LandingPage/index.js
+++ b/src/components/LandingPage/index.js
@@ -57,10 +57,16 @@ const LandingPage = ({
     <main>
       <StaticHelmet.LandingPage />
       <Banner />
-      <SummarySection
-        popularCompanyAverageSalary={popularCompanyAverageSalary}
-        popularJobTitleSalaryDistribution={popularJobTitleSalaryDistribution}
-      />
+      <Section padding>
+        <Wrapper size="l">
+          <SummarySection
+            popularCompanyAverageSalary={popularCompanyAverageSalary}
+            popularJobTitleSalaryDistribution={
+              popularJobTitleSalaryDistribution
+            }
+          />
+        </Wrapper>
+      </Section>
       <Section padding>
         <Wrapper size="l">
           <Heading size="l" center marginBottom>

--- a/src/components/common/Carousel.js
+++ b/src/components/common/Carousel.js
@@ -5,9 +5,11 @@ import cn from 'classnames';
 
 import styles from './Carousel.module.css';
 
-export const CarouselPage = ({ children }) => <div>{children}</div>;
+export const CarouselPage = ({ children }) => (
+  <div className={styles.pageContainer}>{children}</div>
+);
 
-const Carousel = ({ children, selectedIndex, onSelectIndex }) => {
+const Carousel = ({ children, selectedIndex, onSelectIndex, className }) => {
   const handleClickPrevBtn = () => {
     onSelectIndex(selectedIndex - 1);
   };
@@ -24,7 +26,7 @@ const Carousel = ({ children, selectedIndex, onSelectIndex }) => {
   const isNextBtnClickable = selectedIndex < children.length - 1;
 
   return (
-    <div className={styles.carousel}>
+    <div className={cn(styles.carousel, className)}>
       {Children.map(children, (child, i) => (
         <div
           key={i}

--- a/src/components/common/Carousel.module.css
+++ b/src/components/common/Carousel.module.css
@@ -1,6 +1,10 @@
 .carousel {
 }
 
+.pageContainer {
+  width: 100%;
+}
+
 .page {
   display: none;
 

--- a/src/components/common/Charts/CompanyDistributionChart.js
+++ b/src/components/common/Charts/CompanyDistributionChart.js
@@ -1,26 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { BarChart, Bar, XAxis, YAxis } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 
-const CompanyDistributionChart = ({ data, width = 494, height = 233 }) => (
-  <BarChart
-    width={width}
-    height={height}
-    data={data}
-    margin={{ left: -30, bottom: -25 }}
-  >
-    <XAxis
-      type="category"
-      dataKey={({ range: { from, to } }) =>
-        `${Math.floor(from / 10000)}萬~${Math.floor(to / 10000)}萬`
-      }
-      label="月薪"
-      height={70}
-    />
-    <YAxis type="number" label="人數" width={100} />
-    <Bar dataKey="data_count" fill="#fcd406" />
-  </BarChart>
+const CompanyDistributionChart = ({ data }) => (
+  <ResponsiveContainer>
+    <BarChart data={data} margin={{ left: -30, bottom: -25 }}>
+      <XAxis
+        type="category"
+        dataKey={({ range: { from, to } }) =>
+          `${Math.floor(from / 10000)}萬~${Math.floor(to / 10000)}萬`
+        }
+        label="月薪"
+        height={70}
+      />
+      <YAxis type="number" label="人數" width={100} />
+      <Bar dataKey="data_count" fill="#fcd406" />
+    </BarChart>
+  </ResponsiveContainer>
 );
 
 CompanyDistributionChart.propTypes = {

--- a/src/components/common/Charts/JobTitleDistrubitionChart.js
+++ b/src/components/common/Charts/JobTitleDistrubitionChart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { BarChart, Bar, XAxis, YAxis } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 import R from 'ramda';
 
 const maxNameLength = R.pipe(
@@ -14,18 +14,18 @@ const maxNameLength = R.pipe(
   R.reduce(R.max, -Infinity),
 );
 
-const JobTitleDistributionChart = ({ data, width = 494, height = 233 }) => (
-  <BarChart
-    width={width}
-    height={height}
-    data={data}
-    layout="vertical"
-    margin={{ left: maxNameLength(data) * 10, bottom: -25 }}
-  >
-    <XAxis type="number" label="平均月薪" height={70} />
-    <YAxis type="category" dataKey="job_title.name" />
-    <Bar dataKey="average_salary.amount" fill="#fcd406" />
-  </BarChart>
+const JobTitleDistributionChart = ({ data }) => (
+  <ResponsiveContainer>
+    <BarChart
+      data={data}
+      layout="vertical"
+      margin={{ left: maxNameLength(data) * 10, bottom: -25 }}
+    >
+      <XAxis type="number" label="平均月薪" height={70} />
+      <YAxis type="category" dataKey="job_title.name" />
+      <Bar dataKey="average_salary.amount" fill="#fcd406" />
+    </BarChart>
+  </ResponsiveContainer>
 );
 
 JobTitleDistributionChart.propTypes = {
@@ -39,8 +39,6 @@ JobTitleDistributionChart.propTypes = {
       }),
     }),
   ).isRequired,
-  width: PropTypes.number,
-  height: PropTypes.number,
 };
 
 export default JobTitleDistributionChart;


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

原本以為圖表的寬度無解了，幸好發現 ResponsiveContainer 
所以我讓兩種圖表都包 responsive container ，根據外面寬度去 render 

## Screenshots  <!-- 選填，沒有就刪掉 -->

首頁 > 1024px
![screencapture-localhost-3000-2019-12-17-15_23_05](https://user-images.githubusercontent.com/3805975/70973952-abc89080-20e1-11ea-900e-50c9763bbaef.png)

首頁 < 1024px
![screencapture-localhost-3000-2019-12-17-15_23_47](https://user-images.githubusercontent.com/3805975/70973957-ad925400-20e1-11ea-9acc-47858823864d.png)

公司職稱頁 > 767px
![screencapture-localhost-3000-companies-overview-2019-12-17-15_24_21](https://user-images.githubusercontent.com/3805975/70973965-b125db00-20e1-11ea-9003-233fc5eae9d0.png)


公司職稱頁 < 767px
![screencapture-localhost-3000-companies-overview-2019-12-17-15_24_42](https://user-images.githubusercontent.com/3805975/70973972-b420cb80-20e1-11ea-9a0d-4d625bd7ad5d.png)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 首頁，螢幕拉動成不同大小，重新整理，看會不會跑版
- [ ] 公司職稱頁，螢幕拉動成不同大小，重新整理，看會不會跑版
