### PR TITLE
Fix: 面試經驗表單 footer 資料數量錯誤

### DIFF
--- a/src/components/ShareExperience/InterviewForm/TypeForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/TypeForm/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, Fragment, useState } from 'react';
+import React, { useCallback, Fragment, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
   isNil,
@@ -18,7 +18,7 @@ import {
   reject,
   path,
 } from 'ramda';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import ReactGA from 'react-ga';
 import ReactPixel from 'react-facebook-pixel';
@@ -31,7 +31,15 @@ import Header, { CompanyJobTitleHeader } from '../../common/TypeFormHeader';
 import Footer from '../../common/TypeFormFooter';
 import { getCompaniesSearch } from '../../../../apis/companySearchApi';
 import { getJobTitlesSearch } from '../../../../apis/jobTitleSearchApi';
-import { createInterviewExperience } from '../../../../actions/experiences';
+import {
+  experienceCountSelector,
+  timeAndSalaryCountSelector,
+} from '../../../../selectors/countSelector';
+import {
+  createInterviewExperience,
+  queryExperienceCountIfUnfetched,
+} from '../../../../actions/experiences';
+import { queryTimeAndSalaryCountIfUnfetched } from '../../../../actions/timeAndSalary';
 import { GA_CATEGORY, GA_ACTION } from '../../../../constants/gaConstants';
 import PIXEL_CONTENT_CATEGORY from '../../../../constants/pixelConstants';
 import {
@@ -78,7 +86,6 @@ const renderCompanyJobTitleHeader = ({ companyName, jobTitle }) => (
     jobTitle={jobTitle}
   />
 );
-const footer = <Footer />;
 
 const questions = [
   {
@@ -382,6 +389,13 @@ const TypeForm = ({ open, onClose }) => {
     [dispatch, submitStatus],
   );
 
+  const experienceCount = useSelector(experienceCountSelector);
+  const salaryCount = useSelector(timeAndSalaryCountSelector);
+  useEffect(() => {
+    dispatch(queryExperienceCountIfUnfetched());
+    dispatch(queryTimeAndSalaryCountIfUnfetched());
+  }, [dispatch]);
+
   return (
     <Fragment>
       <FormBuilder
@@ -389,7 +403,7 @@ const TypeForm = ({ open, onClose }) => {
         onClose={() => setSubmitStatus('quitting')}
         questions={questions}
         header={header}
-        footer={footer}
+        footer={<Footer dataNum={salaryCount + experienceCount} />}
         onSubmit={handleSubmit}
       />
       <ConfirmModal

--- a/src/components/ShareExperience/common/TypeFormFooter.js
+++ b/src/components/ShareExperience/common/TypeFormFooter.js
@@ -1,9 +1,22 @@
 import React from 'react';
 import styles from './TypeFormFooter.module.css';
 
-const TypeFormFooter = () => (
+const getNumberNext = dataNum => {
+  if (dataNum > 10000) {
+    return ` ${Math.floor(dataNum / 10000)} 萬多筆`;
+  } else if (dataNum > 1000) {
+    return ` ${Math.floor(dataNum / 1000)} 千多筆`;
+  } else if (dataNum > 0) {
+    return ` ${dataNum} 筆`;
+  } else {
+    return '';
+  }
+};
+
+const TypeFormFooter = ({ dataNum }) => (
   <div className={styles.footer}>
-    完成可解鎖全站 2 萬筆資訊 <span className={styles.unlockDuration}></span>
+    完成可解鎖全站{getNumberNext(dataNum)}資訊{' '}
+    <span className={styles.unlockDuration}></span>
   </div>
 );
 


### PR DESCRIPTION
Close #1030 

## 這個 PR 是？ <!-- 必填 -->

- fix #1030 ，讓面試經驗表單 footer 拿 backend 回傳的資料數量

## Screenshots  <!-- 選填，沒有就刪掉 -->
<img width="363" alt="Screen Shot 2022-11-20 at 12 34 50 AM" src="https://user-images.githubusercontent.com/3805975/202861554-ab593106-784c-4719-ba2b-2b32e35921af.png">

<img width="498" alt="Screen Shot 2022-11-20 at 12 34 29 AM" src="https://user-images.githubusercontent.com/3805975/202861551-e1e5b2d8-0404-4261-bd9e-51b5a38bed0d.png">
<img width="364" alt="Screen Shot 2022-11-20 at 12 34 35 AM" src="https://user-images.githubusercontent.com/3805975/202861552-77b364a4-923d-4b74-bc5b-c893d71c2b38.png">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start
- [ ] enter http://localhost:3000/share