### PR TITLE
Hotfix: check window and document before using to prevent SSR error

### DIFF
--- a/src/components/common/withExperimentParameters.js
+++ b/src/components/common/withExperimentParameters.js
@@ -37,7 +37,7 @@ export default (
 ) => WrappedComponent => {
   const WithExperimentParameters = props => {
     const ref = useRef(null);
-    if (document && ref.current === null) {
+    if (typeof document !== 'undefined' && ref.current === null) {
       ref.current = document.getElementById(elementId);
     }
 

--- a/src/utils/gtm.js
+++ b/src/utils/gtm.js
@@ -5,10 +5,12 @@
  * @see {@link https://developers.google.com/tag-manager/devguide}
  */
 export const pushDataLayer = event => {
-  if (window.dataLayer) {
-    window.dataLayer.push(event);
-  } else {
-    window.dataLayer = [event];
+  if (typeof window !== 'undefined') {
+    if (window.dataLayer) {
+      window.dataLayer.push(event);
+    } else {
+      window.dataLayer = [event];
+    }
   }
 };
 

--- a/src/utils/sentryUtil.js
+++ b/src/utils/sentryUtil.js
@@ -10,7 +10,7 @@ function isEnabled() {
 function initSentry() {
   if (isEnabled()) {
     if (config.SENTRY_DSN) {
-      if (window.Raven) {
+      if (typeof window !== 'undefined' && window.Raven) {
         if (config.GIT_SHA1) {
           window.Raven.config(config.SENTRY_DSN, {
             release: config.GIT_SHA1,


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

用 `if(document)` or `if(window)` 這樣的檢查，在 server-side 其實還是會錯（但不知道為什麼有時候才會發生，有時候卻不會），因此改成用 typeof 檢查

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start 可以跑起來就好