### PR TITLE
Refactor: withExperimentParameter

### DIFF
--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -11,6 +11,7 @@ import { Heading } from 'common/base';
 import withExperimentParameters from 'common/withExperimentParameters';
 import CallToLoginShareButton from '../../../containers/PermissionBlock/CallToLoginShareButtonContainer';
 import getScale from '../../../utils/numberUtils';
+import { pushDataLayer } from '../../../utils/gtm';
 import styles from './PermissionBlock.module.css';
 
 class BasicPermissionBlock extends React.Component {
@@ -50,6 +51,9 @@ class BasicPermissionBlock extends React.Component {
     if (this.props.hasFetchedLaborRightsCount === false) {
       this.props.queryLaborRightsCount();
     }
+
+    // this is for triggering Google Optimize A/B testing
+    pushDataLayer({ event: `optimize.basicPermissionBlockMounted` });
   }
 
   renderModalContent = () => {


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

詳細說明一下，為什麼我需要把 withExperimentParameter 改成 class component
故事是這樣的，A/B testing 簡單來說是把使用者分成兩群，A 群看到 A 版本 UI，B 群看到 B 版本 UI，然後看目標的轉換率有沒有顯著變高或變低。既然是轉換 “率”，他就是一個分數，有分子跟分母，分子是成功的次數，分母則是觸發實驗的次數。

以我現在做的 case ，就是當使用者被權限區塊擋住的時候，實驗才被觸發
所以我必須要在權限區塊被 render （或準備被 render）的時候，才觸發實驗

但這樣就問題來了，假設我在 BasicPermissionBlock 的 componentDidMount 才觸發實驗
包住 BasicPermissionBlock 的 HOC withExperimentParameters 卻是在它的 useEffect ，相當於 componentDidMount 的階段才監聽 element ，就來不及聽到該 element 的 attribute 變化了

再說得更詳細一點：

現在的 component 結構是這樣
```
<withExperimentParameters>
  <BasicPermissionBlock>
</withExperimentParameters>
```
原本的觸發順序：
1. withExperimentParameters 的 useState 去取得 node attributes ，這時候 root node 還沒有 `permissionBlockType` attribute （因為還沒觸發實驗）
2. BasicPermissionBlock 的 componentDidMount 觸發實驗，root node 有 `permissionBlockType` 了
3. withExperimentParameters useEffect 才開始監聽 root node ，然而 mutation observer 是 node attributes 有變化才會有反應，但 root node 的 attribute 已經被改過了。

**也就是說，原本的做法，withExperimentParameters 沒監聽到 useState ～ useEffect 這段時間 node attribute 的變化，以致於沒拿到參數，BasicPermissionBlock 就不會切成 B 版本**

所以我必須要在 constructor 的階段，就開始監聽，偏偏 react hook 沒 constructor，所以才改寫成 class component

坦白說這個做法有點 anti react pattern，一般來說要 componentDidMount 才會去監聽事件，但這邊是 constructor 就監聽，確實會造成如果 attribute 有變就會 re-render 的情況

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 打開實驗，按預覽：https://optimize.google.com/optimize/home/#/accounts/4701828256/containers/11757914/experiments/27
- [ ] 從隨便一個頁面進職場經驗單篇，要是 B 版本的 UI 
- [ ] 上一頁再回來，還是 B 版本
- [ ] 職場經驗單篇重新整理，還是 B 版本


### B 版本示意：
<img width="625" alt="截圖 2020-04-13 上午9 41 40" src="https://user-images.githubusercontent.com/3805975/79085394-fe9e1600-7d6a-11ea-8865-eca904d8e3b2.png">
