### PR TITLE
feat: remove fb login announcement & enhance toast of FB login issue

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -17,7 +17,6 @@ import ShareSalaryWorkTimesModal from '../ShareExperience/TimeSalaryForm/TypeFor
 import routes from '../../routes';
 import CollapsedDrawer from 'common/Questionnaire/CollapsedDrawer';
 import NetPromoter from 'common/Questionnaire/ExpandedModal';
-import AnnoucementModal from '../Annoucement';
 
 const useShare = () => {
   const location = useLocation();
@@ -68,7 +67,6 @@ const App = () => {
       <CollapsedDrawer>
         <NetPromoter />
       </CollapsedDrawer>
-      <AnnoucementModal />
     </Fragment>
   );
 };

--- a/src/constants/errorCodeMsg.js
+++ b/src/constants/errorCodeMsg.js
@@ -1,6 +1,9 @@
 const LOGIN_ERROR_MSG =
   '登入時發生錯誤，請再重試一次。若錯誤持續發生，請聯繫 findyourgoodjob@gmail.com';
 
+const LOGIN_ERROR_MSG_CLEAN_BROWSER_DATA =
+  '登入時發生錯誤，請清除瀏覽器資料，再重試一次。若錯誤持續發生，請聯繫 findyourgoodjob@gmail.com';
+
 // maintain a list of global error code
 export const ERROR_CODE_MSG = {
   ER0001: {
@@ -24,7 +27,7 @@ export const ERROR_CODE_MSG = {
     internal: 'Graphql mutation facebookLogin failed',
   },
   ER0006: {
-    external: LOGIN_ERROR_MSG,
+    external: LOGIN_ERROR_MSG_CLEAN_BROWSER_DATA,
     internal: 'FB login failed: unknown auth status',
   },
 };


### PR DESCRIPTION

## 這個 PR 是？ <!-- 必填 -->

1. 移除全站蓋板公告，現在每天遇到 fb login issue 的人數已經相對少 (<40）
2. 遇到 ER0006 (fb response unknown status)，提醒使用者清除瀏覽器資料
3. refactor dispatch 的使用方法 

## Screenshots  <!-- 選填，沒有就刪掉 -->

![Screenshot 2024-05-11 at 5 43 52 PM](https://github.com/goodjoblife/GoodJobShare/assets/3805975/9acc04e5-2bf1-4c7e-9fa1-a352b3276551)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 可以正常 FB 登入
- [ ] 故意 fbLoginResponse.status = 'unknown' 測試錯誤訊息