### PR TITLE
[公司頁面] 面試卡片和工作卡片皆顯示 original company name

### DIFF
--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -22,7 +22,7 @@ const ExperienceEntry = ({
   pageType,
   data: {
     id,
-    company: { name: companyName } = {},
+    originalCompanyName,
     job_title: { name: jobTitle } = {},
     created_at: createdAt,
     salary,
@@ -70,7 +70,7 @@ const ExperienceEntry = ({
           size={size === 'l' ? 'sl' : 'sm'}
           className={styles.heading}
         >
-          {companyName} {jobTitle}
+          {originalCompanyName} {jobTitle}
         </Heading>
 
         <div className={styles.snippetWrapper}>
@@ -91,7 +91,24 @@ const ExperienceEntry = ({
 );
 
 ExperienceEntry.propTypes = {
-  data: PropTypes.object.isRequired,
+  data: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    originalCompanyName: PropTypes.string.isRequired,
+    job_title: PropTypes.shape({ name: PropTypes.string.isRequired })
+      .isRequired,
+    created_at: PropTypes.string.isRequired,
+    salary: PropTypes.shape({
+      type: PropTypes.string.isRequired,
+      amount: PropTypes.number.isRequired,
+    }),
+    overall_rating: PropTypes.number.isRequired,
+    sections: PropTypes.arrayOf(
+      PropTypes.shape({
+        subtitle: PropTypes.string,
+        content: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+  }).isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
   canView: PropTypes.bool.isRequired,
 };

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -24,7 +24,7 @@ const ExperienceEntry = ({
   pageType,
   data: {
     id,
-    company: { name: companyName } = {},
+    originalCompanyName,
     job_title: { name: jobTitle } = {},
     created_at: createdAt,
     sections: [section],
@@ -80,7 +80,7 @@ const ExperienceEntry = ({
           size={size === 'l' ? 'sl' : 'sm'}
           className={styles.heading}
         >
-          {companyName} {jobTitle}
+          {originalCompanyName} {jobTitle}
         </Heading>
 
         <div className={styles.snippetWrapper}>
@@ -101,7 +101,25 @@ const ExperienceEntry = ({
 );
 
 ExperienceEntry.propTypes = {
-  data: PropTypes.object.isRequired,
+  data: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    originalCompanyName: PropTypes.string.isRequired,
+    job_title: PropTypes.shape({ name: PropTypes.string.isRequired })
+      .isRequired,
+    created_at: PropTypes.string.isRequired,
+    sections: PropTypes.arrayOf(
+      PropTypes.shape({
+        subtitle: PropTypes.string,
+        content: PropTypes.string.isRequired,
+      }),
+    ).isRequired,
+    week_work_time: PropTypes.number,
+    salary: PropTypes.shape({
+      type: PropTypes.string.isRequired,
+      amount: PropTypes.number.isRequired,
+    }),
+    recommend_to_others: PropTypes.string,
+  }).isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
   canView: PropTypes.bool.isRequired,
 };

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -4,9 +4,7 @@ query($companyName: String!) {
     interview_experiences {
       id
       type
-      company {
-        name
-      }
+      originalCompanyName
       job_title {
         name
       }
@@ -30,9 +28,7 @@ query($companyName: String!) {
     work_experiences {
       id
       type
-      company {
-        name
-      }
+      originalCompanyName
       job_title {
         name
       }

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -5,6 +5,9 @@ query($companyName: String!) {
       id
       type
       originalCompanyName
+      company {
+        name
+      }
       job_title {
         name
       }
@@ -29,6 +32,9 @@ query($companyName: String!) {
       id
       type
       originalCompanyName
+      company {
+        name
+      }
       job_title {
         name
       }


### PR DESCRIPTION
Close #1246

## 這個 PR 是？ <!-- 必填 -->

將公司頁面的面試和經驗區塊改顯示 original company name

## Screenshots  <!-- 選填，沒有就刪掉 -->

每個卡片都顯示不同的 company name 但指的是同一個公司

![Screenshot 2024-06-05 at 01-00-59 台灣積體電路製造股份有限公司 總覽 GoodJob 職場透明化運動](https://github.com/goodjoblife/GoodJobShare/assets/7566586/d8e7cc4d-0423-4183-b6fd-36d87d9109c9)


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/companies/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8