### PR TITLE
feat: add extra field to rollbar.error

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -55,6 +55,7 @@ const dispatchNotificationAndRollbarAndThrowError = (
   dispatch,
   errorCode,
   error,
+  extra,
 ) => {
   dispatch(loginErrorToast(errorCode, ERROR_CODE_MSG[errorCode].external));
   const internalMsg = composeErrMsg(
@@ -62,7 +63,11 @@ const dispatchNotificationAndRollbarAndThrowError = (
     ERROR_CODE_MSG[errorCode].internal,
     error,
   );
-  rollbar.error(internalMsg);
+  if (!extra) {
+    rollbar.error(internalMsg);
+  } else {
+    rollbar.error(internalMsg, extra);
+  }
   throw new Error(internalMsg);
 };
 
@@ -105,7 +110,12 @@ export const loginWithFB = FBSDK => async (dispatch, getState) => {
       }
       break;
     default:
-      dispatchNotificationAndRollbarAndThrowError(dispatch, 'ER0006');
+      dispatchNotificationAndRollbarAndThrowError(
+        dispatch,
+        'ER0006',
+        null,
+        fbLoginResponse,
+      );
   }
 };
 


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

現在已經有從 rollbar 追蹤 FB 登入發生錯誤的狀況。可以從下圖看出來大部分錯誤是 ER0006，fb API repsonse 的 status 是我們不知道的 status

<img width="944" alt="Screenshot 2024-05-06 at 11 08 52 PM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/f097efba-ef70-4ff1-8e69-1cfb072bd10a">

但原本錯誤訊息不夠詳細，無法進一步 troubleshooting ，因此根據 [rollbar 官方文件](https://docs.rollbar.com/docs/rollbarjs-configuration-reference#rollbarlog)，帶上 extra 欄位（fb API response）

## Screenshots  <!-- 選填，沒有就刪掉 -->

故意把 status 設成 `unknown` 製造一個 ER0006 ，payload 的內容
<img width="831" alt="Screenshot 2024-05-06 at 11 01 27 PM" src="https://github.com/goodjoblife/GoodJobShare/assets/3805975/589384b0-25bc-410c-870c-300fe92dbf82">

（意外的是 rollbar SDK 會幫擋 access token）


## 有什麼背景知識是我需要知道的？  <!-- 選填，沒有就刪掉 -->

<!-- 如果有 Paper、InVision 或使用的 3rd-party library or service，請附上文件連結 -->

## 我應該從何看起？  <!-- 選填，沒有就刪掉 -->

<!-- 這個 PR 要怎麼 review 才會比較好懂 (e.g. by commit 看，或先看哪些檔案) -->
<!-- 介紹一下你為什麼要這麼寫，思路是什麼？ -->

## Questions:  <!-- 選填，沒有就刪掉 -->

- 我需要更新 Packages 嗎？ No <!-- Yes / No -->
- 有哪些文件需要被更新嗎？ No <!-- 文件的連結 -->

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] FB 要可以正常登入
- [ ] 故意製造錯誤，看 rollbar payload