### PR TITLE
[面試經驗表單] 錯誤訊息移除Graphql詞綴

### DIFF
--- a/src/utils/errors/graphqlError.js
+++ b/src/utils/errors/graphqlError.js
@@ -10,7 +10,7 @@ const mapErrorPaths = R.map(R.prop('path'));
 
 class GraphqlError extends Error {
   constructor(errors) {
-    const message = `GraphqlError: ${mapErrorMessages(errors)}`;
+    const message = mapErrorMessages(errors);
     super(message);
 
     this.name = 'GraphqlError';


### PR DESCRIPTION
#1119

## 這個 PR 是？ <!-- 必填 -->

~~這個PR在後端回傳422時顯示toast~~
~~只做面試經驗的部分~~

~~至於工作經驗，因為尚未 migrate to hooks 所以需要另開PR做~~

更新：修正為只從錯誤訊息移除 Graphql 詞綴


## 我應該如何手動測試？ <!-- 必填 -->

需要重現「留過多資料」的情境 (*需要容易測試的方法*)
在 http://localhost:3000/share 面試經驗送出資料時應失敗，並見到 toast