### PR TITLE
Refactor：salary work time quota

### DIFF
--- a/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
+++ b/src/components/ShareExperience/CampaignTimeAndSalaryForm/index.js
@@ -156,8 +156,6 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
 
       return p.then(
         response => {
-          const count = response.queries_count;
-
           ReactGA.event({
             category: GA_CATEGORY.SHARE_TIME_SALARY,
             action: GA_ACTION.UPLOAD_SUCCESS,
@@ -170,8 +168,7 @@ class CampaignTimeAndSalaryForm extends React.PureComponent {
 
           return () => (
             <SuccessFeedback
-              info={`您已經上傳 ${count} 次，還有 ${5 -
-                (count || 0)} 次可以上傳。`}
+              info="感謝你分享薪資、工時資訊，讓台灣的職場變得更透明！"
               buttonText="查看最新工時、薪資"
               buttonClick={() => {
                 window.location.replace(

--- a/src/components/ShareExperience/TimeSalaryForm/index.js
+++ b/src/components/ShareExperience/TimeSalaryForm/index.js
@@ -129,8 +129,6 @@ class TimeSalaryForm extends React.PureComponent {
 
       return p.then(
         response => {
-          const count = response.queries_count;
-
           ReactGA.event({
             category: GA_CATEGORY.SHARE_TIME_SALARY,
             action: GA_ACTION.UPLOAD_SUCCESS,
@@ -143,8 +141,7 @@ class TimeSalaryForm extends React.PureComponent {
 
           return () => (
             <SuccessFeedback
-              info={`您已經上傳 ${count} 次，還有 ${5 -
-                (count || 0)} 次可以上傳。`}
+              info="感謝你分享薪資、工時資訊，讓台灣的職場變得更透明！"
               buttonText="查看最新工時、薪資"
               buttonClick={() => {
                 window.location.replace('/salary-work-times/latest');


### PR DESCRIPTION
Close https://github.com/goodjoblife/WorkTimeSurvey-backend/issues/653

## 這個 PR 是？ <!-- 必填 -->

前端這邊有剩幾筆可以留的訊息，把它換掉

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/687

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="496" alt="螢幕快照 2020-01-30 下午5 33 12" src="https://user-images.githubusercontent.com/3805975/73437058-9f914d80-4386-11ea-82d9-33b0cf1acdd2.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 後端切 https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/687
- [ ] 留六筆薪資工時資料看看，不應該被擋
- [ ] 留完訊息如 screenshot 