### PR TITLE
refactor: import experience page speed

### DIFF
--- a/src/actions/experience.js
+++ b/src/actions/experience.js
@@ -16,8 +16,6 @@ export const queryRelatedExperiencesOnExperience = experienceId => async (
 ) => {
   const page = 0;
 
-  // 判斷 isFetching
-
   dispatch(
     setRelatedExperiencesState(
       // this is an work around

--- a/src/actions/experience.js
+++ b/src/actions/experience.js
@@ -1,0 +1,59 @@
+import { getError, getFetched, toFetching } from 'utils/fetchBox';
+import { relatedExperiencesStateSelector } from 'selectors/experienceSelector';
+
+export const SET_RELATED_EXPERIENCES = '@@EXPERIENCE/SET_RELATED_EXPERIENCES';
+
+const setRelatedExperiencesState = relatedExperiencesState => ({
+  type: SET_RELATED_EXPERIENCES,
+  relatedExperiencesState,
+});
+
+export const queryRelatedExperiencesOnExperience = experienceId => async (
+  dispatch,
+  getState,
+  { api },
+) => {
+  const page = 0;
+
+  // 判斷 isFetching
+
+  dispatch(
+    setRelatedExperiencesState(
+      // this is an work around
+      toFetching({
+        data: {
+          experienceId,
+          page,
+          relatedExperiences: [],
+        },
+      }),
+    ),
+  );
+
+  try {
+    const relatedExperiences = await api.experiences.queryRelatedExperiences({
+      id: experienceId,
+      start: page * 10,
+      limit: 10,
+    });
+
+    const previousState = relatedExperiencesStateSelector(getState()); // FetchBox
+
+    if (
+      experienceId === previousState.data.experienceId &&
+      page === previousState.data.page
+    ) {
+      dispatch(
+        setRelatedExperiencesState(
+          getFetched({
+            experienceId,
+            page,
+            relatedExperiences,
+          }),
+        ),
+      );
+    }
+  } catch (error) {
+    dispatch(setRelatedExperiencesState(getError(error)));
+  }
+};

--- a/src/actions/experience.js
+++ b/src/actions/experience.js
@@ -69,7 +69,7 @@ export const loadMoreRelatedExperiences = () => async (
   const state = relatedExperiencesStateSelector(getState()); // FetchBox
 
   // 判斷 isFetching
-  if (isFetching(relatedExperiencesStateSelector(getState()))) {
+  if (isFetching(state)) {
     return;
   }
 

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -3,7 +3,10 @@ import R from 'ramda';
 import fetchUtil from 'utils/fetchUtil';
 
 import graphqlClient from 'utils/graphqlClient';
-import { getExperienceQuery } from 'graphql/experience';
+import {
+  getExperienceQuery,
+  queryRelatedExperiencesGql,
+} from 'graphql/experience';
 import { getPopularExperiencesQuery } from 'graphql/popularExperience';
 import { deleteReplyLike, createReplyLike } from 'graphql/reply';
 
@@ -120,6 +123,14 @@ const patchExperience = ({ id, status, token }) =>
     token,
   });
 
+export const queryRelatedExperiences = async ({ id, start, limit }) => {
+  const data = await graphqlClient({
+    query: queryRelatedExperiencesGql,
+    variables: { id, start, limit },
+  });
+  return data.experience.relatedExperiences;
+};
+
 export default {
   getExperience,
   getPopularExperiences,
@@ -134,4 +145,5 @@ export default {
   newExperienceSearchBy,
   patchExperience,
   patchReply,
+  queryRelatedExperiences,
 };

--- a/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
+++ b/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import InterviewExperienceEntry from '../../CompanyAndJobTitle/InterviewExperiences/ExperienceEntry';
@@ -48,6 +48,10 @@ const MoreExperiencesBlock = ({ experience }) => {
   const location = useLocation();
   const { state: { pageType = PAGE_TYPE.COMPANY } = {} } = location;
   const [, , canView] = usePermission();
+  const handleLoadMore = useCallback(
+    () => dispatch(loadMoreRelatedExperiences()),
+    [dispatch],
+  );
 
   // we still want to show data even when Fetching
   if (
@@ -78,13 +82,7 @@ const MoreExperiencesBlock = ({ experience }) => {
           canView={canView}
         />
       ))}
-      {hasMore && (
-        <LoadMoreButton
-          onClick={() => {
-            dispatch(loadMoreRelatedExperiences());
-          }}
-        />
-      )}
+      {hasMore && <LoadMoreButton onClick={handleLoadMore} />}
     </div>
   );
 };

--- a/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
+++ b/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
@@ -1,9 +1,12 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useCallback, useMemo, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import InterviewExperienceEntry from '../../CompanyAndJobTitle/InterviewExperiences/ExperienceEntry';
 import WorkExperienceEntry from '../../CompanyAndJobTitle/WorkExperiences/ExperienceEntry';
 import { useLocation } from 'react-router';
 import usePermission from 'hooks/usePermission';
+import { queryRelatedExperiencesOnExperience } from 'actions/experience';
+import { relatedExperiencesStateSelector } from 'selectors/experienceSelector';
 import { pageType as PAGE_TYPE } from '../../../constants/companyJobTitle';
 import Button from '../../common/button/Button';
 import styles from './MoreExperiencesBlock.module.css';
@@ -32,6 +35,16 @@ const LoadMoreButton = ({ children: _, ...props }) => (
 );
 
 const MoreExperiencesBlock = ({ experience }) => {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(queryRelatedExperiencesOnExperience(experience.id));
+  }, [dispatch, experience.id]);
+
+  const relatedExperiencesState = useSelector(relatedExperiencesStateSelector);
+
+  console.log(relatedExperiencesState);
+
   const location = useLocation();
   const { state: { pageType = PAGE_TYPE.COMPANY } = {} } = location;
   const [, , canView] = usePermission();

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -35,8 +35,9 @@ import ReactionZoneOtherOptions from './ReactionZone/ReactionZoneOtherOptions';
 import ReactionZoneStyles from './ReactionZone/ReactionZone.module.css';
 import MoreExperiencesBlock from './MoreExperiencesBlock';
 import ChartsZone from './ChartsZone';
-import { isFetching, isFetched, isError } from '../../constants/status';
-import { fetchExperience } from '../../actions/experienceDetail';
+import { isFetching, isFetched, isError } from 'constants/status';
+import { fetchExperience } from 'actions/experienceDetail';
+import { queryRelatedExperiencesOnExperience } from 'actions/experience';
 import ReportFormContainer from '../../containers/ExperienceDetail/ReportFormContainer';
 import { COMMENT_ZONE } from '../../constants/formElements';
 import {
@@ -318,7 +319,10 @@ ExperienceDetail.propTypes = {
 
 const ssr = setStatic('fetchData', ({ store: { dispatch }, ...props }) => {
   const experienceId = experienceIdSelector(props);
-  return dispatch(fetchExperience(experienceId));
+  return Promise.all([
+    dispatch(fetchExperience(experienceId)),
+    dispatch(queryRelatedExperiencesOnExperience(experienceId)),
+  ]);
 });
 
 const hoc = compose(

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@
  * Default environment for development
  */
 module.exports = {
-  API_HOST: process.env.RAZZLE_API_HOST || 'https://api-dev.goodjob.life',
+  API_HOST: process.env.RAZZLE_API_HOST || 'http://pooh.markchen.space:4000',
   FACEBOOK_APP_ID: process.env.RAZZLE_FACEBOOK_APP_ID || '1844389232511081',
   GA_MEASUREMENT_ID: process.env.RAZZLE_GA_MEASUREMENT_ID || 'G-QDG81J6ESN',
   GOOGLE_APP_ID:

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -2,7 +2,7 @@
  * Default environment for development
  */
 module.exports = {
-  API_HOST: process.env.RAZZLE_API_HOST || 'http://pooh.markchen.space:4000',
+  API_HOST: process.env.RAZZLE_API_HOST || 'https://api-dev.goodjob.life',
   FACEBOOK_APP_ID: process.env.RAZZLE_FACEBOOK_APP_ID || '1844389232511081',
   GA_MEASUREMENT_ID: process.env.RAZZLE_GA_MEASUREMENT_ID || 'G-QDG81J6ESN',
   GOOGLE_APP_ID:

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -170,3 +170,39 @@ mutation CreateWorkExperience($input: CreateWorkExperienceInput!) {
     }
   }
 }`;
+
+export const queryRelatedExperiencesGql = /* GraphQL */ `
+  query($id: ID!, $start: Int!, $limit: Int!) {
+    experience(id: $id) {
+      id
+      relatedExperiences(start: $start, limit: $limit) {
+        id
+        type
+        company {
+          name
+        }
+        job_title {
+          name
+        }
+        created_at
+        salary {
+          type
+          amount
+        }
+        sections {
+          subtitle
+          content
+        }
+
+        ... on InterviewExperience {
+          overall_rating
+        }
+
+        ... on WorkExperience {
+          week_work_time
+          recommend_to_others
+        }
+      }
+    }
+  }
+`;

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -5,47 +5,6 @@ query($id:ID!) {
     type
     company {
       name
-      interview_experiences {
-        id
-        type
-        company {
-          name
-        }
-        job_title {
-          name
-        }
-        created_at
-        salary {
-          type
-          amount
-        }
-        overall_rating
-        sections {
-          subtitle
-          content
-        }
-      }
-      work_experiences {
-        id
-        type
-        company {
-          name
-        }
-        job_title {
-          name
-        }
-        created_at
-        sections {
-          subtitle
-          content
-        }
-        week_work_time
-        salary {
-          type
-          amount
-        }
-        recommend_to_others
-      }
       salary_work_time_statistics {
         job_average_salaries {
           job_title {
@@ -61,47 +20,6 @@ query($id:ID!) {
     }
     job_title {
       name
-      interview_experiences {
-        id
-        type
-        company {
-          name
-        }
-        job_title {
-          name
-        }
-        created_at
-        salary {
-          type
-          amount
-        }
-        overall_rating
-        sections {
-          subtitle
-          content
-        }
-      }
-      work_experiences {
-        id
-        type
-        company {
-          name
-        }
-        job_title {
-          name
-        }
-        created_at
-        sections {
-          subtitle
-          content
-        }
-        week_work_time
-        salary {
-          type
-          amount
-        }
-        recommend_to_others
-      }
       salary_distribution {
         bins {
           data_count

--- a/src/reducers/experience.js
+++ b/src/reducers/experience.js
@@ -1,0 +1,23 @@
+import createReducer from 'utils/createReducer';
+import { getUnfetched } from 'utils/fetchBox';
+import { SET_RELATED_EXPERIENCES } from 'actions/experience';
+
+/*
+ * relatedExperiencesState
+ * data
+ *   experienceId
+ *   page
+ *   relatedExperiences
+ * status
+ * error
+ */
+const preloadedState = {
+  relatedExperiencesState: getUnfetched(),
+};
+
+export default createReducer(preloadedState, {
+  [SET_RELATED_EXPERIENCES]: (state, { relatedExperiencesState }) => ({
+    ...state,
+    relatedExperiencesState,
+  }),
+});

--- a/src/reducers/experience.js
+++ b/src/reducers/experience.js
@@ -8,6 +8,7 @@ import { SET_RELATED_EXPERIENCES } from 'actions/experience';
  *   experienceId
  *   page
  *   relatedExperiences
+ *   hasMore
  * status
  * error
  */

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -4,6 +4,7 @@ import storage from 'redux-persist/lib/storage';
 
 import auth from './auth';
 import experienceDetail from './experienceDetail';
+import experience from './experience';
 import experienceSearch from './experienceSearch';
 import experiences from './experiences';
 import laborRights from './laborRights';
@@ -36,6 +37,7 @@ const rootReducer = combineReducers({
   auth,
   experienceSearch,
   experienceDetail,
+  experience,
   experiences,
   laborRights,
   timeAndSalary,

--- a/src/selectors/experienceSelector.js
+++ b/src/selectors/experienceSelector.js
@@ -1,0 +1,6 @@
+import { path } from 'ramda';
+
+export const relatedExperiencesStateSelector = path([
+  'experience',
+  'relatedExperiencesState',
+]);


### PR DESCRIPTION
Close #1157  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

將單篇 Experence 頁面 更多相關公司與職缺的面試及工作心得 部分改寫

達到：
(1) 增加 page load speed
(2) 減低後端 api 負擔
(3) 減少網路流量

原本會透過 graphql 拿到所有的資料，並排序後選擇前 5 顯示，造成大量資料擷取

所以改成分頁式的拿資料，需要時再拿

SSR 也只需要拿前5筆就足夠

## Screenshots  <!-- 選填，沒有就刪掉 -->

預期行為不變

## 我應該如何手動測試？ <!-- 必填 -->

- [x] 到隨便一個 experience 單頁，確認載入更多可以運作
- [x] 檢視原始碼，確認 前5筆 資料有在 html 原始碼內 (SSR 有運作)