### PR TITLE
Feat: 測試私訊原作者按鈕文案

### DIFF
--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -13,6 +13,7 @@ import { compose, setStatic } from 'recompose';
 import cn from 'classnames';
 import { useParams } from 'react-router-dom';
 import { useWindowSize } from 'react-use';
+import ReactGA from 'react-ga';
 import Loader from 'common/Loader';
 import { Wrapper, Section, Heading, P } from 'common/base';
 import PrivateMessageButton from 'common/button/PrivateMessageButton';
@@ -47,6 +48,7 @@ import { fetchExperience } from '../../actions/experienceDetail';
 import ReportFormContainer from '../../containers/ExperienceDetail/ReportFormContainer';
 import { COMMENT_ZONE } from '../../constants/formElements';
 import breakpoints from '../../constants/breakpoints';
+import { GA_CATEGORY, GA_ACTION } from '../../constants/gaConstants';
 import styles from './ExperienceDetail.module.css';
 
 const MODAL_TYPE = {
@@ -230,6 +232,10 @@ const ExperienceDetail = ({
                 position:
                   ClickPrivateMessageButtonTracker.positions.nextToTopReportBtn,
               });
+              ReactGA.event({
+                category: GA_CATEGORY.TEST_NEW_FEATURE,
+                action: GA_ACTION.CLICK_PRIVATE_MESSAGE_BUTTON,
+              });
             }}
           />
           <ReportDetail
@@ -295,6 +301,10 @@ const ExperienceDetail = ({
                         position:
                           ClickPrivateMessageButtonTracker.positions
                             .articleBottom,
+                      });
+                      ReactGA.event({
+                        category: GA_CATEGORY.TEST_NEW_FEATURE,
+                        action: GA_ACTION.CLICK_PRIVATE_MESSAGE_BUTTON,
                       });
                     }}
                   />

--- a/src/components/common/button/PrivateMessageButton.js
+++ b/src/components/common/button/PrivateMessageButton.js
@@ -1,15 +1,19 @@
 import React from 'react';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import faCommentDots from '@fortawesome/fontawesome-free-solid/faCommentDots';
+import { usePrivateMessageButtonText } from 'hooks/experiments';
 import Button from './Button';
 
 import styles from './PrivateMessageButton.module.css';
 
-const PrivateMessageButton = ({ className, onClick }) => (
-  <Button btnStyle="blue" className={className} onClick={onClick}>
-    <FontAwesomeIcon icon={faCommentDots} className={styles.msgButtonIcon} />
-    私訊原作者
-  </Button>
-);
+const PrivateMessageButton = ({ className, onClick }) => {
+  const text = usePrivateMessageButtonText();
+  return (
+    <Button btnStyle="blue" className={className} onClick={onClick}>
+      <FontAwesomeIcon icon={faCommentDots} className={styles.msgButtonIcon} />
+      {text}
+    </Button>
+  );
+};
 
 export default PrivateMessageButton;

--- a/src/constants/gaConstants.js
+++ b/src/constants/gaConstants.js
@@ -6,6 +6,7 @@ export const GA_CATEGORY = {
   SEARCH_EXPERIENCE: 'search_experience',
   LOGIN: 'login',
   HEADER: 'header',
+  TEST_NEW_FEATURE: 'test_new_feature',
 };
 
 export const GA_ACTION = {
@@ -22,4 +23,5 @@ export const GA_ACTION = {
   CLICK_EXPERIENCE_SEARCH: 'click_experience_search',
   CLICK_LABOR_RIGHTS: 'click_labor_rights',
   CLICK_SHARE_DATA: 'click_share_data',
+  CLICK_PRIVATE_MESSAGE_BUTTON: 'click_private_message_button',
 };

--- a/src/hooks/experiments/index.js
+++ b/src/hooks/experiments/index.js
@@ -1,0 +1,3 @@
+import usePrivateMessageButtonText from './usePrivateMessageButtonText';
+
+export { usePrivateMessageButtonText };

--- a/src/hooks/experiments/usePrivateMessageButtonText.js
+++ b/src/hooks/experiments/usePrivateMessageButtonText.js
@@ -1,0 +1,23 @@
+import { useEffect, useMemo } from 'react';
+import useExperimentParameters from 'hooks/useExperimentParameters';
+import { activateOptimize } from 'utils/gtm';
+
+export default () => {
+  useEffect(() => {
+    activateOptimize('testPrivateMessageButtonText');
+  }, []);
+
+  const experimentParameters = useExperimentParameters([
+    'privateMessageButtonText',
+  ]);
+
+  const text = useMemo(() => {
+    if (experimentParameters.privateMessageButtonText) {
+      return experimentParameters.privateMessageButtonText;
+    } else {
+      return '私訊原作者';
+    }
+  }, [experimentParameters.privateMessageButtonText]);
+
+  return text;
+};


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

雖然點擊私訊原作者的人數不多，但動機都很強，3x 個人裡面有 14 個填寫問卷
決定試試看不同文案，是否可以增加誘因

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 打開這個頁面 https://optimize.google.com/optimize/home/?authuser=0&hl=zh-TW#/accounts/4701828256/containers/11757914/experiments/30 
- [ ] 打開 B 版本，文案要是 `私訊問內幕`
- [ ] 打開 C 版本，文案要是 `私訊問公司實況`
- [ ] 打開 D 版本，文案要是 `私訊問細節`