### PR TITLE
refactor: send maxAge > 0

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -29,7 +29,7 @@ const matchRoutes = (pathname, routes) => {
 const server = Express();
 server
   .disable('x-powered-by')
-  .use(Express.static(process.env.RAZZLE_PUBLIC_DIR));
+  .use(Express.static(process.env.RAZZLE_PUBLIC_DIR, { maxAge: '14d' }));
 
 const wrap = fn => (req, res, next) => fn(req, res).catch(err => next(err));
 server.get(


### PR DESCRIPTION
ref: https://expressjs.com/en/api.html#express.static

since razzle build static files are immutable, add maxAge header to cache them

also, https://developers.cloudflare.com/cache/concepts/default-cache-behavior/ cloudflare suggest how static file will be cached