### PR TITLE
Escape unsafe js object

### DIFF
--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react';
 import Helmet from 'react-helmet';
+import serialize from 'serialize-javascript';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { isFetched } from '../../constants/status';
 import { SITE_NAME } from '../../constants/helmetData';
@@ -72,7 +73,7 @@ const SeoStructureData = ({ experienceState }) => {
     return (
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+        dangerouslySetInnerHTML={{ __html: serialize(data) }}
       />
     );
   }


### PR DESCRIPTION
Since JSON.stringify doesn't escape the char like `<` and `>`, the raw html in script is not safe.

`JSON.stringify(data)` must be escaped, I use the library in https://github.com/goodjoblife/GoodJobShare/blob/0949ae917d3a55a6371bad7b7b1fee7759e61b78/src/helpers/Html.js#L88