### PR TITLE
Fix toast css

### DIFF
--- a/src/components/ToastNotification/Notification.module.css
+++ b/src/components/ToastNotification/Notification.module.css
@@ -7,7 +7,7 @@
   display: flex;
   position: absolute;
   top: 0;
-  right: calc(50% - mobile_width / 2);
+  right: calc(50vw - mobile_width / 2);
   border-radius: 4px;
   padding: 0 16px 0 40px;
   box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.3);

--- a/src/components/ToastNotification/ToastNotification.module.css
+++ b/src/components/ToastNotification/ToastNotification.module.css
@@ -5,7 +5,6 @@
   position: fixed;
   top: calc(NAV_MOBILE_HEIGHT);
   right: 0;
-  width: 100%;
 
   padding-right: 0;
   padding-top: 30px;


### PR DESCRIPTION
Close #1086  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

原本的 toast container 寬100%會擋住底下的元件
此PR修正 toast container 只會照 toast 寬。

## Screenshots  <!-- 選填，沒有就刪掉 -->

![螢幕快照 2023-05-03 下午8 34 32](https://user-images.githubusercontent.com/7566586/235917845-e8cfe473-f59c-48a9-8d19-2af6506564e4.png)
![Screenshot 2023-05-03 at 20-33-48 GoodJob 職場透明化運動](https://user-images.githubusercontent.com/7566586/235917866-8260e53b-b9af-48d4-994b-a75ad6445444.png)


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 在 http://localhost:3000/ 並套用以下 diff 讓 toast 出現在首頁

```diff
diff --git a/src/components/LandingPage/index.js b/src/components/LandingPage/index.js
index cf4feec3..6a10fac5 100644
--- a/src/components/LandingPage/index.js
+++ b/src/components/LandingPage/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import ImmutablePropTypes from 'react-immutable-proptypes';
@@ -15,6 +15,7 @@ import StaticHelmet from 'common/StaticHelmet';
 import CallToActionBlock from './CallToActionBlock';
 import SummarySection from './SummarySection';
 import { isUnfetched } from '../../constants/status';
+import usePushToast from 'hooks/toastNotification/usePushToast';
 
 const ssr = setStatic('fetchData', ({ store: { dispatch } }) => {
   return Promise.all([
@@ -53,6 +54,12 @@ const LandingPage = ({
     coverUrl,
     title,
   }));
+
+  const pushToast = usePushToast();
+  useEffect(() => {
+    pushToast("", "hihi");
+  }, []);
+
   return (
     <main>
       <StaticHelmet.LandingPage />
diff --git a/src/components/ToastNotification/Notification.js b/src/components/ToastNotification/Notification.js
index 8c5fdc1e..fe3db4cf 100644
--- a/src/components/ToastNotification/Notification.js
+++ b/src/components/ToastNotification/Notification.js
@@ -39,7 +39,7 @@ const Notification = ({ index, type, content, id }) => {
     }
   }, [status, removeNotification, id]);
 
-  useTimer(toSunset, FADE_OUT_TIME, countingStatusMap.counting);
+  // useTimer(toSunset, FADE_OUT_TIME, countingStatusMap.counting);
 
   const offsetY = `${calOffsetY(index)}px`;
   const opacity = status === statusMap.ACTIVE ? 100 : 0;
```