### PR TITLE
hotfix: 修附圖表 render 錯誤、調整職場經驗單篇樣式

### DIFF
--- a/src/components/ExperienceDetail/ChartsZone/index.js
+++ b/src/components/ExperienceDetail/ChartsZone/index.js
@@ -2,11 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 import { generatePath } from 'react-router';
+import R from 'ramda';
 import ChartWrapper from '../../LandingPage/ChartWrapper';
 import SalaryDistributionChart from '../../common/Charts/SalaryDistributionChart';
 import JobTitleDistributionChart from '../../common/Charts/JobTitleDistrubitionChart';
 import styles from '../../LandingPage/SummarySection.module.css';
 import moduleStyles from './ChartsZone.module.css';
+
+const isEmptyOrNull = R.either(R.isEmpty, R.isNil);
 
 const ChartsZone = ({
   experience: {
@@ -19,37 +22,45 @@ const ChartsZone = ({
       salary_distribution: { bins },
     },
   },
-}) => (
-  <div className={cn(styles.page, moduleStyles.container)}>
-    <ChartWrapper
-      className={styles.chartWrapper}
-      title={`${companyName}的薪水`}
-      to={generatePath('/companies/:companyName', {
-        companyName,
-      })}
-    >
-      <React.Fragment>
-        <div className={styles.barChart}>
-          <JobTitleDistributionChart data={job_average_salaries} />
-        </div>
-      </React.Fragment>
-    </ChartWrapper>
-
-    <ChartWrapper
-      className={styles.chartWrapper}
-      title={`${jobTitle}的薪水分佈`}
-      to={generatePath('/job-titles/:jobTitle', {
-        jobTitle,
-      })}
-    >
-      <React.Fragment>
-        <div className={styles.barChart}>
-          <SalaryDistributionChart data={bins} />
-        </div>
-      </React.Fragment>
-    </ChartWrapper>
-  </div>
-);
+}) => {
+  if (isEmptyOrNull(job_average_salaries) && isEmptyOrNull(bins)) {
+    return null;
+  }
+  return (
+    <div className={cn(styles.page, moduleStyles.container)}>
+      {isEmptyOrNull(job_average_salaries) ? null : (
+        <ChartWrapper
+          className={styles.chartWrapper}
+          title={`${companyName}的薪水`}
+          to={generatePath('/companies/:companyName', {
+            companyName,
+          })}
+        >
+          <React.Fragment>
+            <div className={styles.barChart}>
+              <JobTitleDistributionChart data={job_average_salaries} />
+            </div>
+          </React.Fragment>
+        </ChartWrapper>
+      )}
+      {isEmptyOrNull(bins) ? null : (
+        <ChartWrapper
+          className={styles.chartWrapper}
+          title={`${jobTitle}的薪水分佈`}
+          to={generatePath('/job-titles/:jobTitle', {
+            jobTitle,
+          })}
+        >
+          <React.Fragment>
+            <div className={styles.barChart}>
+              <SalaryDistributionChart data={bins} />
+            </div>
+          </React.Fragment>
+        </ChartWrapper>
+      )}
+    </div>
+  );
+};
 
 ChartsZone.propTypes = {
   experience: PropTypes.object.isRequired,

--- a/src/components/ExperienceDetail/ExperienceDetail.module.css
+++ b/src/components/ExperienceDetail/ExperienceDetail.module.css
@@ -6,6 +6,7 @@
 }
 
 .leftContainer {
+  flex-grow: 1;
   flex-shrink: 1;
 }
 

--- a/src/components/ExperienceDetail/ExperienceDetail.module.css
+++ b/src/components/ExperienceDetail/ExperienceDetail.module.css
@@ -6,14 +6,9 @@
 }
 
 .leftContainer {
-  flex-grow: 1;
   flex-shrink: 1;
-}
-
-.wrapper {
   @media (min-width: above-small) {
-    padding-left: 32px;
-    padding-right: 32px;
+    padding-right: 16px;
   }
 }
 

--- a/src/components/ExperienceDetail/ExperienceDetail.module.css
+++ b/src/components/ExperienceDetail/ExperienceDetail.module.css
@@ -47,7 +47,6 @@
   width: 160px;
   height: 600px;
   flex-shrink: 0;
-  margin-right: 16px;
 
   @media (max-width: below-small) {
     display: none;

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -13,6 +13,7 @@ import { compose, setStatic } from 'recompose';
 import cn from 'classnames';
 import { useParams } from 'react-router-dom';
 import { useWindowSize } from 'react-use';
+import { StickyContainer, Sticky } from 'react-sticky';
 import Loader from 'common/Loader';
 import { Wrapper, Section } from 'common/base';
 import Modal from 'common/Modal';
@@ -257,41 +258,49 @@ const ExperienceDetail = ({
     <main>
       <Seo experienceState={data} />
       <Section bg="white" paddingBottom className={styles.section}>
-        <Wrapper className={styles.container} size="m">
-          <div className={styles.leftContainer}>
-            {/* 文章區塊  */}
-            {!isFetched(experienceStatus) ? (
-              <Loader />
-            ) : (
-              <Fragment>
-                <div className={styles.breadCrumb}>
-                  <BreadCrumb
-                    data={generateBreadCrumbData({
-                      pageType,
-                      pageName: pageTypeToNameSelector[pageType](experience),
-                      tabType: experienceTypeToTabType[experience.type],
-                      experience,
-                    })}
+        <Wrapper size="m">
+          <StickyContainer className={styles.container}>
+            <div className={styles.leftContainer}>
+              {/* 文章區塊  */}
+              {!isFetched(experienceStatus) ? (
+                <Loader />
+              ) : (
+                <Fragment>
+                  <div className={styles.breadCrumb}>
+                    <BreadCrumb
+                      data={generateBreadCrumbData({
+                        pageType,
+                        pageName: pageTypeToNameSelector[pageType](experience),
+                        tabType: experienceTypeToTabType[experience.type],
+                        experience,
+                      })}
+                    />
+                  </div>
+                  <ExperienceHeading experience={experience} />
+                  {reportZone}
+                  <Article
+                    experience={experience}
+                    hideContent={!canView}
+                    onClickMsgButton={scrollToCommentZone}
                   />
-                </div>
-                <ExperienceHeading experience={experience} />
-                {reportZone}
-                <Article
-                  experience={experience}
-                  hideContent={!canView}
-                  onClickMsgButton={scrollToCommentZone}
-                />
-              </Fragment>
-            )}
-          </div>
-          {width > breakpoints.md ? (
-            <div className={styles.sideAds}>
-              <GoogleAdUnit
-                sizes={[[160, 600]]}
-                adUnit="goodjob_pc_article_sidebar"
-              />
+                </Fragment>
+              )}
             </div>
-          ) : null}
+            {width > breakpoints.md ? (
+              <div className={styles.sideAds}>
+                <Sticky>
+                  {({ style }) => (
+                    <div style={style}>
+                      <GoogleAdUnit
+                        sizes={[[160, 600]]}
+                        adUnit="goodjob_pc_article_sidebar"
+                      />
+                    </div>
+                  )}
+                </Sticky>
+              </div>
+            ) : null}
+          </StickyContainer>
         </Wrapper>
         {isFetched(experienceStatus) && (
           <React.Fragment>

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -257,34 +257,32 @@ const ExperienceDetail = ({
     <main>
       <Seo experienceState={data} />
       <Section bg="white" paddingBottom className={styles.section}>
-        <div className={styles.container}>
+        <Wrapper className={styles.container} size="m">
           <div className={styles.leftContainer}>
-            <Wrapper className={styles.wrapper} size="m">
-              {/* 文章區塊  */}
-              {!isFetched(experienceStatus) ? (
-                <Loader />
-              ) : (
-                <Fragment>
-                  <div className={styles.breadCrumb}>
-                    <BreadCrumb
-                      data={generateBreadCrumbData({
-                        pageType,
-                        pageName: pageTypeToNameSelector[pageType](experience),
-                        tabType: experienceTypeToTabType[experience.type],
-                        experience,
-                      })}
-                    />
-                  </div>
-                  <ExperienceHeading experience={experience} />
-                  {reportZone}
-                  <Article
-                    experience={experience}
-                    hideContent={!canView}
-                    onClickMsgButton={scrollToCommentZone}
+            {/* 文章區塊  */}
+            {!isFetched(experienceStatus) ? (
+              <Loader />
+            ) : (
+              <Fragment>
+                <div className={styles.breadCrumb}>
+                  <BreadCrumb
+                    data={generateBreadCrumbData({
+                      pageType,
+                      pageName: pageTypeToNameSelector[pageType](experience),
+                      tabType: experienceTypeToTabType[experience.type],
+                      experience,
+                    })}
                   />
-                </Fragment>
-              )}
-            </Wrapper>
+                </div>
+                <ExperienceHeading experience={experience} />
+                {reportZone}
+                <Article
+                  experience={experience}
+                  hideContent={!canView}
+                  onClickMsgButton={scrollToCommentZone}
+                />
+              </Fragment>
+            )}
           </div>
           {width > breakpoints.md ? (
             <div className={styles.sideAds}>
@@ -294,12 +292,16 @@ const ExperienceDetail = ({
               />
             </div>
           ) : null}
-        </div>
+        </Wrapper>
         {isFetched(experienceStatus) && (
-          <Wrapper size="l">
-            <MoreExperiencesBlock experience={experience} />
-            <ChartsZone experience={experience} />
-          </Wrapper>
+          <React.Fragment>
+            <Wrapper size="m">
+              <MoreExperiencesBlock experience={experience} />
+            </Wrapper>
+            <Wrapper size="l">
+              <ChartsZone experience={experience} />
+            </Wrapper>
+          </React.Fragment>
         )}
         <Wrapper size="s">
           <ScrollElement name={COMMENT_ZONE} />

--- a/src/components/LandingPage/SummarySection.module.css
+++ b/src/components/LandingPage/SummarySection.module.css
@@ -20,13 +20,16 @@
 .page {
   display: flex;
   flex-direction: column;
+  align-items: center;
 
   @media (min-width: above-desktop) {
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: center;
   }
 
   .chartWrapper {
+    max-width: 545px;
+    width: 100%;
     &:not(:last-child) {
       margin-bottom: 48px;
     }
@@ -34,6 +37,7 @@
       flex: 1;
       &:not(:last-child) {
         margin-right: 46px;
+        margin-bottom: 0;
       }
     }
   }

--- a/src/components/common/Charts/JobTitleDistrubitionChart.js
+++ b/src/components/common/Charts/JobTitleDistrubitionChart.js
@@ -39,7 +39,6 @@ const YAxisTickFormatter = (str, perNWord = 4) => {
 
 const JobTitleDistributionChart = ({ data }) => {
   const { width } = useWindowSize();
-
   return (
     <ResponsiveContainer>
       <BarChart


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. 職場經驗單篇中的薪資圖表區塊，可能會有沒資料的狀況，會間接造成畫面上的錯誤（會整一個塊白色）。因此先圖表的部分，會先檢查再決定是否 render，如果沒資料就不 render。
2. 圖表有可能出現只有一張圖的狀況，因此調整排版，讓只有一張圖的時候，圖表會在中間。
3. 微調整個文章區塊的寬度，並讓右邊的廣告 sticky

## Screenshots  <!-- 選填，沒有就刪掉 -->

### 整體來說會長這樣
![screencapture-g-ad-goodjob-life-3000-experiences-5f58d8271c5ca3001dfa4dbb-2020-09-20-00_25_09](https://user-images.githubusercontent.com/3805975/93671723-ff846200-fad7-11ea-9b84-3390473af01f.png)


### 只有一張圖會長這樣
![screencapture-g-ad-goodjob-life-3000-experiences-5f4daa341c5ca3001df7b164-2020-09-20-00_25_40](https://user-images.githubusercontent.com/3805975/93671716-f3000980-fad7-11ea-89bb-a8a7f30f66d6.png)

### 沒有圖會長這樣
![screencapture-g-ad-goodjob-life-3000-experiences-5f6627ec82a2bf001fa77296-2020-09-20-00_25_59](https://user-images.githubusercontent.com/3805975/93671733-162ab900-fad8-11ea-92f7-672eeb5c8665.png)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 找一間有名的公司＆常見的職稱，進到職場經驗單篇，下方一般來說會有兩個圖表，調整螢幕寬度看顯示是否正常
- [ ] 找一個冷門的職業，但公司還算有名，進到職場經驗單篇，下方一般來說會有一個圖表，調整螢幕寬度看顯示是否正常
- [ ] 找一個職業、公司都冷門的職業，進到職場經驗單篇，下方一般來說沒有圖表，調整螢幕寬度看顯示是否正常
- [ ] 職場經驗單篇右邊的廣告有 sticky