### PR TITLE
fix: 訂單確認頁面文字 highlight

### DIFF
--- a/src/components/BuyResultPage/PaymentResult/InProgress.js
+++ b/src/components/BuyResultPage/PaymentResult/InProgress.js
@@ -52,9 +52,14 @@ const InProgress = ({ paymentRecordId, fetchingStatus }) => {
     <div className={styles.content}>
       <img className={styles.icon} src={TransactionIcon} alt="in progress" />
       <P className={styles.description}>
-        {isTimerEnabled
-          ? `交易確認中，請勿離開，至多 ${countdown} 秒...`
-          : `請稍待再重新整理`}
+        {isTimerEnabled ? (
+          <span>
+            交易確認中，<span className={styles.alert}>請勿關閉此頁面</span>
+            ，至多 {countdown} 秒...
+          </span>
+        ) : (
+          `請稍待再重新整理`
+        )}
       </P>
     </div>
   );

--- a/src/components/BuyResultPage/PaymentResult/InProgress.js
+++ b/src/components/BuyResultPage/PaymentResult/InProgress.js
@@ -54,7 +54,7 @@ const InProgress = ({ paymentRecordId, fetchingStatus }) => {
       <P className={styles.description}>
         {isTimerEnabled ? (
           <span>
-            交易確認中，<span className={styles.alert}>請勿關閉此頁面</span>
+            交易確認中，<span className={styles.alert}>請勿離開此頁面</span>
             ，至多 {countdown} 秒...
           </span>
         ) : (

--- a/src/components/BuyResultPage/PaymentResult/PaymentResult.module.css
+++ b/src/components/BuyResultPage/PaymentResult/PaymentResult.module.css
@@ -26,3 +26,7 @@
 .action {
   margin-top: 24px;
 }
+
+.alert {
+  color: #ed0d5e;
+}


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

更加提醒使用者，在訂單確認頁，不要直接離開。減少 paymentRecord 卡在 pending authorization 的情況

## Screenshots  <!-- 選填，沒有就刪掉 -->

原本：
<img width="646" alt="Screenshot 2023-08-20 at 11 32 10 AM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/7b21a2e7-f0be-4e69-ac88-23c814f67a7b">


修改後：
<img width="623" alt="Screenshot 2023-08-20 at 11 32 57 AM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/b4b899cb-6f49-454f-84d6-c5d68cf647df">


