### PR TITLE
Feat: 解鎖邏輯完成＋共用

### DIFF
--- a/src/actions/permission.js
+++ b/src/actions/permission.js
@@ -18,14 +18,15 @@ const setPermission = ({
   error,
 });
 
-export const fetchMyUnlockedContentsAndPointsIfUnfetched = () => (
-  dispatch,
-  getState,
-  { api },
-) => {
+export const fetchMyUnlockedContentsAndPointsIfUnfetched = (
+  options = {
+    forceFetch: false,
+  },
+) => (dispatch, getState, { api }) => {
+  const forceFetch = options.forceFetch || false;
   const state = getState();
   const token = tokenSelector(state);
-  if (isUnfetched(getState().permission.get('status'))) {
+  if (isUnfetched(getState().permission.get('status')) || forceFetch) {
     dispatch(setPermission({ status: fetchingStatus.FETCHING }));
     return api.me
       .getMyUnlockedContentsAndPoints({ token })

--- a/src/components/common/PermissionBlock/BasicPermissionBlock.js
+++ b/src/components/common/PermissionBlock/BasicPermissionBlock.js
@@ -4,7 +4,7 @@ import cn from 'classnames';
 import usePermission from 'hooks/usePermission';
 import { useLogin } from 'hooks/login';
 import useTaskAndReward from 'hooks/useTaskAndReward';
-import Loading from 'common/Loader';
+import Loader from 'common/Loader';
 import {
   PointsBlock,
   LoginBlock,
@@ -66,7 +66,7 @@ const PermissionBlock = ({ dataId, dataType, className }) => {
   if (!taskAndRewardFetched) {
     return (
       <div className={className}>
-        <Loading size="m" />
+        <Loader size="s" />
       </div>
     );
   } else {

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -72,3 +72,7 @@
 .ctaButtonContainer {
   text-align: center;
 }
+
+.confirmToUnlockModal {
+  text-align: center;
+}

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -52,6 +52,10 @@
   margin-bottom: 20px;
 }
 
+.body {
+  margin-bottom: 20px;
+}
+
 .requiredPoints {
   margin-right: 30px;
   display: inline-block;

--- a/src/components/common/PermissionBlock/components/index.js
+++ b/src/components/common/PermissionBlock/components/index.js
@@ -1,14 +1,12 @@
-import React, { useCallback } from 'react';
+import React, { useState } from 'react';
 import cn from 'classnames';
 import { Link } from 'react-router-dom';
 import { useFacebookLogin, useGoogleLogin } from 'hooks/login';
-import { useToken } from 'hooks/auth';
+import useHandleUnlockData from 'hooks/useHandleUnlockData';
 import { Heading, P } from 'common/base';
+import Modal from 'common/Modal';
 import Button from 'common/button/Button';
-import {
-  rewardToApiMap,
-  mainCTAText,
-} from '../../../../constants/taskAndReward';
+import { mainCTAText } from '../../../../constants/taskAndReward';
 
 import styles from '../PermissionBlock.module.css';
 
@@ -76,13 +74,8 @@ export const CallToDoTask = ({ task, to }) => {
 };
 
 export const CallToUnlock = ({ reward, dataId }) => {
-  const token = useToken();
-  const handleUnlock = useCallback(async () => {
-    if (reward) {
-      const api = rewardToApiMap[reward.id];
-      await api({ token, id: dataId });
-    }
-  }, [dataId, reward, token]);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
+  const handleUnlockData = useHandleUnlockData({ reward, dataId });
   if (reward) {
     return (
       <div>
@@ -94,11 +87,30 @@ export const CallToUnlock = ({ reward, dataId }) => {
             Button
             btnStyle="black"
             circleSize="md"
-            onClick={handleUnlock}
+            onClick={() => setModalIsOpen(true)}
           >
             解鎖
           </Button>
         </div>
+        <Modal
+          isOpen={modalIsOpen}
+          close={() => setModalIsOpen(false)}
+          hasClose
+          closableOnClickOutside
+          contentClassName={styles.confirmToUnlockModal}
+        >
+          <Heading center size="sm" bold className={styles.heading}>
+            確定要解鎖嗎？ 將使用 {reward.points} 積分兌換
+          </Heading>
+          <Button
+            Button
+            btnStyle="black"
+            circleSize="md"
+            onClick={handleUnlockData}
+          >
+            確定解鎖
+          </Button>
+        </Modal>
       </div>
     );
   }

--- a/src/components/common/PermissionBlock/components/index.js
+++ b/src/components/common/PermissionBlock/components/index.js
@@ -100,8 +100,11 @@ export const CallToUnlock = ({ reward, dataId }) => {
           contentClassName={styles.confirmToUnlockModal}
         >
           <Heading center size="sm" bold className={styles.heading}>
-            確定要解鎖嗎？ 將使用 {reward.points} 積分兌換
+            確定要解鎖嗎？
           </Heading>
+          <P size="m" className={styles.body}>
+            將使用 {reward.points} 積分兌換
+          </P>
           <Button
             Button
             btnStyle="black"

--- a/src/hooks/useHandleUnlockData.js
+++ b/src/hooks/useHandleUnlockData.js
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { useDispatch } from 'react-redux';
+import { useToken } from 'hooks/auth';
+import { fetchMyUnlockedContentsAndPointsIfUnfetched } from '../actions/permission';
+import { rewardToApiMap } from '../constants/taskAndReward';
+
+const useHandleUnlockData = ({ reward, dataId }) => {
+  const token = useToken();
+  const dispatch = useDispatch();
+
+  return useCallback(async () => {
+    if (reward) {
+      const api = rewardToApiMap[reward.id];
+      await api({ token, id: dataId });
+      dispatch(
+        fetchMyUnlockedContentsAndPointsIfUnfetched({ forceFetch: true }),
+      );
+    }
+  }, [dataId, dispatch, reward, token]);
+};
+
+export default useHandleUnlockData;

--- a/src/reducers/permission.js
+++ b/src/reducers/permission.js
@@ -32,5 +32,5 @@ export default createReducer(
         .set('status', status)
         .set('error', error),
   },
-  { resetOnLogOut: false },
+  { resetOnLogOut: true },
 );


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

- 把解鎖的邏輯完成，先打 API 解鎖。然後打 API 更新點數、解鎖的資料。
- 把上述邏輯拉出來變成 hook ，之後薪資工時那邊好重複用
- 修 Loader props 小 bug 
- 用戶登出的時候，把 permission redux store 重置，這樣才會再拿一次點數、解鎖的資料。

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：feat/permission

## Screenshots  <!-- 選填，沒有就刪掉 -->

![kMn4JC0eyn](https://user-images.githubusercontent.com/3805975/100436453-5c088c80-30da-11eb-956b-7047deb213a1.gif)

