### PR TITLE
feat: send fb login error message to rollbar and display toast

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -86,27 +86,26 @@ export const loginWithFB = FBSDK => async (dispatch, getState) => {
     dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0003');
   }
 
-  if (fbLoginResponse.status === authStatus.CANCELED) {
-    return;
-  }
-
-  if (fbLoginResponse.status === authStatus.NOT_AUTHORIZED) {
-    dispatch(setLogin(authStatus.NOT_AUTHORIZED));
-    dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0004');
-  }
-
-  if (fbLoginResponse.status === authStatus.CONNECTED) {
-    try {
-      // call GoodJob GraphQL API to get JWT token issued by GoodJob
-      const { token } = await postAuthFacebookApi({
-        accessToken: fbLoginResponse.authResponse.accessToken,
-      });
-      await dispatch(loginWithToken(token));
-    } catch (error) {
-      dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0005', error);
-    }
-  } else {
-    dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0006');
+  switch (fbLoginResponse.status) {
+    case authStatus.CANCELED:
+      return;
+    case authStatus.NOT_AUTHORIZED:
+      dispatch(setLogin(authStatus.NOT_AUTHORIZED));
+      dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0004');
+      break;
+    case authStatus.CONNECTED:
+      try {
+        // call GoodJob GraphQL API to get JWT token issued by GoodJob
+        const { token } = await postAuthFacebookApi({
+          accessToken: fbLoginResponse.authResponse.accessToken,
+        });
+        await dispatch(loginWithToken(token));
+      } catch (error) {
+        dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0005', error);
+      }
+      break;
+    default:
+      dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0006');
   }
 };
 

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -57,7 +57,9 @@ export const loginWithFB = FB => (dispatch, getState) => {
                   '[ER0000] 登入時發生錯誤，若持續發生，請聯繫 findyourgoodjob@gmail.com',
                 ),
               );
-              rollbar.error(`Graphql mutation facebookLogin failed: ${error}`);
+              rollbar.error(
+                `[ER0000] Graphql mutation facebookLogin failed: ${error}`,
+              );
             });
         } else if (response.status === authStatus.NOT_AUTHORIZED) {
           dispatch(
@@ -66,7 +68,7 @@ export const loginWithFB = FB => (dispatch, getState) => {
               '[ER0001] 登入時發生錯誤，若持續發生，請聯繫 findyourgoodjob@gmail.com',
             ),
           );
-          rollbar.error(`FB login failed: unauthorized`);
+          rollbar.error(`[ER0001] FB login failed: unauthorized`);
           dispatch(setLogin(authStatus.NOT_AUTHORIZED));
         }
         return response.status;
@@ -78,7 +80,7 @@ export const loginWithFB = FB => (dispatch, getState) => {
             '[ER0002] 登入時發生錯誤，若持續發生，請聯繫 findyourgoodjob@gmail.com',
           ),
         );
-        rollbar.error(`FB login failed: ${error}`);
+        rollbar.error(`[ER0002] FB login failed: ${error}`);
       });
   }
   dispatch(
@@ -87,7 +89,7 @@ export const loginWithFB = FB => (dispatch, getState) => {
       '[ER0003] 登入時發生錯誤，若持續發生，請聯繫 findyourgoodjob@gmail.com',
     ),
   );
-  rollbar.error('FB SDK is not ready');
+  rollbar.error('[ER0003] FB SDK is not ready');
   return Promise.reject(new Error('FB is not ready'));
 };
 

--- a/src/components/ToastNotification/Notification.js
+++ b/src/components/ToastNotification/Notification.js
@@ -5,13 +5,11 @@ import { NOTIFICATION_TYPE } from 'constants/toastNotification';
 import useRemoveNotification from 'hooks/toastNotification/useRemoveToast';
 import useTimer, { countingStatusMap } from 'hooks/useTimer';
 import CloseNoCircle from 'common/icons/CloseNoCircle';
-import Checked from 'common/icons/Checked';
-import Close from 'common/icons/Close';
-import Exclamation from 'common/icons/Exclamation';
 import { P } from 'common/base';
 
-import { getOffsetY, statusMap, getIconColor } from './helpers';
+import { getOffsetY, statusMap } from './helpers';
 import styles from './Notification.module.css';
+import NotificationIcon from './NotificationIcon';
 
 const FADE_OUT_TIME = 5000;
 const SUNSET_TIME_IN_SEC = 0.6;
@@ -46,20 +44,6 @@ const Notification = ({ index, type, content, id }) => {
   const offsetY = `${calOffsetY(index)}px`;
   const opacity = status === statusMap.ACTIVE ? 100 : 0;
 
-  const iconColor = getIconColor(type);
-
-  const renderIcon = () => {
-    if (type == NOTIFICATION_TYPE.INFO) {
-      return <Checked className={styles.icon} style={{ fill: iconColor }} />;
-    } else if (type == NOTIFICATION_TYPE.WARNING) {
-      return (
-        <Exclamation className={styles.icon} style={{ fill: iconColor }} />
-      );
-    } else {
-      return <Close className={styles.icon} style={{ fill: iconColor }} />;
-    }
-  };
-
   return (
     <div
       className={styles.container}
@@ -70,7 +54,7 @@ const Notification = ({ index, type, content, id }) => {
       }}
     >
       <div className={styles.left}>
-        {renderIcon()}
+        <NotificationIcon type={type} />
         <P tag="p" className={styles.message} title={content}>{`${content}`}</P>
       </div>
       <div className={styles.right}>

--- a/src/components/ToastNotification/Notification.js
+++ b/src/components/ToastNotification/Notification.js
@@ -6,6 +6,8 @@ import useRemoveNotification from 'hooks/toastNotification/useRemoveToast';
 import useTimer, { countingStatusMap } from 'hooks/useTimer';
 import CloseNoCircle from 'common/icons/CloseNoCircle';
 import Checked from 'common/icons/Checked';
+import Close from 'common/icons/Close';
+import Exclamation from 'common/icons/Exclamation';
 import { P } from 'common/base';
 
 import { getOffsetY, statusMap, getIconColor } from './helpers';
@@ -46,18 +48,29 @@ const Notification = ({ index, type, content, id }) => {
 
   const iconColor = getIconColor(type);
 
+  const renderIcon = () => {
+    if (type == NOTIFICATION_TYPE.INFO) {
+      return <Checked className={styles.icon} style={{ fill: iconColor }} />;
+    } else if (type == NOTIFICATION_TYPE.WARNING) {
+      return (
+        <Exclamation className={styles.icon} style={{ fill: iconColor }} />
+      );
+    } else {
+      return <Close className={styles.icon} style={{ fill: iconColor }} />;
+    }
+  };
+
   return (
     <div
       className={styles.container}
       style={{
-        height: `${HEIGHT}px`,
         transform: `translateY(${offsetY})`,
         opacity,
         transition: `transform 0.6s ease-in, opacity ${SUNSET_TIME_IN_SEC}s ease-in`,
       }}
     >
       <div className={styles.left}>
-        <Checked className={styles.icon} style={{ fill: iconColor }} />
+        {renderIcon()}
         <P tag="p" className={styles.message} title={content}>{`${content}`}</P>
       </div>
       <div className={styles.right}>

--- a/src/components/ToastNotification/Notification.module.css
+++ b/src/components/ToastNotification/Notification.module.css
@@ -44,9 +44,3 @@
   text-overflow: ellipsis;
   overflow: hidden;
 }
-
-.icon {
-  height: 24px;
-  width: 24px;
-  margin-right: 14px;
-}

--- a/src/components/ToastNotification/Notification.module.css
+++ b/src/components/ToastNotification/Notification.module.css
@@ -40,7 +40,7 @@
 }
 
 .message {
-  white-space: nowrap;
+  word-break: break-all;
   text-overflow: ellipsis;
   overflow: hidden;
 }

--- a/src/components/ToastNotification/NotificationIcon.js
+++ b/src/components/ToastNotification/NotificationIcon.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import Checked from 'common/icons/Checked';
+import Close from 'common/icons/Close';
+import Exclamation from 'common/icons/Exclamation';
+import { NOTIFICATION_TYPE } from 'constants/toastNotification';
+import styles from './NotificationIcon.module.css';
+import { getIconColor } from './helpers';
+
+const NotificationIcon = ({ type }) => {
+  const iconColor = getIconColor(type);
+
+  if (type === NOTIFICATION_TYPE.INFO) {
+    return <Checked className={styles.icon} style={{ fill: iconColor }} />;
+  } else if (type === NOTIFICATION_TYPE.WARNING) {
+    return <Exclamation className={styles.icon} style={{ fill: iconColor }} />;
+  } else {
+    return <Close className={styles.icon} style={{ fill: iconColor }} />;
+  }
+};
+
+export default NotificationIcon;

--- a/src/components/ToastNotification/NotificationIcon.module.css
+++ b/src/components/ToastNotification/NotificationIcon.module.css
@@ -1,0 +1,5 @@
+.icon {
+  height: 24px;
+  width: 24px;
+  margin-right: 14px;
+}

--- a/src/components/ToastNotification/ToastNotification.module.css
+++ b/src/components/ToastNotification/ToastNotification.module.css
@@ -1,7 +1,7 @@
 @value NAV_HEIGHT, NAV_MOBILE_HEIGHT, TOP_HEIGHT, above-small from "common/variables.module.css";
 
 .container {
-  z-index: 99;
+  z-index: 10000;
   position: fixed;
   top: calc(NAV_MOBILE_HEIGHT);
   right: 0;

--- a/src/constants/authStatus.js
+++ b/src/constants/authStatus.js
@@ -1,5 +1,6 @@
 export default {
   CONNECTED: 'connected',
   NOT_AUTHORIZED: 'not_authorized',
+  CANCELED: 'canceled',
   UNKNOWN: 'unknown',
 };

--- a/src/constants/errorCodeMsg.js
+++ b/src/constants/errorCodeMsg.js
@@ -1,0 +1,30 @@
+const LOGIN_ERROR_MSG =
+  '登入時發生錯誤，請再重試一次。若錯誤持續發生，請聯繫 findyourgoodjob@gmail.com';
+
+// maintain a list of global error code
+export const ERROR_CODE_MSG = {
+  ER0001: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'FB SDK is not ready',
+  },
+  ER0002: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'FB SDK login failed',
+  },
+  ER0003: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'FB login response is empty or does not have status field',
+  },
+  ER0004: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'FB login failed: unauthorized',
+  },
+  ER0005: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'Graphql mutation facebookLogin failed',
+  },
+  ER0006: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'FB login failed: unknown auth status',
+  },
+};


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. FB 登入發生錯誤時，送錯誤訊息到 rollbar (ref: https://github.com/goodjoblife/GoodJobShare/pull/1140)
2. FB 登入發生錯誤時，顯示 toast 訊息，並且有錯誤代碼，讓使用者可以回報，我們會更好 debug

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="958" alt="Screenshot 2024-05-02 at 12 18 18 AM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/f9daf498-7c65-48bd-b317-1ab9e7bbc47e">

<img width="355" alt="Screenshot 2024-05-02 at 12 18 25 AM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/f975fa95-bf36-4574-aebd-8de5082e3a46">

<img width="611" alt="Screenshot 2024-05-02 at 12 21 54 AM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/ba6df652-3c1f-4ea4-9013-8eab8f69dcb9">


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 故意在不同地方丟 error 看不同錯誤訊息
- [ ] FB 登入看看
- [ ] <!-- 列出給 Reviewer 的 Step By Step Checklist -->