### PR TITLE
[公司薪資API] 容許Graphql錯誤

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -1,3 +1,5 @@
+import { isGraphqlError } from 'utils/errors';
+
 import STATUS, { isFetching, isFetched } from '../constants/status';
 import { companyStatus as companyStatusSelector } from '../selectors/companyAndJobTitle';
 
@@ -25,8 +27,12 @@ export const fetchCompany = companyName => (dispatch, getState, { api }) => {
       dispatch(setStatus(companyName, STATUS.FETCHED, data));
     })
     .catch(error => {
-      dispatch(setStatus(companyName, STATUS.ERROR, null, error));
-      throw error;
+      if (isGraphqlError(error)) {
+        dispatch(setStatus(companyName, STATUS.ERROR, null, error));
+      } else {
+        // Unexpected error
+        throw error;
+      }
     });
 };
 

--- a/src/actions/experienceDetail.js
+++ b/src/actions/experienceDetail.js
@@ -1,3 +1,5 @@
+import { isGraphqlError } from 'utils/errors';
+
 import fetchingStatus from '../constants/status';
 import { tokenSelector } from '../selectors/authSelector';
 import { UiNotFoundError } from 'utils/errors';
@@ -118,13 +120,17 @@ export const fetchExperience = id => (dispatch, getState, { api }) => {
       dispatch(setExperience({ _id: id, ...rest }));
     })
     .catch(error => {
-      dispatch({
-        type: SET_EXPERIENCE,
-        experienceStatus: fetchingStatus.ERROR,
-        experienceError: error,
-        experience: null,
-      });
-      throw error;
+      if (isGraphqlError(error)) {
+        dispatch({
+          type: SET_EXPERIENCE,
+          experienceStatus: fetchingStatus.ERROR,
+          experienceError: error,
+          experience: null,
+        });
+      } else {
+        // Unexpected error
+        throw error;
+      }
     });
 };
 

--- a/src/actions/experienceSearch.js
+++ b/src/actions/experienceSearch.js
@@ -1,3 +1,5 @@
+import { isGraphqlError } from 'utils/errors';
+
 import statusConstant from '../constants/status';
 
 export const SET_SEARCH_BY = 'SET_SEARCH_BY';
@@ -65,8 +67,12 @@ export const fetchExperiences = (
       dispatch(setSortAndExperiences(payload));
     })
     .catch(error => {
-      dispatch(setLoadingStatus(statusConstant.ERROR, error));
-      throw error;
+      if (isGraphqlError(error)) {
+        dispatch(setLoadingStatus(statusConstant.ERROR, error));
+      } else {
+        // Unexpected error
+        throw error;
+      }
     });
 };
 

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -1,3 +1,5 @@
+import { isGraphqlError } from 'utils/errors';
+
 import STATUS, { isFetching, isFetched } from '../constants/status';
 import { jobTitleStatus as jobTitleStatusSelector } from '../selectors/companyAndJobTitle';
 
@@ -25,8 +27,12 @@ export const fetchJobTitle = jobTitle => (dispatch, getState, { api }) => {
       dispatch(setStatus(jobTitle, STATUS.FETCHED, data));
     })
     .catch(error => {
-      dispatch(setStatus(jobTitle, STATUS.ERROR, null, error));
-      throw error;
+      if (isGraphqlError(error)) {
+        dispatch(setStatus(jobTitle, STATUS.ERROR, null, error));
+      } else {
+        // Unexpected error
+        throw error;
+      }
     });
 };
 


### PR DESCRIPTION
Close #819   <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->
遇到後端拋出的Graphql錯誤，至少讓頁面SSR正常render (不要全白)。

render的頁面：
<img width="1920" alt="Screen Shot 2020-01-08 at 9 13 12 AM (2)" src="https://user-images.githubusercontent.com/7566586/71942110-1e1b2500-31f7-11ea-8d6b-4e4e2ba331c3.png">


## 我應該如何手動測試？ <!-- 必填 -->

Prerequisite:
新增一筆經驗，並填入極大數字的薪資 (e.g. `10000000000000000000000`)並送出表單

- [ ] 送出後跳轉到的經驗單篇，是否可以render (而非完全空白頁面/SSR render失敗)
- [ ] 搜尋該公司職稱的頁面，是否可以render (而非完全空白頁面/SSR render失敗)
