### PR TITLE
[薪時表單] 移除客戶端工時檢查

### DIFF
--- a/src/components/ShareExperience/TimeSalaryForm/formCheck.js
+++ b/src/components/ShareExperience/TimeSalaryForm/formCheck.js
@@ -20,23 +20,11 @@ export const experienceInYear = R.allPass([
   n => n <= 50,
 ]);
 
-export const dayPromisedWorkTime = R.allPass([
-  notStrEmpty,
-  n => n >= 0,
-  n => n <= 24,
-]);
+export const dayPromisedWorkTime = R.allPass([notStrEmpty]);
 
-export const dayRealWorkTime = R.allPass([
-  notStrEmpty,
-  n => n >= 0,
-  n => n <= 24,
-]);
+export const dayRealWorkTime = R.allPass([notStrEmpty]);
 
-export const weekWorkTime = R.allPass([
-  notStrEmpty,
-  n => n >= 0,
-  n => n <= 168,
-]);
+export const weekWorkTime = R.allPass([notStrEmpty]);
 
 export const overtimeFrequency = R.allPass([t => t !== null]);
 


### PR DESCRIPTION
Close #1103  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

「薪資」「工時」二擇一的規定，讓前端顯示錯誤的機制變得很複雜。
特別是：當「薪資為空」+「工時有填錯」時，很難判斷要捲回薪資欄，還是捲回工時欄。

目前的實作為：捲回較高處的薪資欄，但卻顯示了薪資的錯誤訊息。
然而在留空的情況下，應該要假設使用者要填的是工時。

而工時目前並沒有已實作好的錯誤訊息，只有薪資欄有詳細的錯誤訊息。
但薪資欄的錯誤訊息也滿複雜，分為好幾種狀態。

最後我覺得，既然客戶端的工時檢查本來就沒有警告訊息，
那麼就直接讓使用者按送出，由後端來告知使用者錯誤訊息吧。
填寫工時填錯的量應該不至於會太多。


<!-- 請簡單說明這個 PR 做了什麼 -->


## Screenshots  <!-- 選填，沒有就刪掉 -->

<table>
<tr>
<th>Before</th>
</tr>
<tr>
<td>

https://github.com/goodjoblife/GoodJobShare/assets/7566586/c9168954-75f8-4f4c-bd80-3e9f1ea56df0



</td>
<tr>
<th>After</th>
</tr>
<tr>
<td>


https://github.com/goodjoblife/GoodJobShare/assets/7566586/3e2ecbe2-378c-452c-ac87-4cdfed28441c


</td>
</tr>
</table>


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share/time-and-salary 薪水區塊留空，工時區塊填錯誤數字，完成其餘必填後送出。