### PR TITLE
Carousel will render null when child is not active (selected)

### DIFF
--- a/src/components/common/Carousel.js
+++ b/src/components/common/Carousel.js
@@ -32,7 +32,7 @@ const Carousel = ({ children, selectedIndex, onSelectIndex, className }) => {
           key={i}
           className={cn(styles.page, { [styles.active]: selectedIndex === i })}
         >
-          {child}
+          {selectedIndex === i ? child : null}
         </div>
       ))}
       <div className={styles.nav}>


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

這個 PR 解決了底下的 Warning

![image](https://user-images.githubusercontent.com/1908007/71482941-42aeee80-2840-11ea-91ed-0df044d62f3f.png)

這個 warning 是因為當 carousel 的 child 不是 active 時，style 為 `display: none`，rechart 取得的寬高都是0

