### PR TITLE
[付款頁面] 使用現有元件

### DIFF
--- a/src/components/Buy/SubscriptionsSection/SubscriptionPlan.js
+++ b/src/components/Buy/SubscriptionsSection/SubscriptionPlan.js
@@ -1,47 +1,43 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { P } from 'common/base';
-import RoundCard from 'common/RoundCard';
-import { formatSalaryType } from 'common/formatter';
+import cn from 'classnames';
+import PlanCard from '../../PlanPage/PlanCard';
 import styles from './SubscriptionsSection.module.css';
+import { subscriptionTypes } from 'constants/subscription';
 
 const SubscriptionPlan = ({
   className,
   title,
+  description,
   amount,
-  duration,
+  type,
   active,
   onChange,
 }) => (
-  <label className={className}>
+  <label className={cn(styles.card, className)}>
     <input
       name="plan"
       type="radio"
       style={{ display: 'none' }}
       onChange={onChange}
     ></input>
-    <RoundCard className={styles.content} checked={active}>
-      <P className={styles.title} size="l" bold>
-        {title}
-      </P>
-      <P className={styles.subtitle} size="l">
-        解鎖全站 {duration.amount} 個{formatSalaryType(duration.type)}
-      </P>
-      <P bold>
-        <span className={styles.price}>{amount}</span>元
-      </P>
-    </RoundCard>
+    <PlanCard
+      title={title}
+      description={description}
+      amount={amount}
+      type={type}
+      hideCta
+      checked={active}
+    />
   </label>
 );
 
 SubscriptionPlan.propTypes = {
   className: PropTypes.string,
   title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
   amount: PropTypes.number.isRequired,
-  duration: PropTypes.shape({
-    amount: PropTypes.number.isRequired,
-    type: PropTypes.string.isRequired,
-  }).isRequired,
+  type: PropTypes.oneOf(subscriptionTypes).isRequired,
   active: PropTypes.bool.isRequired,
   onChange: PropTypes.func.isRequired,
 };

--- a/src/components/Buy/SubscriptionsSection/SubscriptionPlan.js
+++ b/src/components/Buy/SubscriptionsSection/SubscriptionPlan.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cn from 'classnames';
 import PlanCard from '../../PlanPage/PlanCard';
-import styles from './SubscriptionsSection.module.css';
 import { subscriptionTypes } from 'constants/subscription';
 
 const SubscriptionPlan = ({
@@ -14,7 +12,7 @@ const SubscriptionPlan = ({
   active,
   onChange,
 }) => (
-  <label className={cn(styles.card, className)}>
+  <label className={className}>
     <input
       name="plan"
       type="radio"

--- a/src/components/Buy/SubscriptionsSection/SubscriptionPlanCollection.js
+++ b/src/components/Buy/SubscriptionsSection/SubscriptionPlanCollection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './SubscriptionsSection.module.css';
 import SubscriptionPlan from './SubscriptionPlan';
+import { subscriptionTypes } from 'constants/subscription';
 
 const SubscriptionPlanCollection = ({ plans, selectedId, setSelectedId }) => (
   <div className={styles.plans}>
@@ -10,10 +11,11 @@ const SubscriptionPlanCollection = ({ plans, selectedId, setSelectedId }) => (
         key={plan.skuId}
         className={styles.plan}
         title={plan.title}
+        description={plan.description}
         amount={plan.amount}
-        duration={plan.duration}
+        type={plan.type}
         active={selectedId === plan.skuId}
-        onChange={e => e.target.checked && setSelectedId(plan.id)}
+        onChange={e => e.target.checked && setSelectedId(plan.skuId)}
       />
     ))}
   </div>
@@ -24,11 +26,9 @@ SubscriptionPlanCollection.propTypes = {
     PropTypes.shape({
       skuId: PropTypes.string.isRequired,
       title: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
       amount: PropTypes.number.isRequired,
-      duration: PropTypes.shape({
-        amount: PropTypes.number.isRequired,
-        type: PropTypes.string.isRequired,
-      }).isRequired,
+      type: PropTypes.oneOf(subscriptionTypes).isRequired,
     }),
   ),
   selectedId: PropTypes.string,

--- a/src/components/Buy/SubscriptionsSection/SubscriptionsSection.module.css
+++ b/src/components/Buy/SubscriptionsSection/SubscriptionsSection.module.css
@@ -25,6 +25,10 @@
   }
 }
 
+.plan {
+  cursor: pointer;
+}
+
 .content {
   padding: 26px 78px;
   display: flex;
@@ -46,8 +50,4 @@
     font-size: 56px;
     margin-right: 10px;
   }
-}
-
-.card {
-  cursor: pointer;
 }

--- a/src/components/Buy/SubscriptionsSection/SubscriptionsSection.module.css
+++ b/src/components/Buy/SubscriptionsSection/SubscriptionsSection.module.css
@@ -14,8 +14,6 @@
   }
 
   .plan {
-    flex: 1;
-
     + .plan {
       margin-left: 24px;
 
@@ -48,4 +46,8 @@
     font-size: 56px;
     margin-right: 10px;
   }
+}
+
+.card {
+  cursor: pointer;
 }

--- a/src/components/PlanPage/PlanCard.js
+++ b/src/components/PlanPage/PlanCard.js
@@ -19,7 +19,15 @@ const getButtonType = type => {
   return 'hollowRed';
 };
 
-const PlanCard = ({ title, description, amount, type, skuId, hideCta }) => {
+const PlanCard = ({
+  title,
+  description,
+  amount,
+  type,
+  skuId,
+  hideCta,
+  checked,
+}) => {
   const actionTitle = getActionTitle(type);
 
   const { toBuy, actionUrl } = useToBuy('/', skuId);
@@ -36,7 +44,7 @@ const PlanCard = ({ title, description, amount, type, skuId, hideCta }) => {
   const linkUrl = isSubmitData ? '/share' : actionUrl;
 
   return (
-    <RoundCard className={styles.container}>
+    <RoundCard className={styles.container} checked={checked}>
       <div className={styles.content}>
         <div className={styles.topArea}>
           <Heading Tag="h3" size="sm" className={styles.title} bold>
@@ -84,6 +92,7 @@ PlanCard.propTypes = {
   amount: PropTypes.number,
   skuId: PropTypes.string,
   hideCta: PropTypes.bool,
+  checked: PropTypes.bool.isRequired,
 };
 
 PlanCard.defaultProps = {
@@ -92,6 +101,7 @@ PlanCard.defaultProps = {
   amount: 0,
   skuId: '',
   hideCta: false,
+  checked: false,
 };
 
 export default PlanCard;

--- a/src/components/PlanPage/PlanCard.module.css
+++ b/src/components/PlanPage/PlanCard.module.css
@@ -1,9 +1,12 @@
-@value above-tablet, main-gray, yellow-dark from "common/variables.module.css";
+@value above-tablet, above-small, main-gray, yellow-dark from "common/variables.module.css";
 
 .container {
   min-height: 300px;
-  width: 300px;
   padding: 26px 0;
+
+  @media (min-width: above-small) {
+    width: 300px;
+  }
 }
 
 .content {

--- a/src/constants/subscription.js
+++ b/src/constants/subscription.js
@@ -1,4 +1,8 @@
+import { values } from 'ramda';
+
 export const subscriptionType = {
   submitData: 'SubmitData',
   buySubscription: 'BuySubscription',
 };
+
+export const subscriptionTypes = values(subscriptionType);


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

原本付款頁面的卡片使用了 flex 延伸了寬度。
這個 PR 將付款頁面的卡片，以我的方案頁面的 PlanCard 取代，除了不會有奇怪的寬度之外，也可以統一復用元件。

## Screenshots  <!-- 選填，沒有就刪掉 -->

|Before|After|
|-|-|
|![Screenshot 2023-05-17 at 8 44 52 PM](https://github.com/goodjoblife/GoodJobShare/assets/7566586/ee869f8f-bcf4-418c-8e25-2eb3ff690437)|![Screenshot 2023-05-17 at 11 15 06 PM](https://github.com/goodjoblife/GoodJobShare/assets/7566586/52a6d437-2274-47e1-a485-02a4e96cf96e)|






## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/buy?skuId=plan_30_days
