### PR TITLE
[經驗頁面] 新增麵包屑 structure data

### DIFF
--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -47,7 +47,6 @@ const SeoStructureData = ({ experience }) => {
     author: {
       '@type': 'Organization',
       name: 'GoodJob 職場透明化運動',
-      url: formatCanonicalPath('/'),
     },
     publisher: {
       '@type': 'Organization',

--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import Helmet from 'react-helmet';
-import serialize from 'serialize-javascript';
+import SeoStructure from 'common/Seo/SeoStructure';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
 import {
@@ -30,7 +30,7 @@ const SeoHelmet = ({ experience }) => {
   );
 };
 
-const SeoStructureData = ({ experience }) => {
+const getStructureData = ({ experience }) => {
   const id = experience.id;
   const title = metaTitleSelector(experience);
   const description = metaDescriptionSelector(experience);
@@ -58,21 +58,16 @@ const SeoStructureData = ({ experience }) => {
     },
     description,
   };
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: serialize(data) }}
-    />
-  );
+  return <SeoStructure data={data} />;
 };
 
 const Seo = ({ experienceState, experience }) => {
   return (
     <Fragment>
       <SeoHelmet experienceState={experienceState} experience={experience} />
-      <SeoStructureData
+      <SeoStructure
         experienceState={experienceState}
-        experience={experience}
+        experience={getStructureData({ experience })}
       />
     </Fragment>
   );

--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -47,6 +47,7 @@ const SeoStructureData = ({ experience }) => {
     author: {
       '@type': 'Organization',
       name: 'GoodJob 職場透明化運動',
+      url: formatCanonicalPath('/'),
     },
     publisher: {
       '@type': 'Organization',

--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -47,6 +47,7 @@ const getStructureData = ({ experience }) => {
     author: {
       '@type': 'Organization',
       name: 'GoodJob 職場透明化運動',
+      url: formatCanonicalPath('/'),
     },
     publisher: {
       '@type': 'Organization',

--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -59,17 +59,14 @@ const getStructureData = ({ experience }) => {
     },
     description,
   };
-  return <SeoStructure data={data} />;
+  return data;
 };
 
 const Seo = ({ experienceState, experience }) => {
   return (
     <Fragment>
       <SeoHelmet experienceState={experienceState} experience={experience} />
-      <SeoStructure
-        experienceState={experienceState}
-        experience={getStructureData({ experience })}
-      />
+      <SeoStructure data={getStructureData({ experience })} />
     </Fragment>
   );
 };

--- a/src/components/ExperienceDetail/Seo.js
+++ b/src/components/ExperienceDetail/Seo.js
@@ -47,7 +47,7 @@ const getStructureData = ({ experience }) => {
     author: {
       '@type': 'Organization',
       name: 'GoodJob 職場透明化運動',
-      url: formatCanonicalPath('/'),
+      url: formatCanonicalPath('/about'),
     },
     publisher: {
       '@type': 'Organization',

--- a/src/components/common/BreadCrumb/index.js
+++ b/src/components/common/BreadCrumb/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import R from 'ramda';
 import styles from './BreadCrumb.module.css';
 import { Link } from 'react-router-dom';
-import serialize from 'serialize-javascript';
+import SeoStructure from '../Seo/SeoStructure';
 import { formatCanonicalPath } from 'utils/helmetHelper';
 
 const toInterspersedLinkNodes = R.compose(
@@ -20,29 +20,20 @@ const formatItem = R.compose(
   R.when(R.is(Object), R.prop('pathname')),
 );
 
-const StructureData = ({ items }) => {
-  const data = {
-    '@context': 'https://schema.org',
-    '@type': 'BreadcrumbList',
-    itemListElement: items.map(({ label, to }, i) => ({
-      '@type': 'ListItem',
-      position: i + 1,
-      name: label,
-      item: formatItem(to),
-    })),
-  };
-
-  return (
-    <script
-      type="application/ld+json"
-      dangerouslySetInnerHTML={{ __html: serialize(data) }}
-    />
-  );
-};
+const getStructureData = ({ items }) => ({
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: items.map(({ label, to }, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: label,
+    item: formatItem(to),
+  })),
+});
 
 const BreadCrumb = ({ data }) => (
   <Fragment>
-    <StructureData items={data}></StructureData>
+    <SeoStructure data={getStructureData({ items: data })} />
     <div className={styles.breadCrumb}>{toInterspersedLinkNodes(data)}</div>
   </Fragment>
 );

--- a/src/components/common/BreadCrumb/index.js
+++ b/src/components/common/BreadCrumb/index.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import R from 'ramda';
 import styles from './BreadCrumb.module.css';
 import { Link } from 'react-router-dom';
+import serialize from 'serialize-javascript';
+import { formatCanonicalPath } from 'utils/helmetHelper';
 
 const toInterspersedLinkNodes = R.compose(
   R.intersperse(' > '),
@@ -13,8 +15,31 @@ const toInterspersedLinkNodes = R.compose(
   )),
 );
 
+const StructureData = ({ items }) => {
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map(({ label, to }, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: label,
+      item: formatCanonicalPath(to),
+    })),
+  };
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialize(data) }}
+    />
+  );
+};
+
 const BreadCrumb = ({ data }) => (
-  <div className={styles.breadCrumb}>{toInterspersedLinkNodes(data)}</div>
+  <Fragment>
+    <StructureData items={data}></StructureData>
+    <div className={styles.breadCrumb}>{toInterspersedLinkNodes(data)}</div>
+  </Fragment>
 );
 
 BreadCrumb.propTypes = {

--- a/src/components/common/BreadCrumb/index.js
+++ b/src/components/common/BreadCrumb/index.js
@@ -15,6 +15,11 @@ const toInterspersedLinkNodes = R.compose(
   )),
 );
 
+const formatItem = R.compose(
+  formatCanonicalPath,
+  R.when(R.is(Object), R.prop('pathname')),
+);
+
 const StructureData = ({ items }) => {
   const data = {
     '@context': 'https://schema.org',
@@ -23,7 +28,7 @@ const StructureData = ({ items }) => {
       '@type': 'ListItem',
       position: i + 1,
       name: label,
-      item: formatCanonicalPath(to),
+      item: formatItem(to),
     })),
   };
 

--- a/src/components/common/Seo/SeoStructure.js
+++ b/src/components/common/Seo/SeoStructure.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import serialize from 'serialize-javascript';
+
+const SeoStructure = ({ data }) => {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: serialize(data) }}
+    />
+  );
+};
+
+export default SeoStructure;


### PR DESCRIPTION
Close #1165 #1178 #1179 

## 這個 PR 是？ <!-- 必填 -->

新增麵包屑structure data
~~新增author.url到Article structure data~~


## Screenshots  <!-- 選填，沒有就刪掉 -->
![截圖 2023-11-09 上午12 44 05](https://github.com/goodjoblife/GoodJobShare/assets/7566586/772cc940-deb3-4384-9996-14e6c42d58e5)


## 我應該如何手動測試？ <!-- 必填 -->

檢查經驗頁面的html是否有structure data
http://localhost:3000/experiences/5b17d823489c0d000fc30534

將經驗頁面的原始碼放進[檢測工具](https://search.google.com/test/rich-results)並確認通過：
![截圖 2023-11-09 上午12 54 54](https://github.com/goodjoblife/GoodJobShare/assets/7566586/3364f162-7239-4418-ade3-9952c3fce80b)

其中「文章」的「非重大問題」為缺漏 image，但我們文章確實沒有圖片。