### PR TITLE
hotfix: only use Error.captureStackTrace if it exists

### DIFF
--- a/src/utils/errors/graphqlError.js
+++ b/src/utils/errors/graphqlError.js
@@ -16,7 +16,9 @@ class GraphqlError extends Error {
     this.name = 'GraphqlError';
     this.codes = mapErrorCodes(errors);
     this.paths = mapErrorPaths(errors);
-    Error.captureStackTrace(this, GraphqlError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, GraphqlError);
+    }
   }
 }
 

--- a/src/utils/errors/httpError.js
+++ b/src/utils/errors/httpError.js
@@ -5,7 +5,9 @@ class HttpError extends Error {
     super(message);
     this.name = 'HttpError';
     this.statusCode = statusCode;
-    Error.captureStackTrace(this, HttpError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, HttpError);
+    }
   }
 }
 

--- a/src/utils/errors/uiNotFoundError.js
+++ b/src/utils/errors/uiNotFoundError.js
@@ -5,7 +5,9 @@ class UiNotFoundError extends Error {
     super(message);
 
     this.name = 'UiNotFoundError';
-    Error.captureStackTrace(this, UiNotFoundError);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, UiNotFoundError);
+    }
   }
 }
 


### PR DESCRIPTION
Close #823 

## 這個 PR 是？ <!-- 必填 -->

only use Error.captureStackTrace if it exists

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

MDN 上的 example 有範例：https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#Examples

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 其實不知道怎麼測..，要先產生一個錯誤看看，而且可能要用 iOS 的 chrome
