### PR TITLE
[面試表單] 重構"其他"選項

### DIFF
--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -115,15 +115,16 @@ export const createInterviewResultQuestion = () => ({
   dataKey: DATA_KEY_RESULT,
   defaultValue: [null, ''],
   required: true,
-  validateOrWarn: ([selected, elseText]) => {
+  validateOrWarn: ([selected, elseText], { elseOptionValue }) => {
     if (isNil(selected)) return '需填寫面試結果';
-    if (equals(selected, last(RESULT_OPTIONS))) {
+    if (equals(selected, elseOptionValue)) {
       if (isEmpty(elseText)) return '需填寫面試結果';
       if (!within(1, 100, elseText.length)) return '面試結果僅限 1~100 字！';
     }
     return null;
   },
   options: RESULT_OPTIONS,
+  elseOptionValue: last(RESULT_OPTIONS),
   placeholder: '輸入面試結果',
 });
 
@@ -212,14 +213,15 @@ export const createSensitiveQuestionsQuestion = () => ({
   type: QUESTION_TYPE.CHECKBOX_ELSE,
   dataKey: DATA_KEY_SENSITIVE_QUESTIONS,
   defaultValue: [[], ''],
-  validateOrWarn: ([selected, elseText]) =>
-    contains(last(SENSITIVE_QUESTIONS_OPTIONS), selected) &&
+  validateOrWarn: ([selected, elseText], { elseOptionValue }) =>
+    contains(elseOptionValue, selected) &&
     (isEmpty(elseText)
       ? '需填寫其他特殊問題的內容'
       : !within(1, 20, elseText.length)
       ? '面試中提及的特別問題僅限 1~20 字！'
       : null),
   options: SENSITIVE_QUESTIONS_OPTIONS,
+  elseOptionValue: last(SENSITIVE_QUESTIONS_OPTIONS),
   placeholder: '輸入其他特殊問題內容',
 });
 

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Checkbox.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Checkbox.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Wrapper from './private/Wrapper';
 import BlockSelect from './private/BlockSelect';
+import { OptionPropType, ValuePropType } from './PropTypes';
 
 const Checkbox = ({
   page,
@@ -33,11 +34,11 @@ Checkbox.propTypes = {
   description: PropTypes.string,
   dataKey: PropTypes.string.isRequired,
   required: PropTypes.bool,
-  defaultValue: PropTypes.arrayOf(PropTypes.string).isRequired,
-  value: PropTypes.arrayOf(PropTypes.string).isRequired,
+  defaultValue: PropTypes.arrayOf(ValuePropType).isRequired,
+  value: PropTypes.arrayOf(ValuePropType).isRequired,
   onChange: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(OptionPropType).isRequired,
 };
 
 export default Checkbox;

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/CheckboxElse.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/CheckboxElse.js
@@ -4,6 +4,7 @@ import { withShape } from 'airbnb-prop-types';
 
 import Wrapper from './private/Wrapper';
 import BlockSelectElse from './private/BlockSelectElse';
+import { OptionPropType, ValuePropType } from './PropTypes';
 
 const CheckboxElse = ({
   page,
@@ -17,6 +18,7 @@ const CheckboxElse = ({
   onConfirm,
   warning,
   options,
+  elseOptionValue,
   placeholder,
 }) => (
   <Wrapper warning={warning}>
@@ -26,6 +28,7 @@ const CheckboxElse = ({
       onChange={onChange}
       onConfirm={onConfirm}
       options={options}
+      elseOptionValue={elseOptionValue}
       multiple
       placeholder={placeholder}
     />
@@ -40,20 +43,21 @@ CheckboxElse.propTypes = {
   required: PropTypes.bool,
   defaultValue: withShape(PropTypes.array.isRequired, {
     // option
-    0: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    0: PropTypes.arrayOf(ValuePropType.isRequired).isRequired,
     // else
     1: PropTypes.string.isRequired,
   }),
   value: withShape(PropTypes.array.isRequired, {
     // option
-    0: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    0: PropTypes.arrayOf(ValuePropType.isRequired).isRequired,
     // else
     1: PropTypes.string.isRequired,
   }),
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(OptionPropType).isRequired,
+  elseOptionValue: ValuePropType.isRequired,
   placeholder: PropTypes.string,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/PropTypes.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/PropTypes.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+
+export const ValuePropType = PropTypes.oneOfType([PropTypes.string]);
+
+export const OptionPropType = PropTypes.oneOfType([
+  ValuePropType,
+  PropTypes.shape({
+    label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+    value: ValuePropType.isRequired,
+  }),
+]);

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Radio.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/Radio.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import Wrapper from './private/Wrapper';
 import BlockSelect from './private/BlockSelect';
+import { OptionPropType, ValuePropType } from './PropTypes';
 
 const Radio = ({
   page,
@@ -35,12 +36,12 @@ Radio.propTypes = {
   description: PropTypes.string,
   dataKey: PropTypes.string.isRequired,
   required: PropTypes.bool,
-  defaultValue: PropTypes.string,
-  value: PropTypes.string,
+  defaultValue: ValuePropType,
+  value: ValuePropType,
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(OptionPropType).isRequired,
 };
 
 export default Radio;

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/RadioElse.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/RadioElse.js
@@ -4,6 +4,7 @@ import { withShape } from 'airbnb-prop-types';
 
 import Wrapper from './private/Wrapper';
 import BlockSelectElse from './private/BlockSelectElse';
+import { OptionPropType, ValuePropType } from './PropTypes';
 
 const RadioElse = ({
   page,
@@ -17,6 +18,7 @@ const RadioElse = ({
   onConfirm,
   warning,
   options,
+  elseOptionValue,
   placeholder,
 }) => (
   <Wrapper warning={warning}>
@@ -27,6 +29,7 @@ const RadioElse = ({
       onChange={onChange}
       onConfirm={onConfirm}
       options={options}
+      elseOptionValue={elseOptionValue}
       placeholder={placeholder}
     />
   </Wrapper>
@@ -40,20 +43,21 @@ RadioElse.propTypes = {
   required: PropTypes.bool,
   defaultValue: withShape(PropTypes.array.isRequired, {
     // option
-    0: PropTypes.string,
+    0: ValuePropType,
     // else
     1: PropTypes.string.isRequired,
   }),
   value: withShape(PropTypes.array.isRequired, {
     // option
-    0: PropTypes.string,
+    0: ValuePropType,
     // else
     1: PropTypes.string.isRequired,
   }),
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   warning: PropTypes.string,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(OptionPropType).isRequired,
+  elseOptionValue: ValuePropType.isRequired,
   placeholder: PropTypes.string,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/private/BlockSelect.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/private/BlockSelect.js
@@ -5,6 +5,8 @@ import R from 'ramda';
 import useDebouncedConfirm from '../../../useDebouncedConfirm';
 import styles from './private.module.css';
 import { toggle } from './utils';
+import { normalizeOptions } from './utils';
+import { OptionPropType, ValuePropType } from '../PropTypes';
 
 const BlockSelect = ({
   dataKey,
@@ -15,6 +17,8 @@ const BlockSelect = ({
   options,
   multiple,
 }) => {
+  options = normalizeOptions(options);
+
   const isChecked = useCallback(
     option => {
       if (multiple) {
@@ -44,17 +48,17 @@ const BlockSelect = ({
     [multiple, required, value, onChange, debouncedConfirm],
   );
 
-  return options.map(option => (
-    <label key={option} className={styles.label}>
+  return options.map(({ label, value }) => (
+    <label key={value} className={styles.label}>
       <input
         className={styles.input}
         type="checkbox"
         name={dataKey}
-        value={option}
-        checked={isChecked(option)}
-        onChange={() => handleChange(option)}
+        value={value}
+        checked={isChecked(value)}
+        onChange={() => handleChange(value)}
       />
-      <div className={styles.button}>{option}</div>
+      <div className={styles.button}>{label}</div>
     </label>
   ));
 };
@@ -63,12 +67,12 @@ BlockSelect.propTypes = {
   dataKey: PropTypes.string.isRequired,
   required: PropTypes.bool,
   value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string).isRequired,
+    ValuePropType,
+    PropTypes.arrayOf(ValuePropType).isRequired,
   ]),
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(OptionPropType).isRequired,
   multiple: PropTypes.bool.isRequired,
 };
 

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/private/BlockSelectElse.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/private/BlockSelectElse.js
@@ -7,6 +7,8 @@ import cn from 'classnames';
 import styles from './private.module.css';
 import TextInput from 'common/form/TextInput';
 import BlockSelect from './BlockSelect';
+import { OptionPropType, ValuePropType } from '../PropTypes';
+import { normalizeOptions } from './utils';
 
 const BlockSelectElse = ({
   dataKey,
@@ -15,17 +17,20 @@ const BlockSelectElse = ({
   onChange,
   onConfirm,
   options,
+  elseOptionValue,
   multiple,
   placeholder,
 }) => {
+  options = normalizeOptions(options);
+
   const elseRef = useRef(null);
   const hasElse = useMemo(() => {
     if (multiple) {
-      return R.contains(R.last(options), selected);
+      return R.contains(elseOptionValue, selected);
     } else {
-      return R.equals(R.last(options), selected);
+      return R.equals(elseOptionValue, selected);
     }
-  }, [multiple, options, selected]);
+  }, [elseOptionValue, multiple, selected]);
   const handleSelectChange = useCallback(
     selected => onChange([selected, elseText]),
     [elseText, onChange],
@@ -73,15 +78,16 @@ BlockSelectElse.propTypes = {
   value: withShape(PropTypes.array.isRequired, {
     // option
     0: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+      ValuePropType,
+      PropTypes.arrayOf(ValuePropType).isRequired,
     ]),
     // else
     1: PropTypes.string.isRequired,
   }),
   onChange: PropTypes.func.isRequired,
   onConfirm: PropTypes.func,
-  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  options: PropTypes.arrayOf(OptionPropType).isRequired,
+  elseOptionValue: ValuePropType.isRequired,
   multiple: PropTypes.bool.isRequired,
   placeholder: PropTypes.string,
 };

--- a/src/components/common/FormBuilder/QuestionBuilder/Checkbox/private/utils.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Checkbox/private/utils.js
@@ -7,3 +7,5 @@ export const toggle = (value, values) => {
     return R.append(value, values);
   }
 };
+
+export { normalizeOptions } from '../../utils';

--- a/src/components/common/FormBuilder/QuestionBuilder/index.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/index.js
@@ -24,6 +24,7 @@ import TextList from './TextList';
 import TitleBlock from '../TitleBlock';
 import Scrollable from '../Scrollable';
 import styles from './styles.module.css';
+import { OptionPropType, ValuePropType } from './Checkbox/PropTypes';
 
 export const QUESTION_TYPE = {
   TEXT: 'TEXT',
@@ -57,6 +58,7 @@ const useQuestionNode = ({
   placeholder,
   footnote,
   options,
+  elseOptionValue,
   ratingLabels,
   renderCustomizedQuestion,
 }) => {
@@ -94,6 +96,7 @@ const useQuestionNode = ({
         <RadioElse
           {...commonProps}
           options={options}
+          elseOptionValue={elseOptionValue}
           placeholder={placeholder}
         />,
       ];
@@ -105,6 +108,7 @@ const useQuestionNode = ({
         <CheckboxElse
           {...commonProps}
           options={options}
+          elseOptionValue={elseOptionValue}
           placeholder={placeholder}
         />,
       ];
@@ -167,6 +171,7 @@ const QuestionBuilder = ({
   placeholder,
   footnote,
   options,
+  elseOptionValue,
   ratingLabels,
   renderCustomizedQuestion,
 }) => {
@@ -187,6 +192,7 @@ const QuestionBuilder = ({
     placeholder,
     footnote,
     options,
+    elseOptionValue,
     ratingLabels,
     renderCustomizedQuestion,
   });
@@ -235,8 +241,8 @@ QuestionBuilder.propTypes = {
   onSelect: func,
   search: func,
   placeholder: string,
-  footnote: oneOfType([string, func]),
-  options: arrayOf(string),
+  options: arrayOf(OptionPropType),
+  elseOptionValue: ValuePropType,
   ratingLabels: arrayOf(string.isRequired),
   renderCustomizedQuestion: func,
 };

--- a/src/components/common/FormBuilder/QuestionBuilder/utils.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/utils.js
@@ -1,0 +1,9 @@
+export const normalizeOptions = options =>
+  options.map(option => {
+    if (typeof option === 'object') {
+      const { label, value } = option;
+      return { label, value };
+    } else {
+      return { label: `${option}`, value: option };
+    }
+  });

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -21,6 +21,7 @@ import NavigatorBlock from './NavigatorBlock';
 import SubmissionBlock from './SubmissionBlock';
 import AnimatedPager from './AnimatedPager';
 import styles from './FormBuilder.module.css';
+import { OptionPropType } from './QuestionBuilder/Checkbox/PropTypes';
 
 const findIfQuestionsAcceptDraft = draft =>
   R.all(
@@ -34,6 +35,7 @@ const findIfQuestionsAcceptDraft = draft =>
             dataKey => draft[dataKey],
             R.prop('dataKey'),
           ),
+          R.identity,
         ]),
       ),
       R.always(true),
@@ -55,7 +57,8 @@ const useQuestion = (question, draft) => {
       questionHeader: header,
       questionFooter: footer,
       dataKey,
-      warning: (validateOrWarn && validateOrWarn(draft[dataKey])) || null,
+      warning:
+        (validateOrWarn && validateOrWarn(draft[dataKey], question)) || null,
       skippable:
         !required &&
         R.equals(
@@ -241,7 +244,7 @@ export const QuestionPropType = shape({
   search: func,
   placeholder: string,
   footnote: oneOfType([string, func]),
-  options: arrayOf(string),
+  options: arrayOf(OptionPropType),
   ratingLabels: arrayOf(string.isRequired),
   renderCustomizedQuestion: func,
 });


### PR DESCRIPTION
#886 

## 這個 PR 是？ <!-- 必填 -->

此PR重構多選題的兩個部分：
1. `options` 改為 `[{label, value}]` 的形式。若為 `[string]` 則會以 `[{label: string, value: string}]` 相容。
1. 先前一律假設 `options` 的「最後一個選項」作為「其他」。為了增加往後彈性，新增 `elseOptionValue` 作為「其他」選項的認定。

## Screenshots

![Screenshot 2024-02-05 at 12 16 45 PM](https://github.com/goodjoblife/GoodJobShare/assets/7566586/5fc625b9-ddbf-4ff7-b277-0ba33c837bac)



## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share 面試表單的單選題/多選題應功能不受影響