### PR TITLE
Hotfix/salary chart

### DIFF
--- a/src/components/CompanyAndJobTitle/Overview/SummaryBlock.js
+++ b/src/components/CompanyAndJobTitle/Overview/SummaryBlock.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import CompanyDistributionChart from '../../common/Charts/CompanyDistributionChart';
+import SalaryDistributionChart from '../../common/Charts/SalaryDistributionChart';
 import JobTitleDistrubitionChart from '../../common/Charts/JobTitleDistrubitionChart';
 import AverageWeekWorkTimeView from './AverageWeekWorkTimeView';
 import styles from './SummaryBlock.module.css';
@@ -16,10 +16,10 @@ const SummaryBlock = ({
     {salaryDistribution && (
       <React.Fragment>
         <div className={styles.barChart}>
-          <CompanyDistributionChart data={salaryDistribution} />
+          <SalaryDistributionChart data={salaryDistribution} />
         </div>
         <div className={styles.barChartSm}>
-          <CompanyDistributionChart data={salaryDistribution} />
+          <SalaryDistributionChart data={salaryDistribution} />
         </div>
       </React.Fragment>
     )}

--- a/src/components/LandingPage/SummarySection.js
+++ b/src/components/LandingPage/SummarySection.js
@@ -4,7 +4,7 @@ import { zip } from 'ramda';
 
 import Carousel, { CarouselPage } from 'common/Carousel';
 import ChartWrapper from './ChartWrapper';
-import CompanyDistributionChart from '../common/Charts/CompanyDistributionChart';
+import SalaryDistributionChart from '../common/Charts/SalaryDistributionChart';
 import JobTitleDistributionChart from '../common/Charts/JobTitleDistrubitionChart';
 import styles from './SummarySection.module.css';
 
@@ -56,7 +56,7 @@ const SummarySection = ({
                 >
                   <React.Fragment>
                     <div className={styles.barChart}>
-                      <CompanyDistributionChart
+                      <SalaryDistributionChart
                         data={
                           jobTitleSalaryDistribution.salary_distribution.bins
                         }

--- a/src/components/common/Charts/CompanyDistributionChart.js
+++ b/src/components/common/Charts/CompanyDistributionChart.js
@@ -1,24 +1,62 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useWindowSize } from 'react-use';
 
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
+import breakpoints from '../../../constants/breakpoints';
 
-const CompanyDistributionChart = ({ data }) => (
-  <ResponsiveContainer>
-    <BarChart data={data} margin={{ left: -30, bottom: -25 }}>
-      <XAxis
-        type="category"
-        dataKey={({ range: { from, to } }) =>
-          `${Math.floor(from / 10000)}萬~${Math.floor(to / 10000)}萬`
-        }
-        label="月薪"
-        height={70}
-      />
-      <YAxis type="number" label="人數" width={100} />
-      <Bar dataKey="data_count" fill="#fcd406" />
-    </BarChart>
-  </ResponsiveContainer>
-);
+const CustomizedLabel = ({ viewBox: { x, y, width, height } }) => {
+  return (
+    <g transform={`translate(${x + width / 2},${y + height - 20})`}>
+      <text x={0} y={0} dy={16} fill="#000">
+        <tspan textAnchor="middle" x="0">
+          月薪
+        </tspan>
+      </text>
+    </g>
+  );
+};
+
+const CustomizedAxisTick = ({ x, y, stroke, payload }) => {
+  const [from, to] = payload.value.split('~');
+  return (
+    <g transform={`translate(${x},${y})`}>
+      <text x={0} y={0} dy={16} fill="#666">
+        <tspan textAnchor="middle" x="0">
+          {from}~
+        </tspan>
+        <tspan textAnchor="middle" x="0" dy="20">
+          {to}
+        </tspan>
+      </text>
+    </g>
+  );
+};
+
+const CompanyDistributionChart = ({ data }) => {
+  const { width } = useWindowSize();
+  return (
+    <ResponsiveContainer>
+      <BarChart
+        data={data}
+        margin={{ left: -30, bottom: width < breakpoints.xs ? 0 : -25 }}
+      >
+        <XAxis
+          type="category"
+          dataKey={({ range: { from, to } }) =>
+            `${Math.floor(from / 1000) / 10}萬~${Math.floor(to / 1000) / 10}萬`
+          }
+          label={width < breakpoints.xs ? <CustomizedLabel /> : '月薪'}
+          height={70}
+          tick={width < breakpoints.xs ? <CustomizedAxisTick /> : {}}
+          interval={0}
+        />
+        <YAxis type="number" label="人數" width={100} />
+        <Bar dataKey="data_count" fill="#fcd406" />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};
 
 CompanyDistributionChart.propTypes = {
   data: PropTypes.arrayOf(

--- a/src/components/common/Charts/SalaryDistributionChart.js
+++ b/src/components/common/Charts/SalaryDistributionChart.js
@@ -33,7 +33,7 @@ const CustomizedAxisTick = ({ x, y, stroke, payload }) => {
   );
 };
 
-const CompanyDistributionChart = ({ data }) => {
+const SalaryDistributionChart = ({ data }) => {
   const { width } = useWindowSize();
   return (
     <ResponsiveContainer>
@@ -58,7 +58,7 @@ const CompanyDistributionChart = ({ data }) => {
   );
 };
 
-CompanyDistributionChart.propTypes = {
+SalaryDistributionChart.propTypes = {
   data: PropTypes.arrayOf(
     PropTypes.shape({
       data_count: PropTypes.number,
@@ -71,4 +71,4 @@ CompanyDistributionChart.propTypes = {
   ).isRequired,
 };
 
-export default CompanyDistributionChart;
+export default SalaryDistributionChart;

--- a/src/components/common/Charts/SalaryDistributionChart.js
+++ b/src/components/common/Charts/SalaryDistributionChart.js
@@ -5,7 +5,7 @@ import { useWindowSize } from 'react-use';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 import breakpoints from '../../../constants/breakpoints';
 
-const CustomizedLabel = ({ viewBox: { x, y, width, height } }) => {
+const LabelOnSmallDevice = ({ viewBox: { x, y, width, height } }) => {
   return (
     <g transform={`translate(${x + width / 2},${y + height - 20})`}>
       <text x={0} y={0} dy={16} fill="#000">
@@ -17,7 +17,7 @@ const CustomizedLabel = ({ viewBox: { x, y, width, height } }) => {
   );
 };
 
-const CustomizedAxisTick = ({ x, y, stroke, payload }) => {
+const XAxisOnSmallDevice = ({ x, y, stroke, payload }) => {
   const [from, to] = payload.value.split('~');
   return (
     <g transform={`translate(${x},${y})`}>
@@ -46,9 +46,9 @@ const SalaryDistributionChart = ({ data }) => {
           dataKey={({ range: { from, to } }) =>
             `${Math.floor(from / 1000) / 10}萬~${Math.floor(to / 1000) / 10}萬`
           }
-          label={width < breakpoints.xs ? <CustomizedLabel /> : '月薪'}
+          label={width < breakpoints.xs ? <LabelOnSmallDevice /> : '月薪'}
           height={70}
-          tick={width < breakpoints.xs ? <CustomizedAxisTick /> : {}}
+          tick={width < breakpoints.xs ? <XAxisOnSmallDevice /> : {}}
           interval={0}
         />
         <YAxis type="number" label="人數" width={100} />


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

- 修復薪資分布圖表

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/647

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="557" alt="螢幕快照 2019-12-22 上午2 56 40" src="https://user-images.githubusercontent.com/3805975/71312510-b7f87900-2466-11ea-8d49-6e14aa216cae.png">
<img width="359" alt="螢幕快照 2019-12-22 上午2 56 47" src="https://user-images.githubusercontent.com/3805975/71312511-b7f87900-2466-11ea-86db-7f6a177d5b36.png">

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 拉動螢幕大小，確認首頁、職業頁面的薪資分布圖表正常
