### PR TITLE
feature: redirect company, job_title overview url with status code 301

### DIFF
--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -5,12 +5,13 @@ import { createStructuredSelector } from 'reselect';
 import { withProps, lifecycle, compose, setStatic } from 'recompose';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import Overview from '../CompanyAndJobTitle/Overview';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 import NotFound from 'common/NotFound';
+import Redirect from 'common/routing/Redirect';
 import { withPermission } from 'common/permission-context';
 
 import { tabType, pageType } from 'constants/companyJobTitle';

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -5,12 +5,13 @@ import { createStructuredSelector } from 'reselect';
 import { withProps, lifecycle, compose, setStatic } from 'recompose';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route } from 'react-router-dom';
 import Overview from '../CompanyAndJobTitle/Overview';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 import NotFound from 'common/NotFound';
+import Redirect from 'common/routing/Redirect';
 import { withPermission } from 'common/permission-context';
 
 import { tabType, pageType } from 'constants/companyJobTitle';


### PR DESCRIPTION
Close #1210

## 這個 PR 是？ <!-- 必填 -->

修正 `/companies/:company/overview` 的重新導向 code

## 測試方法

production:
```
% curl -i "https://www.goodjob.life/companies/Goodjob"
HTTP/2 302
location: /companies/Goodjob/overview
```

before PR:

```
% curl -i "http://localhost:3000/companies/Goodjob"
HTTP/1.1 302 Found
Location: /companies/Goodjob/overview
```

after PR

```
% curl -i "http://localhost:3000/companies/Goodjob"
HTTP/1.1 301 Moved Permanently
Location: /companies/Goodjob/overview
```
