### PR TITLE
Feat/user feedback safari animation

### DIFF
--- a/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
+++ b/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
@@ -3,9 +3,14 @@
 .container {
   position: fixed;
   top: 50%;
-  right: 0;
   transform: translateY(-50%);
   z-index: 9;
+  display: none;
+}
+
+.applyStyle {
+  right: 0;
+  display: flex;
 }
 
 .label {

--- a/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
+++ b/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
@@ -5,10 +5,6 @@
   top: 50%;
   transform: translateY(-50%);
   z-index: 9;
-  display: none;
-}
-
-.applyStyle {
   right: 0;
   display: flex;
 }

--- a/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
+++ b/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
@@ -25,5 +25,11 @@
   padding: 2rem 0.5rem;
   letter-spacing: 0.3rem;
   line-height: 19px;
+  transform: translateX(2px);
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+.label:hover {
   box-shadow: 0px 0px 7px 0px main-black;
+  transform: translateX(0px);
 }

--- a/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
+++ b/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
@@ -33,3 +33,9 @@
   box-shadow: 0px 0px 7px 0px main-black;
   transform: translateX(0px);
 }
+
+@-moz-document url-prefix() {
+  .container {
+    transform: translateX(-100%) translateY(-50%);
+  }
+}

--- a/src/components/common/Questionnaire/CollapsedDrawer/index.js
+++ b/src/components/common/Questionnaire/CollapsedDrawer/index.js
@@ -1,21 +1,15 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import styles from './CollapsedDrawer.module.css';
 import { LS_USER_FEEDBACK_SUBMISSION_TIME_KEY } from 'constants/localStorageKey';
-import cn from 'classnames';
 
 const THIRTY_DAYS_IN_MILLISECONDS = 1000 * 60 * 60 * 24 * 30;
 
 const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isApplyStyle, setIsApplyStyle] = useState(false);
 
   const handleToggleModalOpen = useCallback(() => {
     setIsExpanded(prev => !prev);
   }, []);
-
-  useEffect(() => {
-    setIsApplyStyle(!isExpanded);
-  }, [isExpanded]);
 
   if (typeof window !== 'undefined') {
     const lastSubmissionTime = Number(
@@ -40,10 +34,7 @@ const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
   if (isExpanded) return childrenWithProps;
 
   return (
-    <div
-      className={cn(styles.container, { [styles.applyStyle]: isApplyStyle })}
-      onClick={handleToggleModalOpen}
-    >
+    <div className={styles.container} onClick={handleToggleModalOpen}>
       <div className={styles.label}>{title}</div>
     </div>
   );

--- a/src/components/common/Questionnaire/CollapsedDrawer/index.js
+++ b/src/components/common/Questionnaire/CollapsedDrawer/index.js
@@ -1,14 +1,21 @@
-import React, { useState, Fragment, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import styles from './CollapsedDrawer.module.css';
 import { LS_USER_FEEDBACK_SUBMISSION_TIME_KEY } from 'constants/localStorageKey';
+import cn from 'classnames';
 
 const THIRTY_DAYS_IN_MILLISECONDS = 1000 * 60 * 60 * 24 * 30;
 
 const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isApplyStyle, setIsApplyStyle] = useState(false);
+
   const handleToggleModalOpen = useCallback(() => {
     setIsExpanded(prev => !prev);
   }, []);
+
+  useEffect(() => {
+    setIsApplyStyle(!isExpanded);
+  }, [isExpanded]);
 
   if (typeof window !== 'undefined') {
     const lastSubmissionTime = Number(
@@ -27,13 +34,16 @@ const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
   }
 
   const childrenWithProps = React.Children.map(children, child =>
-    React.cloneElement(child, { handleToggleModalOpen }),
+    React.cloneElement(child, { handleToggleModalOpen, isExpanded }),
   );
 
-  if (isExpanded) return <Fragment>{childrenWithProps}</Fragment>;
+  if (isExpanded) return childrenWithProps;
 
   return (
-    <div className={styles.container} onClick={handleToggleModalOpen}>
+    <div
+      className={cn(styles.container, { [styles.applyStyle]: isApplyStyle })}
+      onClick={handleToggleModalOpen}
+    >
       <div className={styles.label}>{title}</div>
     </div>
   );

--- a/src/components/common/Questionnaire/CollapsedDrawer/index.js
+++ b/src/components/common/Questionnaire/CollapsedDrawer/index.js
@@ -28,7 +28,7 @@ const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
   }
 
   const childrenWithProps = React.Children.map(children, child =>
-    React.cloneElement(child, { handleToggleModalOpen, isExpanded }),
+    React.cloneElement(child, { handleToggleModalOpen }),
   );
 
   if (isExpanded) return childrenWithProps;

--- a/src/components/common/Questionnaire/ExpandedModal/ExpandedModal.module.css
+++ b/src/components/common/Questionnaire/ExpandedModal/ExpandedModal.module.css
@@ -1,5 +1,16 @@
 @value main-yellow from "common/variables.module.css";
 
+@keyframes slideIn {
+  from {
+    transform: translateX(100%) translateY(-50%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0) translateY(-50%);
+    opacity: 1;
+  }
+}
+
 .container {
   position: fixed;
   top: 50%;
@@ -18,6 +29,7 @@
   flex-direction: column;
   justify-content: space-between;
   box-shadow: 0px 0px 19px 0px rgba(0, 0, 0, 0.2);
+  animation: slideIn 0.2s ease-in-out;
 }
 
 .question {

--- a/src/components/common/Questionnaire/ExpandedModal/ExpandedModal.module.css
+++ b/src/components/common/Questionnaire/ExpandedModal/ExpandedModal.module.css
@@ -10,6 +10,14 @@
     opacity: 1;
   }
 }
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
 
 .container {
   position: fixed;
@@ -130,6 +138,7 @@
     right: auto;
     margin: 0;
     transform: translate(-50%, -50%);
+    animation: fadeIn 0.2s ease-in-out;
   }
 }
 

--- a/src/components/common/Questionnaire/ExpandedModal/ScoreRange/ScoreRange.module.css
+++ b/src/components/common/Questionnaire/ExpandedModal/ScoreRange/ScoreRange.module.css
@@ -13,6 +13,7 @@
   position: relative;
   cursor: pointer;
   border-radius: 8px;
+  height: 5px;
 }
 
 /* Chrome, Safari, Opera and Edge Chromium styles */
@@ -31,10 +32,6 @@
 }
 
 /* Firefox styles */
-.range input[type='range']::-moz-range-track {
-  height: 5px;
-}
-
 .range input[type='range']::-moz-range-thumb {
   background-color: main-black;
   border: none; /* Removes extra border that FF applies */


### PR DESCRIPTION
Close #1235 

## 這個 PR 是？
1. 修正 side bar (CollapsedDrawer) 在 Safari 以及 Firefox 位置偏移問題，[Issue Link](https://github.com/goodjoblife/GoodJobShare/issues/1235?fbclid=IwAR2MSoXEmfXq9fbL-91cQ9nxxCJ1JRKASdxPJ2orcYcPhawgT7XHOkM4-ko_aem_AX-E_psI-xSumtNwAx6vaJl8efTehZKYhUXVzXsX7OrtbBCN_IqUgqoPanZhr5QpdaOTqrZCP1H8ujbZnzg4OR89)。
2. 新增 label hover 樣式；新增 animation 效果，桌機、手機 animation 效果略有不同。



## Screenshots
修正 Safari 及 Firefox 上 side bar 位置，新增動畫效果。
![Screen Recording Mar](https://github.com/goodjoblife/GoodJobShare/assets/30387546/5e5a3895-80ee-4eca-b5c4-35aba84947ae)
p.s. 點選時會有圈圈效果，是因為錄影軟體的關係，實際上不會有。

## 我應該如何手動測試？ <!-- 必填 -->
1. 在 Safari, Firefox 驗證 side bar 樣式正確。
2. 收合功能正常，收合後樣式正確。 
4. hover side bar，有稍微變大，點選 side bar，ExpandedModal 有動畫效果。