### PR TITLE
feat: end salary A/B testing

### DIFF
--- a/src/components/common/ShareExpSection/index.js
+++ b/src/components/common/ShareExpSection/index.js
@@ -6,9 +6,9 @@ import InterviewImg from './share-2.png';
 import WorkExperienceImg from './share-3.png';
 import SalaryWorkTimeImg from './share-1.png';
 import styles from './ShareExpSection.module.css';
-import { useShareLink } from 'hooks/experiments';
 import {
   generateShareInterviewTypeForm,
+  generateShareTimeSalaryTypeForm,
   generateShareWork,
 } from './shareLinkTo';
 
@@ -22,8 +22,6 @@ const DefaultSubheading = () => (
 );
 
 const ShareExpSection = ({ heading, Subheading }) => {
-  // TODO: after AB testing, should update it.
-  const shareSalaryLink = useShareLink();
   return (
     <Section padding>
       <Wrapper size="l">
@@ -60,7 +58,7 @@ const ShareExpSection = ({ heading, Subheading }) => {
               想推薦工作、爆料的，這邊請！
             </P>
           </Link>
-          <Link to={shareSalaryLink} className={styles.item}>
+          <Link to={generateShareTimeSalaryTypeForm()} className={styles.item}>
             <img
               src={SalaryWorkTimeImg}
               alt="留下工時或薪資"

--- a/src/hooks/experiments/useShareLink.js
+++ b/src/hooks/experiments/useShareLink.js
@@ -2,26 +2,18 @@ import { useEffect } from 'react';
 import { useLocation } from 'react-use';
 import { path } from 'ramda';
 import {
-  generateShareTimeSalaryOnePage,
   generateShareTimeSalaryTypeForm,
-  generateShareTimeSalaryTypeFormHideProgressBar,
+  generateShareInterviewTypeForm,
 } from 'common/ShareExpSection/shareLinkTo';
 
 const ACTIONS = [
   {
-    prob: 0.34,
-    type: 'SALARY_FORM_ONE_PAGE',
-    generateTo: generateShareTimeSalaryOnePage,
-  },
-  {
-    prob: 0.33,
-    type: 'SALARY_FORM_TYPE_FORM',
+    prob: 0.75,
     generateTo: generateShareTimeSalaryTypeForm,
   },
   {
-    prob: 0.33,
-    type: 'SALARY_FORM_TYPE_FORM_NO_PROGRESS',
-    generateTo: generateShareTimeSalaryTypeFormHideProgressBar,
+    prob: 0.25,
+    generateTo: generateShareInterviewTypeForm,
   },
 ];
 


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. 結束 Salary form A/B testing，一頁一題式＆有 progress bar 的結果最好（觀察三天、五天結果都是一樣顯著），因此都導流到這個 variant
2. 根據 google search console 的數據，設定為 75% 薪水、25% 面試

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share 的薪資工時會 100% 到薪資表單一頁一題式有 progress bar
- [ ] 薪資、工作＆面試心得 lock 頁面的導流，會 25% 到面試，75% 到薪水