### PR TITLE
[新版表單] 修復Debounce

### DIFF
--- a/src/components/common/FormBuilder/QuestionBuilder/Radio.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Radio.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 
 import Scrollable from '../Scrollable';
+import useDebouncedConfirm from '../useDebouncedConfirm';
 import styles from './Radio.module.css';
 
 const Radio = ({
@@ -16,31 +17,34 @@ const Radio = ({
   onConfirm,
   warning,
   options,
-}) => (
-  <div className={cn(styles.container, { [styles.hasWarning]: !!warning })}>
-    <div className={styles.options}>
-      <Scrollable className={styles.optionsContent}>
-        {options.map(option => (
-          <label className={styles.label} key={option}>
-            <input
-              className={styles.input}
-              type="radio"
-              name={dataKey}
-              value={option}
-              checked={option === value}
-              onChange={() => {
-                onChange(option);
-                setTimeout(onConfirm, 300);
-              }}
-            />
-            <div className={styles.button}>{option}</div>
-          </label>
-        ))}
-      </Scrollable>
+}) => {
+  const debouncedConfirm = useDebouncedConfirm(onConfirm, 300);
+  return (
+    <div className={cn(styles.container, { [styles.hasWarning]: !!warning })}>
+      <div className={styles.options}>
+        <Scrollable className={styles.optionsContent}>
+          {options.map(option => (
+            <label className={styles.label} key={option}>
+              <input
+                className={styles.input}
+                type="radio"
+                name={dataKey}
+                value={option}
+                checked={option === value}
+                onChange={() => {
+                  onChange(option);
+                  debouncedConfirm();
+                }}
+              />
+              <div className={styles.button}>{option}</div>
+            </label>
+          ))}
+        </Scrollable>
+      </div>
+      <div className={styles.warning}>{warning}</div>
     </div>
-    <div className={styles.warning}>{warning}</div>
-  </div>
-);
+  );
+};
 
 Radio.propTypes = {
   page: PropTypes.number.isRequired,

--- a/src/components/common/FormBuilder/QuestionBuilder/Rating.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Rating.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 import { Glike } from 'common/icons';
 
+import useDebouncedConfirm from '../useDebouncedConfirm';
 import styles from './Rating.module.css';
 
 const range = n => {
@@ -32,6 +33,7 @@ const Rating = ({
   warning,
   maxRating,
 }) => {
+  const debouncedConfirm = useDebouncedConfirm(onConfirm, 300);
   const [hoveredValue, handleMouseOver, handleMouseOut] = useHover();
   return (
     <div className={cn(styles.container, { [styles.hasWarning]: !!warning })}>
@@ -51,7 +53,7 @@ const Rating = ({
               checked={hoveredValue ? i < hoveredValue : i < value}
               onChange={() => {
                 onChange(i + 1);
-                setTimeout(onConfirm, 300);
+                debouncedConfirm();
               }}
             />
             <Glike className={cn(styles.glikeContainer)} />

--- a/src/components/common/FormBuilder/useDebouncedConfirm.js
+++ b/src/components/common/FormBuilder/useDebouncedConfirm.js
@@ -1,0 +1,19 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useDebounce } from 'react-use';
+
+const useDebouncedConfirm = (onConfirm, delay) => {
+  const [confirmed, setConfirmed] = useState(false);
+  const [debouncedConfirmed, setDebouncedConfirmed] = useState(false);
+  useDebounce(() => setDebouncedConfirmed(confirmed), delay, [confirmed]);
+  useEffect(() => {
+    if (debouncedConfirmed) {
+      setConfirmed(false);
+      setDebouncedConfirmed(false);
+      onConfirm();
+    }
+  }, [debouncedConfirmed]); // eslint-disable-line react-hooks/exhaustive-deps
+  const confirm = useCallback(() => setConfirmed(true), []);
+  return confirm;
+};
+
+export default useDebouncedConfirm;

--- a/src/components/common/FormBuilder/useDebouncedConfirm.js
+++ b/src/components/common/FormBuilder/useDebouncedConfirm.js
@@ -2,7 +2,10 @@ import { useState, useCallback, useEffect } from 'react';
 import { useDebounce } from 'react-use';
 
 const useDebouncedConfirm = (onConfirm, delay) => {
+  // 使用者確認作答完成
   const [confirmed, setConfirmed] = useState(false);
+
+  // 作答完成後延遲一段時間才觸發 onConfirm
   const [debouncedConfirmed, setDebouncedConfirmed] = useState(false);
   useDebounce(() => setDebouncedConfirmed(confirmed), delay, [confirmed]);
   useEffect(() => {
@@ -12,6 +15,8 @@ const useDebouncedConfirm = (onConfirm, delay) => {
       onConfirm();
     }
   }, [debouncedConfirmed]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // 僅暴露確認作答完成的函數給外界使用
   const confirm = useCallback(() => setConfirmed(true), []);
   return confirm;
 };


### PR DESCRIPTION
#846 

## 這個 PR 是？ <!-- 必填 -->

修復debounce問題

重現Bug步驟：
1. DemoForm 初次填寫 Radio 或 Rating
2. 作答但沒有自動跳下一題

![](http://g.recordit.co/F42PqvciV5.gif)

原因：因為 `onConfirm` 為
```js
page => {
  setWarningShown(true);
  if (!warning) { // <-- 有warning時會阻擋
    setPage(page);
  }
}
```
而 `onConfirm` 的 debounce 寫在
```js
onClick={() => {
  onChange(..)
  setTimeout(onConfirm, 300)
}}
```
在未填寫的時候，其實是有 `warning` 的只是沒顯示出來
原本預期填寫時觸發 `onChange` 然後 `warning` 就會消失(因為已填寫)
然後此時觸發 `onConfirm` 就會到下一題

但實際發生的是， `onConfirm` 與 `onChange` 是同一次render的
`onConfirm` 的當下是有 `warning` 的，所以不會跳題

解決方法是，讓 `onConfirm` 在 `onChange` 完的下一次 render 才觸發
該次 render 才會是沒有 `warning` 的狀態，才會觸發跳下一題的動作

## Screenshots  <!-- 選填，沒有就刪掉 -->

![](http://g.recordit.co/CL9uYbD8yF.gif)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 初次填寫 Radio 和 Rating 就會自動跳下一題