### PR TITLE
[面試經驗] 化簡驗證邏輯

### DIFF
--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -63,7 +63,7 @@ export const createCompanyQuestion = ({ header }) => ({
     return companyName;
   },
   required: true,
-  warning: value => isEmpty(value) && '請填寫公司名稱',
+  validateOrWarn: value => isEmpty(value) && '請填寫公司名稱',
   placeholder: 'ＯＯ 股份有限公司',
   search: value =>
     getCompaniesSearch({ key: value }).then(
@@ -78,7 +78,7 @@ export const createJobTitleQuestion = ({ header }) => ({
   dataKey: DATA_KEY_JOB_TITLE,
   defaultValue: '',
   required: true,
-  warning: value => isEmpty(value) && '請填寫職稱',
+  validateOrWarn: value => isEmpty(value) && '請填寫職稱',
   placeholder: '軟體工程師',
   search: value =>
     getJobTitlesSearch({ key: value }).then(when(isNot(isArray), always([]))),
@@ -91,7 +91,7 @@ export const createInterviewDateQuestion = () => ({
   dataKey: DATA_KEY_DATE,
   defaultValue: [null, null],
   required: true,
-  warning: ([year, month]) =>
+  validateOrWarn: ([year, month]) =>
     (isNil(year) || isNil(month)) &&
     `需填寫面試${joinCompact(' 及 ')(
       isNil(year) && '年份',
@@ -105,7 +105,7 @@ export const createInterviewRegionQuestion = () => ({
   dataKey: DATA_KEY_REGION,
   defaultValue: null,
   required: true,
-  warning: value => isNil(value) && '需填寫面試地區',
+  validateOrWarn: value => isNil(value) && '需填寫面試地區',
   options: REGION_OPTIONS,
 });
 
@@ -115,7 +115,7 @@ export const createInterviewResultQuestion = () => ({
   dataKey: DATA_KEY_RESULT,
   defaultValue: [null, ''],
   required: true,
-  warning: ([selected, elseText]) => {
+  validateOrWarn: ([selected, elseText]) => {
     if (isNil(selected)) return '需填寫面試結果';
     if (equals(selected, last(RESULT_OPTIONS))) {
       if (isEmpty(elseText)) return '需填寫面試結果';
@@ -133,7 +133,7 @@ export const createInterviewRatingQuestion = () => ({
   dataKey: DATA_KEY_RATING,
   defaultValue: 0,
   required: true,
-  warning: value => equals(0, value) && '需選取面試滿意程度',
+  validateOrWarn: value => equals(0, value) && '需選取面試滿意程度',
   ratingLabels: RATING_LABELS,
 });
 
@@ -145,7 +145,7 @@ export const createInterviewCourseQuestion = () => ({
 第二次面試：
 工作環境：`,
   required: true,
-  warning: value =>
+  validateOrWarn: value =>
     compose(
       lessThan(COURSE_MIN_LENGTH),
       wordCount,
@@ -162,7 +162,7 @@ export const createInterviewSuggestionsQuestion = () => ({
 是否推薦此份工作：
 其他注意事項：`,
   required: true,
-  warning: value =>
+  validateOrWarn: value =>
     compose(
       lessThan(SUGGESTIONS_MIN_LENGTH),
       wordCount,
@@ -185,7 +185,7 @@ export const createSalaryQuestion = () => ({
   type: QUESTION_TYPE.SELECT_TEXT,
   dataKey: DATA_KEY_SALARY,
   defaultValue: [null, ''],
-  warning: ([type, amount]) =>
+  validateOrWarn: ([type, amount]) =>
     isNot(isNil, type) && (isEmpty(amount) || isNot(isSalaryAmount, amount))
       ? '需填寫薪資'
       : isNil(type) && isNot(isEmpty, amount)
@@ -203,7 +203,7 @@ export const createQuestionsQuestion = () => ({
   type: QUESTION_TYPE.TEXT_LIST,
   dataKey: DATA_KEY_QUESTIONS,
   defaultValue: [],
-  warning: value => any(isEmpty, value) && '需填寫面試問題內容',
+  validateOrWarn: value => any(isEmpty, value) && '需填寫面試問題內容',
   placeholder: '面試問題',
 });
 
@@ -212,7 +212,7 @@ export const createSensitiveQuestionsQuestion = () => ({
   type: QUESTION_TYPE.CHECKBOX_ELSE,
   dataKey: DATA_KEY_SENSITIVE_QUESTIONS,
   defaultValue: [[], ''],
-  warning: ([selected, elseText]) =>
+  validateOrWarn: ([selected, elseText]) =>
     contains(last(SENSITIVE_QUESTIONS_OPTIONS), selected) &&
     (isEmpty(elseText)
       ? '需填寫其他特殊問題的內容'

--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -63,7 +63,7 @@ export const createCompanyQuestion = ({ header }) => ({
     return companyName;
   },
   required: true,
-  validate: value => isEmpty(value) && '請填寫公司名稱',
+  warning: value => isEmpty(value) && '請填寫公司名稱',
   placeholder: 'ＯＯ 股份有限公司',
   search: value =>
     getCompaniesSearch({ key: value }).then(
@@ -78,7 +78,7 @@ export const createJobTitleQuestion = ({ header }) => ({
   dataKey: DATA_KEY_JOB_TITLE,
   defaultValue: '',
   required: true,
-  validate: value => isEmpty(value) && '請填寫職稱',
+  warning: value => isEmpty(value) && '請填寫職稱',
   placeholder: '軟體工程師',
   search: value =>
     getJobTitlesSearch({ key: value }).then(when(isNot(isArray), always([]))),
@@ -91,7 +91,7 @@ export const createInterviewDateQuestion = () => ({
   dataKey: DATA_KEY_DATE,
   defaultValue: [null, null],
   required: true,
-  validate: ([year, month]) =>
+  warning: ([year, month]) =>
     (isNil(year) || isNil(month)) &&
     `需填寫面試${joinCompact(' 及 ')(
       isNil(year) && '年份',
@@ -105,7 +105,7 @@ export const createInterviewRegionQuestion = () => ({
   dataKey: DATA_KEY_REGION,
   defaultValue: null,
   required: true,
-  validate: value => isNil(value) && '需填寫面試地區',
+  warning: value => isNil(value) && '需填寫面試地區',
   options: REGION_OPTIONS,
 });
 
@@ -115,7 +115,7 @@ export const createInterviewResultQuestion = () => ({
   dataKey: DATA_KEY_RESULT,
   defaultValue: [null, ''],
   required: true,
-  validate: ([selected, elseText]) => {
+  warning: ([selected, elseText]) => {
     if (isNil(selected)) return '需填寫面試結果';
     if (equals(selected, last(RESULT_OPTIONS))) {
       if (isEmpty(elseText)) return '需填寫面試結果';
@@ -133,7 +133,7 @@ export const createInterviewRatingQuestion = () => ({
   dataKey: DATA_KEY_RATING,
   defaultValue: 0,
   required: true,
-  validate: value => equals(0, value) && '需選取面試滿意程度',
+  warning: value => equals(0, value) && '需選取面試滿意程度',
   ratingLabels: RATING_LABELS,
 });
 
@@ -145,7 +145,7 @@ export const createInterviewCourseQuestion = () => ({
 第二次面試：
 工作環境：`,
   required: true,
-  validate: value =>
+  warning: value =>
     compose(
       lessThan(COURSE_MIN_LENGTH),
       wordCount,
@@ -162,7 +162,7 @@ export const createInterviewSuggestionsQuestion = () => ({
 是否推薦此份工作：
 其他注意事項：`,
   required: true,
-  validate: value =>
+  warning: value =>
     compose(
       lessThan(SUGGESTIONS_MIN_LENGTH),
       wordCount,
@@ -185,7 +185,7 @@ export const createSalaryQuestion = () => ({
   type: QUESTION_TYPE.SELECT_TEXT,
   dataKey: DATA_KEY_SALARY,
   defaultValue: [null, ''],
-  validate: ([type, amount]) =>
+  warning: ([type, amount]) =>
     isNot(isNil, type) && (isEmpty(amount) || isNot(isSalaryAmount, amount))
       ? '需填寫薪資'
       : isNil(type) && isNot(isEmpty, amount)
@@ -203,7 +203,7 @@ export const createQuestionsQuestion = () => ({
   type: QUESTION_TYPE.TEXT_LIST,
   dataKey: DATA_KEY_QUESTIONS,
   defaultValue: [],
-  validate: value => any(isEmpty, value) && '需填寫面試問題內容',
+  warning: value => any(isEmpty, value) && '需填寫面試問題內容',
   placeholder: '面試問題',
 });
 
@@ -212,7 +212,7 @@ export const createSensitiveQuestionsQuestion = () => ({
   type: QUESTION_TYPE.CHECKBOX_ELSE,
   dataKey: DATA_KEY_SENSITIVE_QUESTIONS,
   defaultValue: [[], ''],
-  validate: ([selected, elseText]) =>
+  warning: ([selected, elseText]) =>
     contains(last(SENSITIVE_QUESTIONS_OPTIONS), selected) &&
     (isEmpty(elseText)
       ? '需填寫其他特殊問題的內容'

--- a/src/components/ShareExperience/utils.js
+++ b/src/components/ShareExperience/utils.js
@@ -4,6 +4,7 @@ import R, {
   allPass,
   lt,
   lte,
+  gt,
   gte,
   not,
   type,
@@ -46,6 +47,7 @@ export const isSalaryAmount = compose(
 
 export const greaterThan = lt;
 export const greaterThanOrEqualTo = lte;
+export const lessThan = gt;
 export const lessThanOrEqualTo = gte;
 
 export const compact = filter(Boolean);

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Checkbox.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Checkbox.js
@@ -14,7 +14,6 @@ const Checkbox = ({
   value,
   onChange,
   warning,
-  validator,
   options,
 }) => (
   <Wrapper warning={warning}>
@@ -38,7 +37,6 @@ Checkbox.propTypes = {
   value: PropTypes.arrayOf(PropTypes.string).isRequired,
   onChange: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/CheckboxElse.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/CheckboxElse.js
@@ -16,7 +16,6 @@ const CheckboxElse = ({
   onChange,
   onConfirm,
   warning,
-  validator,
   options,
   placeholder,
 }) => (
@@ -54,7 +53,6 @@ CheckboxElse.propTypes = {
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   placeholder: PropTypes.string,
 };

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Radio.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Radio.js
@@ -15,7 +15,6 @@ const Radio = ({
   onChange,
   onConfirm,
   warning,
-  validator,
   options,
 }) => (
   <Wrapper warning={warning}>
@@ -41,7 +40,6 @@ Radio.propTypes = {
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/RadioElse.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/RadioElse.js
@@ -16,7 +16,6 @@ const RadioElse = ({
   onChange,
   onConfirm,
   warning,
-  validator,
   options,
   placeholder,
 }) => (
@@ -54,7 +53,6 @@ RadioElse.propTypes = {
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   options: PropTypes.arrayOf(PropTypes.string).isRequired,
   placeholder: PropTypes.string,
 };

--- a/src/components/common/FormBuilder/QuestionBuilder/Date.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Date.js
@@ -27,7 +27,6 @@ const DatePicker = ({
   value: [year, month],
   onChange,
   warning,
-  validator,
 }) => (
   <div className={cn({ [commonStyles.hasWarning]: !!warning })}>
     <div className={cn(styles.inputRow, commonStyles.warnableContainer)}>
@@ -81,7 +80,6 @@ DatePicker.propTypes = {
   }),
   onChange: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
 };
 
 DatePicker.defaultProps = {

--- a/src/components/common/FormBuilder/QuestionBuilder/File.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/File.js
@@ -36,7 +36,6 @@ const File = ({
   value,
   onChange,
   warning,
-  validator,
 }) => {
   const [filename, setFilename] = useState(null);
   const [error, setError] = useState(null);
@@ -88,7 +87,6 @@ File.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
 };
 
 export default File;

--- a/src/components/common/FormBuilder/QuestionBuilder/Rating.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Rating.js
@@ -33,7 +33,6 @@ const Rating = ({
   onChange,
   onConfirm,
   warning,
-  validator,
   ratingLabels,
 }) => {
   const debouncedConfirm = useDebouncedConfirm(onConfirm, 300);
@@ -87,7 +86,6 @@ Rating.propTypes = {
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   ratingLabels: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/SelectText.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/SelectText.js
@@ -18,7 +18,6 @@ const SelectText = ({
   onChange,
   onConfirm,
   warning,
-  validator,
   placeholder,
   options,
 }) => (
@@ -58,7 +57,6 @@ SelectText.propTypes = {
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   placeholder: PropTypes.string,
   options: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
 };

--- a/src/components/common/FormBuilder/QuestionBuilder/Text.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Text.js
@@ -19,7 +19,6 @@ const Text = ({
   onSelect,
   search,
   warning,
-  validator,
   placeholder,
 }) => {
   const [items, setItems] = useState([]);
@@ -88,7 +87,6 @@ Text.propTypes = {
   onSelect: PropTypes.func,
   search: PropTypes.func,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   placeholder: PropTypes.string,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextArea.js
@@ -17,7 +17,6 @@ const Textarea = ({
   onChange,
   footnote,
   warning,
-  validator,
 }) => (
   <div
     className={cn(styles.container, { [commonStyles.hasWarning]: !!warning })}
@@ -53,7 +52,6 @@ Textarea.propTypes = {
   onChange: PropTypes.func.isRequired,
   footnote: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   warning: PropTypes.string,
-  validator: PropTypes.func,
 };
 
 export default Textarea;

--- a/src/components/common/FormBuilder/QuestionBuilder/TextList.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/TextList.js
@@ -17,7 +17,6 @@ const TextList = ({
   value: values,
   onChange,
   warning,
-  validator,
   placeholder,
 }) => {
   const ref = useRef(null);
@@ -85,7 +84,6 @@ TextList.propTypes = {
   value: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   onChange: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  validator: PropTypes.func,
   placeholder: PropTypes.string,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/index.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/index.js
@@ -53,7 +53,6 @@ const useQuestionNode = ({
   onSelect,
   search,
   warning,
-  validator,
   placeholder,
   footnote,
   options,
@@ -72,7 +71,6 @@ const useQuestionNode = ({
     onChange,
     onConfirm,
     warning,
-    validator,
   };
   switch (type) {
     case 'text':
@@ -141,7 +139,6 @@ const useQuestionNode = ({
             onChange,
             onConfirm,
             warning,
-            validator,
           }),
         ];
       } else {
@@ -166,7 +163,6 @@ const QuestionBuilder = ({
   onSelect,
   search,
   warning,
-  validator,
   placeholder,
   footnote,
   options,
@@ -187,7 +183,6 @@ const QuestionBuilder = ({
     onSelect,
     search,
     warning,
-    validator,
     placeholder,
     footnote,
     options,
@@ -233,7 +228,6 @@ QuestionBuilder.propTypes = {
   value: any,
   onChange: func.isRequired,
   warning: string,
-  validator: func,
   onConfirm: func.isRequired,
   onSelect: func,
   search: func,

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -55,7 +55,7 @@ const useQuestion = (question, draft) => {
       questionHeader: header,
       questionFooter: footer,
       dataKey,
-      warning: warning && warning(draft[dataKey]),
+      warning: (warning && warning(draft[dataKey])) || null,
       skippable:
         !required &&
         R.equals(
@@ -187,7 +187,7 @@ const FormBuilder = ({
                     warnBeforeSetPage(i + 1);
                   }
                 }}
-                warning={(isWarningShown && warning) || null}
+                warning={isWarningShown ? warning : null}
               />
             </AnimatedPager.Page>
           ))}

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -25,11 +25,11 @@ import styles from './FormBuilder.module.css';
 const findIfQuestionsAcceptDraft = draft =>
   R.all(
     R.ifElse(
-      R.has('warning'),
+      R.has('validateOrWarn'),
       R.compose(
         R.isNil,
         R.converge(R.call, [
-          R.prop('warning'),
+          R.prop('validateOrWarn'),
           R.compose(
             dataKey => draft[dataKey],
             R.prop('dataKey'),
@@ -48,14 +48,14 @@ const useQuestion = (question, draft) => {
       dataKey,
       defaultValue,
       required,
-      warning,
+      validateOrWarn,
     } = question;
     return {
       shouldRenderQuestion: true,
       questionHeader: header,
       questionFooter: footer,
       dataKey,
-      warning: (warning && warning(draft[dataKey])) || null,
+      warning: (validateOrWarn && validateOrWarn(draft[dataKey])) || null,
       skippable:
         !required &&
         R.equals(
@@ -236,7 +236,7 @@ export const QuestionPropType = shape({
   dataKey: string.isRequired,
   defaultValue: oneOfType([func, any]),
   required: bool,
-  warning: func,
+  validateOrWarn: func,
   onSelect: func,
   search: func,
   placeholder: string,

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -25,11 +25,11 @@ import styles from './FormBuilder.module.css';
 const findIfQuestionsAcceptDraft = draft =>
   R.all(
     R.ifElse(
-      R.has('validate'),
+      R.has('warning'),
       R.compose(
         R.isNil,
         R.converge(R.call, [
-          R.prop('validate'),
+          R.prop('warning'),
           R.compose(
             dataKey => draft[dataKey],
             R.prop('dataKey'),
@@ -48,14 +48,14 @@ const useQuestion = (question, draft) => {
       dataKey,
       defaultValue,
       required,
-      validate,
+      warning,
     } = question;
     return {
       shouldRenderQuestion: true,
       questionHeader: header,
       questionFooter: footer,
       dataKey,
-      warning: validate && validate(draft[dataKey]),
+      warning: warning && warning(draft[dataKey]),
       skippable:
         !required &&
         R.equals(
@@ -236,7 +236,7 @@ export const QuestionPropType = shape({
   dataKey: string.isRequired,
   defaultValue: oneOfType([func, any]),
   required: bool,
-  validate: func,
+  warning: func,
   onSelect: func,
   search: func,
   placeholder: string,

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -23,23 +23,6 @@ import SubmissionBlock from './SubmissionBlock';
 import AnimatedPager from './AnimatedPager';
 import styles from './FormBuilder.module.css';
 
-const findWarningAgainstValue = (value, warning, validator) => {
-  if (validator) {
-    const isValid = validator(value);
-    if (isValid) {
-      return null;
-    } else {
-      if (typeof warning === 'function') {
-        return warning(value);
-      } else {
-        return warning;
-      }
-    }
-  } else {
-    return null;
-  }
-};
-
 const findIfQuestionsAcceptDraft = draft =>
   R.all(
     R.ifElse(
@@ -63,15 +46,14 @@ const useQuestion = (question, draft) => {
       dataKey,
       defaultValue,
       required,
-      warning,
-      validator,
+      validate,
     } = question;
     return [
       true,
       typeof header === 'function' ? header(draft) : header,
       typeof footer === 'function' ? footer(draft) : footer,
       dataKey,
-      findWarningAgainstValue(draft[dataKey], warning, validator),
+      validate && validate(draft[dataKey]),
       !required &&
         R.equals(
           draft[dataKey],
@@ -202,7 +184,7 @@ const FormBuilder = ({
                     warnBeforeSetPage(i + 1);
                   }
                 }}
-                warning={isWarningShown ? warning : null}
+                warning={(isWarningShown && warning) || null}
               />
             </AnimatedPager.Page>
           ))}
@@ -254,8 +236,7 @@ FormBuilder.propTypes = {
       dataKey: string.isRequired,
       defaultValue: oneOfType([func, any]),
       required: bool,
-      warning: oneOfType([func, string]),
-      validator: func,
+      validate: func,
       onSelect: func,
       search: func,
       placeholder: string,

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -51,20 +51,21 @@ const useQuestion = (question, draft) => {
       required,
       validate,
     } = question;
-    return [
-      true,
-      typeof header === 'function' ? header(draft) : header,
-      typeof footer === 'function' ? footer(draft) : footer,
+    return {
+      shouldRenderQuestion: true,
+      questionHeader: header,
+      questionFooter: footer,
       dataKey,
-      validate && validate(draft[dataKey]),
-      !required &&
+      warning: validate && validate(draft[dataKey]),
+      skippable:
+        !required &&
         R.equals(
           draft[dataKey],
           typeof defaultValue === 'function' ? defaultValue() : defaultValue,
         ),
-    ];
+    };
   } else {
-    return [false];
+    return { shouldRenderQuestion: false };
   }
 };
 
@@ -91,14 +92,14 @@ const FormBuilder = ({
   const hasPrevious = page > 0;
   const hasNext = page < questions.length - 1;
 
-  const [
+  const {
     shouldRenderQuestion,
     questionHeader,
     questionFooter,
     dataKey,
     warning,
     skippable,
-  ] = useQuestion(questions[page], draft);
+  } = useQuestion(questions[page], draft);
 
   const [isWarningShown, setWarningShown] = useState(false);
 

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -26,14 +26,17 @@ import styles from './FormBuilder.module.css';
 const findIfQuestionsAcceptDraft = draft =>
   R.all(
     R.ifElse(
-      R.has('validator'),
-      R.converge(R.call, [
-        R.prop('validator'),
-        R.compose(
-          dataKey => draft[dataKey],
-          R.prop('dataKey'),
-        ),
-      ]),
+      R.has('validate'),
+      R.compose(
+        R.isNil,
+        R.converge(R.call, [
+          R.prop('validate'),
+          R.compose(
+            dataKey => draft[dataKey],
+            R.prop('dataKey'),
+          ),
+        ]),
+      ),
       R.always(true),
     ),
   );


### PR DESCRIPTION
#1195

## 這個 PR 是？ <!-- 必填 -->

原始的面試表單在驗證時分兩個步驟：
1. 用 `validator` 驗證輸入是否合法 (true/false)
2. 若否，用 `warning` 產生警告標示

但邏輯上，應該可以直接合併兩者，化簡成一個函式：當輸入有誤時就回傳警告文字，若合法則回傳null。

此重構會使表單更容易定義。

### Before
```mermaid
flowchart LR
    A[value] --> B{validator} -->|true| C[valid] -.->|null\nwarning| F
    B --> |false| E[invalid] --> D{warning} -.->|non-null\nwarning| F[Element]
```

### After
```mermaid
flowchart LR
    A[value] --> B{warning} -->|null| C[valid] -.->|null\nwarning| F
    B --> |non-null| E[invalid] -.->|non-null\nwarning| F[Element]
```


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share 面試表單應不受影響]