### PR TITLE
Form textArea css 

### DIFF
--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styles from './TextArea.module.css';
 
 const Textarea = ({ title, description, dataKey, required, validator }) => (
   <div>
-    {title}
-    <textarea />
+    <div className={styles.title}>
+      2. {title}
+      <span className={styles.necessary}> * </span>
+    </div>
+    <textarea className={styles.textarea} />
+    <p className={styles.warning}>最少30字，現在0字</p>
   </div>
 );
 

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styles from './TextArea.module.css';
 
 const Textarea = ({ title, description, dataKey, required, validator }) => (
-  <div>
+  <div className={styles.container}>
     <div className={styles.title}>
       2. {title}
       <span className={styles.necessary}> * </span>

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import cn from 'classnames';
 import styles from './TextArea.module.css';
 
 const Textarea = ({ title, description, dataKey, required, validator }) => (
   <div className={styles.container}>
-    <div className={styles.title}>
+    <div className={cn(styles.title, { [styles.necessary]: required })}>
       2. {title}
-      <span className={styles.necessary}> * </span>
     </div>
     <textarea className={styles.textarea} />
     <p className={styles.warning}>最少30字，現在0字</p>

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
@@ -1,29 +1,32 @@
 .title {
-  width: 315px;
   height: 25px;
-  font-family: PingFangTC;
   font-size: 18px;
   font-weight: 500;
   color: #555555;
-  margin-bottom: 10px;
 
   .necessary {
     color: red;
   }
 }
 
-.textarea {
-  width: 313px;
-  height: 269px;
-  border: solid 1px #bdbdbd;
-  background-color: #ffffff;
-}
+.container {
+  display: flex;
+  flex-direction: column;
+  width: 310px;
+  height: 290px;
 
-.warning {
-  margin-top: 7px;
-  width: 142px;
-  height: 20px;
-  font-family: PingFangTC;
-  font-size: 14px;
-  color: #969696;
+  .textarea {
+    flex: 1;
+    border: solid 1px #bdbdbd;
+    background-color: #ffffff;
+    resize: none;
+  }
+
+  .warning {
+    display: inline;
+    text-align: right;
+    margin-top: 9px;
+    font-size: 14px;
+    color: #969696;
+  }
 }

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
@@ -1,0 +1,29 @@
+.title {
+  width: 315px;
+  height: 25px;
+  font-family: PingFangTC;
+  font-size: 18px;
+  font-weight: 500;
+  color: #555555;
+  margin-bottom: 10px;
+
+  .necessary {
+    color: red;
+  }
+}
+
+.textarea {
+  width: 313px;
+  height: 269px;
+  border: solid 1px #bdbdbd;
+  background-color: #ffffff;
+}
+
+.warning {
+  margin-top: 7px;
+  width: 142px;
+  height: 20px;
+  font-family: PingFangTC;
+  font-size: 14px;
+  color: #969696;
+}

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
@@ -13,8 +13,11 @@
 .container {
   display: flex;
   flex-direction: column;
-  width: 310px;
-  height: 290px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
 
   .textarea {
     flex: 1;

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
@@ -1,10 +1,11 @@
 .title {
-  height: 25px;
   font-size: 18px;
   font-weight: 500;
   color: #555555;
+  margin-bottom: 10px;
 
-  .necessary {
+  &.necessary::after {
+    content: ' *';
     color: red;
   }
 }

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.module.css
@@ -24,6 +24,9 @@
     border: solid 1px #bdbdbd;
     background-color: #ffffff;
     resize: none;
+    padding: 13px 15px;
+    font-size: 16px;
+    line-height: normal;
   }
 
   .warning {
@@ -32,5 +35,6 @@
     margin-top: 9px;
     font-size: 14px;
     color: #969696;
+    line-height: normal;
   }
 }


### PR DESCRIPTION
#846  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

edit TextArea css

## Screenshots  <!-- 選填，沒有就刪掉 -->
after 
![2K1qQRk2yk](https://user-images.githubusercontent.com/61968341/76675834-b15a4780-65f8-11ea-922c-31bc4c32e141.gif)
before
<img width="341" alt="螢幕快照 2020-03-14 下午12 43 37" src="https://user-images.githubusercontent.com/61968341/76675842-c2a35400-65f8-11ea-9a35-54406641f4be.png">


## Questions:  <!-- 選填，沒有就刪掉 -->

下拉選單會把整個題目也一起往下拉
有點奇怪 ～～ 
應該scroll那格框框的內容而已？