### PR TITLE
[API] 移除 /companies/search

### DIFF
--- a/src/apis/companySearchApi.js
+++ b/src/apis/companySearchApi.js
@@ -1,6 +1,0 @@
-import fetchUtil from 'utils/fetchUtil';
-
-const endpoint = '/companies/search';
-
-export const getCompaniesSearch = ({ key }) =>
-  fetchUtil(endpoint).get({ query: { key } });

--- a/src/components/ShareExperience/common/CompanyQuery.js
+++ b/src/components/ShareExperience/common/CompanyQuery.js
@@ -6,7 +6,7 @@ import AutoCompleteTextInput from 'common/form/AutoCompleteTextInput';
 import { debounce } from 'utils/streamUtils';
 
 import InputTitle from './InputTitle';
-import { getCompaniesSearch } from 'apis/companySearchApi';
+import { fetchSearchCompany } from 'apis/timeAndSalaryApi';
 
 const getItemValue = item => item.label;
 
@@ -26,7 +26,7 @@ class CompanyQuery extends React.Component {
 
   search = debounce((e, value) => {
     if (value) {
-      return getCompaniesSearch({ key: value })
+      return fetchSearchCompany({ companyName: value })
         .then(r =>
           Array.isArray(r)
             ? this.handleAutocompleteItems(r.map(mapToAutocompleteList))

--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -58,7 +58,7 @@ import {
   isValidSalary,
   isNumber,
 } from './utils';
-import { getCompaniesSearch } from 'apis/companySearchApi';
+import { fetchSearchCompany } from 'apis/timeAndSalaryApi';
 import { getJobTitlesSearch } from 'apis/jobTitleSearchApi';
 import { employmentTypeOptions, salaryTypeOptions } from './common/optionMap';
 import WorkTimeExample from './WorkTimeExample';
@@ -83,7 +83,7 @@ export const createCompanyQuestion = ({ header }) => ({
   validateOrWarn: value => isEmpty(value) && '請填寫公司名稱',
   placeholder: 'ＯＯ 股份有限公司',
   search: value =>
-    getCompaniesSearch({ key: value }).then(
+    fetchSearchCompany({ companyName: value }).then(
       ifElse(isArray, map(prop('name')), always([])),
     ),
   header,


### PR DESCRIPTION
Close #1239 #1240  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

移除舊版 `/companies/search`
改用 `Query.search_companies`

## Screenshots  <!-- 選填，沒有就刪掉 -->

<table>
<tr>
<th>一頁一題公司名稱</th>
<td>

https://github.com/goodjoblife/GoodJobShare/assets/7566586/0b0a12fc-a96b-4c7f-b8d3-60d91078b101

</td>
</tr>
<tr>
<th>舊版面試表單</th>
<td>

https://github.com/goodjoblife/GoodJobShare/assets/7566586/65f7a08e-1e0e-4d5e-8104-4ed453250465

</td>
</tr>
<tr>
<th>公司表單</th>
<td>

https://github.com/goodjoblife/GoodJobShare/assets/7566586/5a823a2d-86c1-4b8e-b249-b8d885820181

</td>
</tr>
</table>








## 我應該如何手動測試？ <!-- 必填 -->

測試以下autocomplete:
- [ ] 分享經驗 > 面試經驗 > 公司名稱
- [ ] /share/interview-one-page
- [ ] /share/work-experiences