### PR TITLE
Get rid of immutable on persist layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "recompose": "^0.30.0",
     "redux": "^4.0.4",
     "redux-persist": "^5.10.0",
-    "redux-persist-transform-immutable": "^5.0.0",
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.1",
     "serialize-javascript": "^3.1.0"

--- a/src/components/App/Header/index.js
+++ b/src/components/App/Header/index.js
@@ -138,7 +138,7 @@ const Header = () => {
                     }
                   >
                     <div className={styles.userNameBtn}>
-                      {user && user.get('name')}
+                      {user && user.name}
                     </div>
                   </PopoverToggle>
                 )}

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,11 +1,9 @@
-import { fromJS } from 'immutable';
-
 import createReducer from 'utils/createReducer';
 import { SET_LOGIN, SET_USER } from '../actions/auth';
 
 import authStatus from '../constants/authStatus';
 
-const preloadedState = fromJS({
+const preloadedState = {
   status: authStatus.UNKNOWN,
   token: null,
   user: {
@@ -13,11 +11,11 @@ const preloadedState = fromJS({
     _id: null,
     email_status: null,
   },
-});
+};
 
 const auth = createReducer(preloadedState, {
-  [SET_LOGIN]: (state, { status, token }) => state.merge({ status, token }),
-  [SET_USER]: (state, { user }) => state.setIn(['user'], fromJS(user)),
+  [SET_LOGIN]: (state, { status, token }) => ({ ...state, status, token }),
+  [SET_USER]: (state, { user }) => ({ ...state, user }),
 });
 
 export default auth;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,7 +1,6 @@
 import { combineReducers } from 'redux';
 import { persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
-import immutableTransform from 'redux-persist-transform-immutable';
 
 import auth from './auth';
 import experienceDetail from './experienceDetail';
@@ -28,7 +27,6 @@ const persistConfig = {
   key: PERSIST_KEY,
   storage,
   whitelist: ['auth'],
-  transforms: [immutableTransform()],
 };
 
 const rootReducer = combineReducers({

--- a/src/selectors/authSelector.js
+++ b/src/selectors/authSelector.js
@@ -1,11 +1,12 @@
+import { path } from 'ramda';
+
 import AUTH_STATUS from '../constants/authStatus';
 
-export const statusSelector = state => state.auth.get('status');
-export const tokenSelector = state => state.auth.get('token');
-export const userSelector = state => state.auth.get('user');
-export const getUserName = state => state.auth.getIn(['user', 'name']);
-export const getUserEmail = state => state.auth.getIn(['user', 'email']);
-export const getUserEmailStatus = state =>
-  state.auth.getIn(['user', 'email_status']);
+export const statusSelector = state => state.auth.status;
+export const tokenSelector = state => state.auth.token;
+export const userSelector = state => state.auth.user;
+export const getUserName = path(['auth', 'user', 'name']);
+export const getUserEmail = path(['auth', 'user', 'email']);
+export const getUserEmailStatus = path(['auth', 'user', 'email_status']);
 export const isLoggedInSelector = state =>
   statusSelector(state) === AUTH_STATUS.CONNECTED;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6237,11 +6237,6 @@ js-yaml@~3.7.0:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-jsan@^3.1.13:
-  version "3.1.13"
-  resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.13.tgz#4de8c7bf8d1cfcd020c313d438f930cec4b91d86"
-  integrity sha512-9kGpCsGHifmw6oJet+y8HaCl14y7qgAsxVdV3pCHDySNR3BfDC30zgkssd7x5LRVAT22dnpbe9JdzzmXZnq9/g==
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -9392,13 +9387,6 @@ redux-logger@^2.7.4:
   dependencies:
     deep-diff "0.3.4"
 
-redux-persist-transform-immutable@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/redux-persist-transform-immutable/-/redux-persist-transform-immutable-5.0.0.tgz#0ae277b4d8d662016f62af394df2572525ad6671"
-  integrity sha512-Gf7pNqHIVrCM459BzyqT25A8+8/PP6ce57kXY+PEgYnWn8jQRCAZaSNxw7T1eqKGXrJfICnMQ39RwehvMqlJMg==
-  dependencies:
-    remotedev-serialize "^0.1.0"
-
 redux-persist@^5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-5.10.0.tgz#5d8d802c5571e55924efc1c3a9b23575283be62b"
@@ -9550,13 +9538,6 @@ remark@^10.0.1:
     remark-parse "^6.0.0"
     remark-stringify "^6.0.0"
     unified "^7.0.0"
-
-remotedev-serialize@^0.1.0:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.8.tgz#c99cb184e7f71a906162abc404be8ce33810205f"
-  integrity sha512-3YG/FDcOmiK22bl5oMRM8RRnbGrFEuPGjbcDG+z2xi5aQaNQNZ8lqoRnZTwXVfaZtutXuiAQOgPRrogzQk8edg==
-  dependencies:
-    jsan "^3.1.13"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->
為了接下來的redirect 功能做點準備，該功能會有些資訊需要存進local storage 。由於redux-persist 我之前在設定時會涉入immutable transform ，想說既然新的不會再使用immutable 了，在redux persist 這層就開始斷開，所以把既有的會被persist 的"auth" 開始斷開immutable 

<!-- 請簡單說明這個 PR 做了什麼 -->

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Front-end PR：<!-- 這個 PR 需要先等其它前端 PR merge 之後才能 merge -->
- Back-end PR：<!-- 這個 PR 需要 checkout 這個 back-end 才能 work -->

## Screenshots  <!-- 選填，沒有就刪掉 -->

<!-- 可以的話，請提供畫面截圖，如果是 GIF 的話更好 -->

## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

<!-- 如果有 Paper、InVision 或使用的 3rd-party library or service，請附上文件連結 -->

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

<!-- 這個 PR 要怎麼 review 才會比較好懂 (e.g. by commit 看，或先看哪些檔案) -->
<!-- 介紹一下你為什麼要這麼寫，思路是什麼？ -->
脈絡是從 `src/reducers/index.js` 開始拿掉redux-persist config 中的transformer，一路到相對應的auth store 的reducer, selector 都de-immutable

## Questions:  <!-- 選填，沒有就刪掉 -->

- 我需要更新 Packages 嗎？ No <!-- Yes / No -->
- 有哪些文件需要被更新嗎？ No <!-- 文件的連結 -->

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] <!-- 提供一些前置作業需要輸入的指令 -->
- [ ] <!-- 提供一個 Demo URL Link -->
- [ ] <!-- 列出給 Reviewer 的 Step By Step Checklist -->