### PR TITLE
[付款頁面] 後端回傳錯誤時切換到錯誤訊息頁面

### DIFF
--- a/src/apis/payment.js
+++ b/src/apis/payment.js
@@ -33,9 +33,9 @@ export const checkoutSubscriptionWithPrime = ({
       checkoutSubscriptionWithPrime: {
         paymentRecord: { id },
         paymentUrl,
-        error: { message } = {},
+        error,
       },
-    }) => [message, id, paymentUrl],
+    }) => [error ? error.message : null, id, paymentUrl],
   );
 
 const getPaymentRecord = token => paymentRecordId =>

--- a/src/apis/payment.js
+++ b/src/apis/payment.js
@@ -28,7 +28,15 @@ export const checkoutSubscriptionWithPrime = ({
       },
     },
     token,
-  }).then(({ checkoutSubscriptionWithPrime: { paymentUrl } }) => paymentUrl);
+  }).then(
+    ({
+      checkoutSubscriptionWithPrime: {
+        paymentRecord: { id },
+        paymentUrl,
+        error: { message },
+      },
+    }) => [message, id, paymentUrl],
+  );
 
 const getPaymentRecord = token => paymentRecordId =>
   graphqlClient({

--- a/src/apis/payment.js
+++ b/src/apis/payment.js
@@ -33,7 +33,7 @@ export const checkoutSubscriptionWithPrime = ({
       checkoutSubscriptionWithPrime: {
         paymentRecord: { id },
         paymentUrl,
-        error: { message },
+        error: { message } = {},
       },
     }) => [message, id, paymentUrl],
   );

--- a/src/components/Buy/PaymentSection/useForm.js
+++ b/src/components/Buy/PaymentSection/useForm.js
@@ -2,6 +2,8 @@ import { useCallback, useState } from 'react';
 import { useToken } from 'hooks/auth';
 import useTapPay from './useTapPay';
 import { checkoutSubscriptionWithPrime } from '../../../apis/payment';
+import usePushToast from 'hooks/toastNotification/usePushToast';
+import { NOTIFICATION_TYPE } from 'constants/toastNotification';
 
 const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
   const [activeCardType, setActiveCardType] = useState('unknown');
@@ -11,6 +13,8 @@ const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
     setActiveCardType(update.cardType);
     setCanGetPrime(update.canGetPrime);
   }, []);
+
+  const pushToast = usePushToast();
 
   const token = useToken();
   const handlePrime = useCallback(
@@ -24,11 +28,10 @@ const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
         });
         window.location = paymentUrl;
       } catch (error) {
-        // TODO: Error handling
-        console.error(error);
+        pushToast(NOTIFICATION_TYPE.ALERT, '發生未知錯誤。');
       }
     },
-    [isPrimary, skuId, token],
+    [isPrimary, pushToast, skuId, token],
   );
 
   const submit = useTapPay({

--- a/src/components/Buy/PaymentSection/useForm.js
+++ b/src/components/Buy/PaymentSection/useForm.js
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { useHistory } from 'react-router';
 import { useToken } from 'hooks/auth';
 import useTapPay from './useTapPay';
 import { checkoutSubscriptionWithPrime } from '../../../apis/payment';
@@ -15,23 +16,33 @@ const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
   }, []);
 
   const pushToast = usePushToast();
+  const history = useHistory();
 
   const token = useToken();
   const handlePrime = useCallback(
     async prime => {
       try {
-        const paymentUrl = await checkoutSubscriptionWithPrime({
+        const [
+          error,
+          paymentId,
+          paymentUrl,
+        ] = await checkoutSubscriptionWithPrime({
           token,
           prime,
           skuId,
           isPrimary,
         });
+        if (error) {
+          // Some error arises.
+          history.push(`/buy/result/${paymentId}`);
+          return;
+        }
         window.location = paymentUrl;
       } catch (error) {
         pushToast(NOTIFICATION_TYPE.ALERT, '發生未知錯誤。');
       }
     },
-    [isPrimary, pushToast, skuId, token],
+    [history, isPrimary, pushToast, skuId, token],
   );
 
   const submit = useTapPay({

--- a/src/components/Buy/PaymentSection/useForm.js
+++ b/src/components/Buy/PaymentSection/useForm.js
@@ -40,6 +40,7 @@ const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
         window.location = paymentUrl;
       } catch (error) {
         pushToast(NOTIFICATION_TYPE.ALERT, '發生未知錯誤。');
+        console.error(error);
       }
     },
     [history, isPrimary, pushToast, skuId, token],

--- a/src/components/Buy/PaymentSection/useForm.js
+++ b/src/components/Buy/PaymentSection/useForm.js
@@ -23,7 +23,7 @@ const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
     async prime => {
       try {
         const [
-          error,
+          errorMessage,
           paymentId,
           paymentUrl,
         ] = await checkoutSubscriptionWithPrime({
@@ -32,7 +32,7 @@ const useForm = ({ tapPayCard, loadTapPayCard, skuId, isPrimary }) => {
           skuId,
           isPrimary,
         });
-        if (error) {
+        if (errorMessage) {
           // Some error arises.
           history.push(`/buy/result/${paymentId}`);
           return;

--- a/src/components/common/icons/CloseNoCircle.js
+++ b/src/components/common/icons/CloseNoCircle.js
@@ -10,8 +10,8 @@ const CloseNoCircle = props => (
     {...props}
   >
     <title>x</title>
-    <g id="icons" stroke="none" stroke-width="1" fill-rule="evenodd">
-      <g id="x" fill-rule="nonzero">
+    <g id="icons" stroke="none" strokeWidth="1" fillRule="evenodd">
+      <g id="x" fillRule="nonzero">
         <path
           d={`M145.29003,2.7097656 C143.570709,0.975547058 141.229771,1.49332653e-16 138.787634,
 0 C136.345497,-1.50064675e-16 134.004559,0.975547058 132.285237,2.7097656 L74,60.9906013 L15.7147626,

--- a/src/graphql/payment.js
+++ b/src/graphql/payment.js
@@ -1,7 +1,13 @@
 export const checkoutSubscriptionWithPrimeMutation = `
   mutation($input: CheckoutSubscriptionWithPrimeInput!) {
     checkoutSubscriptionWithPrime(input: $input) {
+      paymentRecord {
+        id
+      }
       paymentUrl
+      error {
+        message
+      }
     }
   }
 `;


### PR DESCRIPTION
Close #1066

## 這個 PR 是？ <!-- 必填 -->

後端回傳錯誤訊息時，切換到錯誤訊息頁面

## Dependency

- 後端 PR - https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/839


## 我應該如何手動測試？ <!-- 必填 -->

http://localhost:3000/buy
輸入TapPay提供的[錯誤card number](https://docs.tappaysdk.com/tutorial/zh/reference.html#what-is-it234)，應該要能看到切換至錯誤頁面