### PR TITLE
Feat: side ads for company/job-title pages

### DIFF
--- a/src/components/CompanyAndJobTitle/TabLinkGroup.module.css
+++ b/src/components/CompanyAndJobTitle/TabLinkGroup.module.css
@@ -1,4 +1,4 @@
-@value main-yellow, above-small from "common/variables.module.css";
+@value main-yellow, above-desktop from "common/variables.module.css";
 
 .group {
   display: inline-flex;
@@ -20,7 +20,7 @@
   border-bottom: 1px solid main-yellow;
   border-right: 1px solid main-yellow;
 
-  @media (min-width: above-small) {
+  @media (min-width: above-desktop) {
     flex: 0 1 auto;
     border-bottom: 0;
     &:last-child {

--- a/src/components/CompanyAndJobTitle/index.js
+++ b/src/components/CompanyAndJobTitle/index.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Switch } from 'react-router';
+import { useWindowSize } from 'react-use';
+import Wrapper from 'common/base/Wrapper';
+import GoogleAdsense from 'common/GoogleAdsense';
+import RouteWithSubRoutes from '../route';
+import styles from './styles.module.css';
+import breakpoints from '../../constants/breakpoints';
+
+const CompanyAndJobTitlePageContainer = ({ routes }) => {
+  const { width } = useWindowSize();
+  return (
+    <div>
+      <Wrapper size="l" className={styles.container}>
+        <div className={styles.leftContainer}>
+          <Switch>
+            {routes.map((route, i) => (
+              <RouteWithSubRoutes key={i} {...route} />
+            ))}
+          </Switch>
+        </div>
+        {width > breakpoints.md ? (
+          <div className={styles.sideAds}>
+            <GoogleAdsense
+              style={{ display: 'block' }}
+              slot="6339096692"
+              format="auto"
+              responsive="true"
+            />
+          </div>
+        ) : null}
+      </Wrapper>
+    </div>
+  );
+};
+
+CompanyAndJobTitlePageContainer.propTypes = {
+  routes: PropTypes.array,
+};
+
+export default CompanyAndJobTitlePageContainer;

--- a/src/components/CompanyAndJobTitle/styles.module.css
+++ b/src/components/CompanyAndJobTitle/styles.module.css
@@ -1,0 +1,41 @@
+@value below-desktop, below-small, below-mobile, page-gutter-s from "common/variables.module.css";
+
+.container {
+  display: flex;
+  justify-content: center;
+  max-width: 1360px;
+  margin: auto;
+  margin-top: 40px;
+
+  /* Overwriting padding between 1024px and 850px*/
+  @media (max-width: below-desktop) {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+
+  @media (max-width: below-mobile) {
+    padding-left: page-gutter-s;
+    padding-right: page-gutter-s;
+  }
+}
+
+.leftContainer {
+  flex-shrink: 1;
+  padding: 0 32px;
+  width: 100%;
+
+  @media (max-width: below-small) {
+    padding: 0;
+  }
+}
+
+.sideAds {
+  width: 160px;
+  height: 600px;
+  flex-shrink: 0;
+  margin-right: 16px;
+
+  @media (max-width: below-small) {
+    display: none;
+  }
+}

--- a/src/routes.js
+++ b/src/routes.js
@@ -27,6 +27,7 @@ import Privacy from './components/Privacy';
 import Terms from './components/Terms';
 import Redirect from 'common/routing/Redirect';
 import VerificationPage from './components/EmailVerification/VerificationPage';
+import CompanyAndJobTitlePageContainer from './components/CompanyAndJobTitle';
 import CompanyPageProvider from './components/Company/CompanyPageProvider';
 import JobTitlePageProvider from './components/JobTitle/JobTitlePageProvider';
 
@@ -208,7 +209,7 @@ const routes = [
   },
   {
     path: '/companies/:companyName',
-    component: TimeAndSalary,
+    component: CompanyAndJobTitlePageContainer,
     routes: [
       {
         path: '/companies/:companyName',
@@ -221,7 +222,7 @@ const routes = [
   },
   {
     path: '/job-titles/:jobTitle',
-    component: TimeAndSalary,
+    component: CompanyAndJobTitlePageContainer,
     routes: [
       {
         path: '/job-titles/:jobTitle',


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

公司/職業頁面的，因為埋設廣告的需求，調整了排版，右邊固定是廣告版位

## Screenshots  <!-- 選填，沒有就刪掉 -->

![screencapture-g-ad-goodjob-life-3000-companies-overview-2020-03-24-00_22_27](https://user-images.githubusercontent.com/3805975/77338802-d02dac00-6d65-11ea-98ab-8b481375a816.png)
![screencapture-g-ad-goodjob-life-3000-companies-overview-2020-03-24-00_22_44](https://user-images.githubusercontent.com/3805975/77338762-c015cc80-6d65-11ea-8462-7d280cf06884.png)


## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

- 把原本以 TimeAndSalary component 作為 container 的方法換掉，直接新增新的 component 

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

by commit 

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] `sudo vim /private/etc/host` 加上 `127.0.0.1    g-ad.goodjob.life` 這行
- [ ] yarn start
- [ ] open http://g-ad.goodjob.life:3000/
- [ ] 進到公司頁，右邊廣告正常出現，拉動螢幕寬度，要正常縮放，廣告在螢幕小一點的時候正常消失
- [ ] 進到職業頁，右邊廣告正常出現，拉動螢幕寬度，要正常縮放，廣告在螢幕小一點的時候正常消失
