### PR TITLE
hotfix: experience_in_year bug

### DIFF
--- a/src/components/ExperienceDetail/Article/ArticleInfo.js
+++ b/src/components/ExperienceDetail/Article/ArticleInfo.js
@@ -17,11 +17,13 @@ const InterviewInfoBlocks = ({ experience, hideContent }) => (
     </div>
     <InfoBlock label="面試地區">{experience.region}</InfoBlock>
     <InfoBlock label="應徵職稱">{experience.job_title.name}</InfoBlock>
-    {experience.experience_in_year && (
+    {Number.isInteger(experience.experience_in_year) ? (
       <InfoBlock label="相關職務工作經驗">
-        {experience.experience_in_year} 年
+        {experience.experience_in_year === 0
+          ? '不到 1 年'
+          : `${experience.experience_in_year} 年`}
       </InfoBlock>
-    )}
+    ) : null}
     {experience.education && (
       <InfoBlock label="最高學歷">{experience.education}</InfoBlock>
     )}

--- a/src/components/ExperienceDetail/Article/ArticleInfo.js
+++ b/src/components/ExperienceDetail/Article/ArticleInfo.js
@@ -9,104 +9,115 @@ import InfoBlock from './InfoBlock';
 import RateButtons from './RateButtons';
 
 const formatDate = date => `${date.getFullYear()} 年 ${date.getMonth()} 月`;
+const formatExperienceInYear = year => {
+  if (Number.isInteger(year)) {
+    if (year === 0) {
+      return '不到 1 年';
+    } else {
+      return `${year} 年`;
+    }
+  } else {
+    return null;
+  }
+};
 
-const InterviewInfoBlocks = ({ experience, hideContent }) => (
-  <Fragment>
-    <div className={styles.date}>
-      {formatDate(new Date(experience.created_at))}
-    </div>
-    <InfoBlock label="面試地區">{experience.region}</InfoBlock>
-    <InfoBlock label="應徵職稱">{experience.job_title.name}</InfoBlock>
-    {Number.isInteger(experience.experience_in_year) ? (
-      <InfoBlock label="相關職務工作經驗">
-        {experience.experience_in_year === 0
-          ? '不到 1 年'
-          : `${experience.experience_in_year} 年`}
+const InterviewInfoBlocks = ({ experience, hideContent }) => {
+  const expInYearText = formatExperienceInYear(experience.experience_in_year);
+  return (
+    <Fragment>
+      <div className={styles.date}>
+        {formatDate(new Date(experience.created_at))}
+      </div>
+      <InfoBlock label="面試地區">{experience.region}</InfoBlock>
+      <InfoBlock label="應徵職稱">{experience.job_title.name}</InfoBlock>
+      {expInYearText !== null ? (
+        <InfoBlock label="相關職務工作經驗">{expInYearText}</InfoBlock>
+      ) : null}
+      {experience.education && (
+        <InfoBlock label="最高學歷">{experience.education}</InfoBlock>
+      )}
+      {experience.interview_time && (
+        <InfoBlock label="面試時間">
+          {`${experience.interview_time.year} 年 ${experience.interview_time.month} 月`}
+        </InfoBlock>
+      )}
+      <InfoBlock label="面試結果">{experience.interview_result}</InfoBlock>
+      {experience.salary && (
+        <InfoBlock label="待遇">
+          {hideContent ? (
+            <React.Fragment>
+              <FontAwesomeIcon icon={faLock} className={styles.lock} />
+              {formatSalaryRange(experience.salary)}
+            </React.Fragment>
+          ) : (
+            formatSalary(experience.salary)
+          )}
+        </InfoBlock>
+      )}
+      <InfoBlock label="整體面試滿意度">
+        <RateButtons rate={experience.overall_rating} />
       </InfoBlock>
-    ) : null}
-    {experience.education && (
-      <InfoBlock label="最高學歷">{experience.education}</InfoBlock>
-    )}
-    {experience.interview_time && (
-      <InfoBlock label="面試時間">
-        {`${experience.interview_time.year} 年 ${experience.interview_time.month} 月`}
-      </InfoBlock>
-    )}
-    <InfoBlock label="面試結果">{experience.interview_result}</InfoBlock>
-    {experience.salary && (
-      <InfoBlock label="待遇">
-        {hideContent ? (
-          <React.Fragment>
-            <FontAwesomeIcon icon={faLock} className={styles.lock} />
-            {formatSalaryRange(experience.salary)}
-          </React.Fragment>
-        ) : (
-          formatSalary(experience.salary)
-        )}
-      </InfoBlock>
-    )}
-    <InfoBlock label="整體面試滿意度">
-      <RateButtons rate={experience.overall_rating} />
-    </InfoBlock>
-    {experience.interview_sensitive_questions &&
-    experience.interview_sensitive_questions.length ? (
-      <InfoBlock label="有以下特殊問題">
-        <ul>
-          {experience.interview_sensitive_questions.map((o, idx) => (
-            <li key={idx}>{o}</li>
-          ))}
-        </ul>
-      </InfoBlock>
-    ) : null}
-  </Fragment>
-);
+      {experience.interview_sensitive_questions &&
+      experience.interview_sensitive_questions.length ? (
+        <InfoBlock label="有以下特殊問題">
+          <ul>
+            {experience.interview_sensitive_questions.map((o, idx) => (
+              <li key={idx}>{o}</li>
+            ))}
+          </ul>
+        </InfoBlock>
+      ) : null}
+    </Fragment>
+  );
+};
 
 InterviewInfoBlocks.propTypes = {
   experience: PropTypes.object.isRequired,
 };
 
-const WorkInfoBlocks = ({ experience, hideContent }) => (
-  <Fragment>
-    <InfoBlock label="工作地區">{experience.region}</InfoBlock>
-    <InfoBlock label="職稱">{experience.job_title.name}</InfoBlock>
-    {experience.experience_in_year && (
-      <InfoBlock label="自身相關職務工作經驗">
-        {experience.experience_in_year} 年
-      </InfoBlock>
-    )}
-    {experience.education && (
-      <InfoBlock label="最高學歷">{experience.education}</InfoBlock>
-    )}
-    {experience.week_work_time && (
-      <InfoBlock label="一週工時">{experience.week_work_time}</InfoBlock>
-    )}
-    {experience.salary && (
-      <InfoBlock label="待遇">
-        {hideContent ? (
-          <React.Fragment>
-            <FontAwesomeIcon icon={faLock} className={styles.lock} />
-            {formatSalaryRange(experience.salary)}
-          </React.Fragment>
-        ) : (
-          formatSalary(experience.salary)
-        )}
-      </InfoBlock>
-    )}
-    {experience.recommend_to_others && (
-      <InfoBlock label="是否推薦此工作">
-        {experience.recommend_to_others === 'yes' ? (
-          <div className={styles.recommendIcon}>
-            <Good />推
-          </div>
-        ) : (
-          <div className={styles.recommendIcon}>
-            <Bad /> 不推
-          </div>
-        )}
-      </InfoBlock>
-    )}
-  </Fragment>
-);
+const WorkInfoBlocks = ({ experience, hideContent }) => {
+  const expInYearText = formatExperienceInYear(experience.experience_in_year);
+  return (
+    <Fragment>
+      <InfoBlock label="工作地區">{experience.region}</InfoBlock>
+      <InfoBlock label="職稱">{experience.job_title.name}</InfoBlock>
+      {expInYearText !== null && (
+        <InfoBlock label="自身相關職務工作經驗">{expInYearText}</InfoBlock>
+      )}
+      {experience.education && (
+        <InfoBlock label="最高學歷">{experience.education}</InfoBlock>
+      )}
+      {experience.week_work_time && (
+        <InfoBlock label="一週工時">{experience.week_work_time}</InfoBlock>
+      )}
+      {experience.salary && (
+        <InfoBlock label="待遇">
+          {hideContent ? (
+            <React.Fragment>
+              <FontAwesomeIcon icon={faLock} className={styles.lock} />
+              {formatSalaryRange(experience.salary)}
+            </React.Fragment>
+          ) : (
+            formatSalary(experience.salary)
+          )}
+        </InfoBlock>
+      )}
+      {experience.recommend_to_others && (
+        <InfoBlock label="是否推薦此工作">
+          {experience.recommend_to_others === 'yes' ? (
+            <div className={styles.recommendIcon}>
+              <Good />推
+            </div>
+          ) : (
+            <div className={styles.recommendIcon}>
+              <Bad /> 不推
+            </div>
+          )}
+        </InfoBlock>
+      )}
+    </Fragment>
+  );
+};
 
 WorkInfoBlocks.propTypes = {
   experience: PropTypes.object.isRequired,


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

意外發現一個 bug，experience_in_year === 0 的時候，職場經驗單篇會有顯示上的問題，詳見 screenshot，此 PR 修正之。

## Screenshots  <!-- 選填，沒有就刪掉 -->

修正前：
<img width="277" alt="截圖 2020-05-11 上午9 58 23" src="https://user-images.githubusercontent.com/3805975/81517590-fe933500-936d-11ea-98e3-37db2d0d22de.png">


修正後：
<img width="299" alt="截圖 2020-05-11 上午9 57 08" src="https://user-images.githubusercontent.com/3805975/81517554-e4f1ed80-936d-11ea-9c03-b6ee66fc7f70.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 留一筆面試資料，不填相關職務工作經驗，單篇顯示的地方應該不顯示
- [ ] 留一筆面試資料，填寫「不到 1 年」，單篇顯示的地方也是顯示不到 1 年
- [ ] 留一筆面試資料，填寫 1 年或以上，單篇顯示的地方可以正常顯示
