### PR TITLE
Fix: wording and location.reload 

### DIFF
--- a/src/components/ShareExperience/InterviewForm/TypeForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/TypeForm/index.js
@@ -347,11 +347,14 @@ const TypeForm = ({ open, onClose }) => {
       <ConfirmModal
         isOpen={submitStatus === 'success'}
         title="上傳成功"
-        subtitle="你已解鎖全站資訊 48 小時"
+        subtitle="你已解鎖全站資訊囉！"
         description="感謝你分享你的資訊，台灣的職場因為有你而變得更好！"
         close={() => {
           setSubmitStatus('unsubmitted');
           onClose();
+          if (typeof window !== 'undefined') {
+            window.location.reload();
+          }
         }}
         closableOnClickOutside
         actions={[
@@ -360,6 +363,9 @@ const TypeForm = ({ open, onClose }) => {
             () => {
               setSubmitStatus('unsubmitted');
               onClose();
+              if (typeof window !== 'undefined') {
+                window.location.reload();
+              }
             },
           ],
         ]}


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

1. 修正送出成功後的文案（移除 48 小時）
2. 送出成功後，重新整理頁面，讓原本鎖定的頁面可以被解鎖

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="391" alt="截圖 2020-05-31 下午10 10 33" src="https://user-images.githubusercontent.com/3805975/83354485-968fa780-a38b-11ea-905a-5ae0677253e1.png">

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進 [這裡](https://optimize.google.com/optimize/home/?authuser=0&hl=zh-TW#/accounts/4701828256/containers/13865540/experiments/7) 打開 B 版本實驗 
- [ ] 進 /experiences/search，點擊左方的 banner
- [ ] 留一筆資料，成功的訊息要是對的，不管按確認或 X ，都會重整一次頁面