### PR TITLE
Fix: 當只有state改變時捲軸不置頂

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -14,9 +14,18 @@ import Root from './components/Root';
 import configureStore from './store/configureStore';
 
 function shouldUpdateScroll(prevProps, props) {
-  return (
-    (prevProps ? prevProps.location.pathname : '') !== props.location.pathname
+  const getSignature = R.compose(
+    R.omit(['state', 'key']),
+    R.path(['location']),
   );
+  const diffSignature = R.unapply(
+    R.compose(
+      R.not,
+      R.apply(R.equals),
+      R.map(getSignature),
+    ),
+  );
+  return diffSignature(prevProps, props);
 }
 
 function parseState(window) {

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,6 +1,5 @@
-import React, { Fragment, useMemo, useCallback } from 'react';
+import React, { Fragment, useCallback } from 'react';
 import { Switch, useLocation, useHistory } from 'react-router-dom';
-import { parse, stringify } from 'qs';
 import { omit } from 'ramda';
 
 import { AppRouteWithSubRoutes } from '../route';
@@ -14,15 +13,12 @@ import routes from '../../routes';
 
 const useShare = () => {
   const location = useLocation();
-  const query = useMemo(
-    () => parse(location.search, { ignoreQueryPrefix: true }),
-    [location.search],
-  );
-  const share = query.share;
+  const state = location.state || {};
+  const share = state.share;
   const history = useHistory();
   const exitShare = useCallback(
-    () => history.push(`?${stringify(omit(['share'], query))}`),
-    [history, query],
+    () => history.push({ state: omit(['share'], state) }),
+    [history, state],
   );
   return [share, exitShare];
 };

--- a/src/components/LandingPage/CallToActionBlock.js
+++ b/src/components/LandingPage/CallToActionBlock.js
@@ -16,7 +16,7 @@ const CallToActionBlock = ({ history }) => {
       if (companyName) {
         history.push(
           true
-            ? `?share=interview&companyName=${companyName}`
+            ? { state: { share: 'interview', companyName } }
             : `/share/interview?companyName=${companyName}`,
         ); // TODO: A/B
       }

--- a/src/components/ShareExperience/InterviewForm/TypeForm.js
+++ b/src/components/ShareExperience/InterviewForm/TypeForm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import R from 'ramda';
-import { parse } from 'qs';
 
 import FormBuilder from 'common/FormBuilder';
 import Header, { CompanyJobTitleHeader } from '../common/TypeFormHeader';
@@ -25,13 +24,11 @@ const questions = [
     type: 'text',
     dataKey: 'companyName',
     defaultValue: () => {
-      const query =
-        typeof document === 'undefined'
+      const state =
+        typeof window === 'undefined'
           ? {}
-          : parse(document.location.search, {
-              ignoreQueryPrefix: true,
-            });
-      const companyName = query.companyName || '';
+          : R.path(['history', 'state', 'state'], window) || {};
+      const companyName = state.companyName || '';
       return companyName;
     },
     required: true,

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -36,7 +36,7 @@ class BasicPermissionBlock extends React.Component {
   };
 
   static defaultProps = {
-    to: true ? '?share=interview' : '/share/interview/step1', // TODO: A/B
+    to: true ? { state: { share: 'interview' } } : '/share/interview/step1', // TODO: A/B
     rootClassName: '',
     simple: false,
   };

--- a/src/components/common/ShareExpSection/index.js
+++ b/src/components/common/ShareExpSection/index.js
@@ -17,7 +17,9 @@ const DefaultSubheading = () => (
 );
 
 const ShareExpSection = ({ heading, Subheading }) => {
-  const shareInterviewPath = true ? '?share=interview' : '/share/interview'; // TODO: A/B
+  const shareInterviewPath = true
+    ? { state: { share: 'interview' } }
+    : '/share/interview'; // TODO: A/B
   return (
     <Section padding>
       <Wrapper size="l">

--- a/src/constants/dataProgress.js
+++ b/src/constants/dataProgress.js
@@ -1,2 +1,4 @@
 export const goalNum = 10000;
-export const shareLink = true ? '?share=interview' : '/share/interview/step1'; // TODO: A/B
+export const shareLink = true
+  ? { state: { share: 'interview' } }
+  : '/share/interview/step1'; // TODO: A/B


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

原本寫pathname不改變就不置頂
但考量到query改變仍有置頂的可能 (?p=2)
因此把某些只是為了內部使用(所以不用置頂)的變數從query搬移到state

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 首頁CTA輸入公司名稱叫出Modal之後不會置頂，且公司名稱有自動填入
- [ ] 其他頁面的location & query變化都會使頁面置頂