### PR TITLE
fix: displayed subscriptionPlan

### DIFF
--- a/src/components/PlanPage/index.js
+++ b/src/components/PlanPage/index.js
@@ -1,11 +1,13 @@
 import React, { useEffect } from 'react';
 import { setStatic } from 'recompose';
 import { useDispatch } from 'react-redux';
+import R from 'ramda';
 
 import Heading from 'common/base/Heading';
 import { useSubscriptionPlans } from 'hooks/payment/usePayment';
 import { isUnfetched, isFetched } from 'utils/fetchBox';
 import Loading from 'common/Loader';
+import { subscriptionType } from 'constants/subscription';
 
 import { fetchSubscriptionPlans } from '../../actions/payment';
 import styles from './PlanPage.module.css';
@@ -34,9 +36,8 @@ const PlanPage = () => {
 
   let plans = subscriptionPlansBox.data;
   if (Array.isArray(plans)) {
-    plans = plans.filter(plan =>
-      ['BuySubscription', 'SubmitData'].includes(plan.type),
-    );
+    const planTypes = R.values(subscriptionType);
+    plans = plans.filter(plan => planTypes.includes(plan.type));
   }
 
   return (

--- a/src/components/PlanPage/index.js
+++ b/src/components/PlanPage/index.js
@@ -32,7 +32,12 @@ const PlanPage = () => {
     return <Loading size="l" />;
   }
 
-  const plans = subscriptionPlansBox.data;
+  let plans = subscriptionPlansBox.data;
+  if (Array.isArray(plans)) {
+    plans = plans.filter(plan =>
+      ['BuySubscription', 'SubmitData'].includes(plan.type),
+    );
+  }
 
   return (
     <div className={styles.container}>


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

因為新增給早期使用者的 subscriptionPlan，UI 上顯示會多一個，這邊把它過濾掉

## Screenshots  <!-- 選填，沒有就刪掉 -->
old:
<img width="1054" alt="Screenshot 2023-06-02 at 7 32 50 PM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/494bdae0-1d9c-4936-95ba-e20f6e84d9d3">


new:
<img width="1032" alt="Screenshot 2023-06-02 at 7 31 12 PM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/baadcb0d-2850-46e8-a19f-d79afa3528e7">

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start & enter `/plans` page
- [ ] <!-- 提供一個 Demo URL Link -->
- [ ] <!-- 列出給 Reviewer 的 Step By Step Checklist -->