### PR TITLE
[WIP] Feat: 面試經驗表單加上 email 欄位

### DIFF
--- a/src/components/ShareExperience/InterviewStepsForm/InterviewForm.module.css
+++ b/src/components/ShareExperience/InterviewStepsForm/InterviewForm.module.css
@@ -110,3 +110,15 @@
     color: #626262;
   }
 }
+
+.agreeTermContainer {
+  display: flex;
+  flex-direction: column;
+  margin-top: 57px;
+}
+
+.agreeTermLabel {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+}

--- a/src/components/ShareExperience/InterviewStepsForm/Step3.js
+++ b/src/components/ShareExperience/InterviewStepsForm/Step3.js
@@ -134,7 +134,7 @@ class Step3 extends React.Component {
         <Block style={{ marginTop: '35px' }}>
           <Email
             email={state.email}
-            inputTitle="訂閱 GoodJob，我們會寄送最新的薪資、面試資訊給您"
+            inputTitle="留下 E-mail，掌握最新資訊"
             onChange={v => {
               handleState('email')(v);
             }}

--- a/src/components/ShareExperience/InterviewStepsForm/Step3.js
+++ b/src/components/ShareExperience/InterviewStepsForm/Step3.js
@@ -10,8 +10,13 @@ import ButtonRect from 'common/button/ButtonRect';
 import ButtonSubmit from 'common/button/ButtonSubmit';
 import Checkbox from 'common/form/Checkbox';
 import Modal from 'common/Modal';
+import Block from 'common/Block';
+import { validateEmail } from 'utils/dataCheckUtil';
+import Email from '../common/Email';
 import { compose } from 'recompose';
 import styles from './InterviewForm.module.css';
+
+import { EMAIL } from '../../../constants/formElements';
 
 class Step3 extends React.Component {
   static propTypes = {
@@ -126,6 +131,25 @@ class Step3 extends React.Component {
             ＋增加更多章節
           </Button>
         </div>
+        <Block style={{ marginTop: '35px' }}>
+          <Email
+            email={state.email}
+            inputTitle="訂閱 GoodJob，我們會寄送最新的薪資、面試資訊給您"
+            onChange={v => {
+              handleState('email')(v);
+            }}
+            validator={v => {
+              if (v) {
+                return validateEmail(v);
+              } else {
+                return true;
+              }
+            }}
+            submitted={state.submitted}
+            changeValidationStatus={changeValidationStatus}
+            elementName={EMAIL}
+          />
+        </Block>
         <div className={styles.agreeTermContainer}>
           <label
             className={styles.agreeTermLabel}

--- a/src/components/ShareExperience/InterviewStepsForm/Step3.js
+++ b/src/components/ShareExperience/InterviewStepsForm/Step3.js
@@ -126,19 +126,9 @@ class Step3 extends React.Component {
             ＋增加更多章節
           </Button>
         </div>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            marginTop: '57px',
-          }}
-        >
+        <div className={styles.agreeTermContainer}>
           <label
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-start',
-            }}
+            className={styles.agreeTermLabel}
             htmlFor="submitArea-checkbox"
           >
             <Checkbox
@@ -149,11 +139,7 @@ class Step3 extends React.Component {
               onChange={e => handleAgree(e.target.checked)}
               id="submitArea-checkbox"
             />
-            <p
-              style={{
-                color: '#3B3B3B',
-              }}
-            >
+            <p style={{ color: '#3B3B3B' }}>
               我分享的是真實資訊，並且遵守本站
               <Link
                 to="/guidelines"

--- a/src/components/ShareExperience/InterviewStepsForm/formCheck.js
+++ b/src/components/ShareExperience/InterviewStepsForm/formCheck.js
@@ -6,6 +6,8 @@ import {
   lteLength,
   gteLength,
   gtLength,
+  isStrEmpty,
+  validateEmail,
 } from 'utils/dataCheckUtil';
 
 import { ifThenLog } from 'utils/debugUtil';
@@ -87,6 +89,8 @@ export const interviewSensitiveQuestions = R.anyPass([
   n => n === [],
 ]);
 
+export const email = R.anyPass([isStrEmpty, validateEmail]);
+
 const ifFalseLog = ifThenLog(n => n === false);
 
 export const interviewFormCheck = R.allPass([
@@ -154,5 +158,10 @@ export const interviewFormCheck = R.allPass([
     ifFalseLog('interviewSensitiveQuestions not pass'),
     interviewSensitiveQuestions,
     R.prop('interviewSensitiveQuestions'),
+  ),
+  R.compose(
+    ifFalseLog('email not pass'),
+    email,
+    R.prop('email'),
   ),
 ]);

--- a/src/components/ShareExperience/InterviewStepsForm/index.js
+++ b/src/components/ShareExperience/InterviewStepsForm/index.js
@@ -110,6 +110,7 @@ const defaultForm = {
   },
   interviewQas: {},
   interviewSensitiveQuestions: [],
+  email: '',
 };
 
 const getDefaultFormFromDraft = () => {

--- a/src/components/ShareExperience/common/Email.js
+++ b/src/components/ShareExperience/common/Email.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import cn from 'classnames';
+
+import TextInput from 'common/form/TextInput';
+import subscribeValidation from 'common/subscribeValidation';
+
+import InputTitle from './InputTitle';
+
+import styles from './Region.module.css';
+import shareStyles from './share.module.css';
+
+import { EMAIL } from '../../../constants/formElements';
+
+const Email = ({ email, inputTitle, onChange, validator, submitted }) => {
+  const isWarning = submitted && !validator(email);
+  return (
+    <div>
+      <InputTitle text={inputTitle} />
+      <div
+        className={cn(
+          isWarning ? styles.warning : null,
+          shareStyles.single__select__input,
+        )}
+        style={{
+          position: 'relative',
+        }}
+      >
+        <TextInput
+          value={email}
+          onChange={e => onChange(e.target.value)}
+          placeholder="您的電子郵件"
+          type="string"
+        />
+        {isWarning ? (
+          <div
+            style={{
+              position: 'absolute',
+              bottom: '0',
+              transform: 'translateY(150%)',
+            }}
+          >
+            <p className={`pS ${styles.warning__wording}`}>Email 格式錯誤</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+Email.propTypes = {
+  email: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  inputTitle: PropTypes.string,
+  onChange: PropTypes.func,
+  validator: PropTypes.func,
+  submitted: PropTypes.bool,
+};
+
+Email.defaultProps = {
+  validator: () => {},
+};
+
+const EmailWithValidation = subscribeValidation(
+  Email,
+  props => props.validator(props.email),
+  EMAIL,
+);
+
+export default EmailWithValidation;

--- a/src/components/ShareExperience/utils.js
+++ b/src/components/ShareExperience/utils.js
@@ -28,6 +28,7 @@ const propsInterviewForm = state => {
     sections,
     interviewQas,
     interviewSensitiveQuestions,
+    email,
   } = state;
 
   return {
@@ -47,6 +48,7 @@ const propsInterviewForm = state => {
     sections: handleBlocks(sections),
     interviewQas: handleBlocks(interviewQas),
     interviewSensitiveQuestions,
+    email,
   };
 };
 

--- a/src/constants/formElements.js
+++ b/src/constants/formElements.js
@@ -4,6 +4,7 @@ export const COMPANY = 'company';
 export const REGION = 'region';
 export const JOB_TITLE = 'job_title';
 export const EMPLOYMENT_TYPE = 'employment_type';
+export const EMAIL = 'email';
 
 export const SALARY_TYPE = 'salary_type';
 export const SALARY_AMOUNT = 'salary_amount';
@@ -33,6 +34,7 @@ export const INTERVIEW_FORM_ORDER = [
   SECTIONS,
   INTERVIEW_QAS,
   INTERVIEW_SENSITIVE_QUESTIONS,
+  EMAIL,
 ];
 
 export const INTERVIEW_FORM_STEPS = [

--- a/src/utils/dataCheckUtil.js
+++ b/src/utils/dataCheckUtil.js
@@ -4,6 +4,7 @@ export const lteLength = legnth => l => l.length <= legnth;
 export const ltLength = legnth => l => l.length < legnth;
 export const eqLength = length => l => l.length === length;
 export const notStrEmpty = str => str.trim() !== '';
+export const isStrEmpty = str => typeof str === 'string' && str.trim() === '';
 export const notArrayEmpty = arr => arr.length !== 0;
 export const notNullOrUndefined = t => t !== null && t !== undefined;
 export const validateEmail = email => {


### PR DESCRIPTION
#678  這個 PR 是？ <!-- 必填 -->

面試經驗表單加上 email 欄位
1. 如果要寄問卷，可以拿來用
2. 如果成果信被驗證有效，那多搜集一點比較好

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="864" alt="螢幕快照 2019-12-22 下午8 52 21" src="https://user-images.githubusercontent.com/3805975/71322003-f9d3fe80-24fc-11ea-85b6-d8bcd0502bef.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 前後端跑起來
- [ ] 留一筆面試經驗看看，並且留下 email ，應該要 work 

## TODO 
- [ ] 已經 subscribeEmail 的使用者，該欄位就不用出現了