### PR TITLE
[職稱薪時頁面] 顯示 originalCompanyName

### DIFF
--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -93,7 +93,7 @@ const ExperienceEntry = ({
 ExperienceEntry.propTypes = {
   data: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    originalCompanyName: PropTypes.string.isRequired,
+    originalCompanyName: PropTypes.string,
     job_title: PropTypes.shape({ name: PropTypes.string.isRequired })
       .isRequired,
     created_at: PropTypes.string.isRequired,

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -103,7 +103,7 @@ const ExperienceEntry = ({
 ExperienceEntry.propTypes = {
   data: PropTypes.shape({
     id: PropTypes.string.isRequired,
-    originalCompanyName: PropTypes.string.isRequired,
+    originalCompanyName: PropTypes.string,
     job_title: PropTypes.shape({ name: PropTypes.string.isRequired })
       .isRequired,
     created_at: PropTypes.string.isRequired,

--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -26,8 +26,9 @@ export const getJobTitle = item => {
 };
 
 export const getNameAsCompanyName = (o, row) => (
-  <Link to={`/companies/${encodeURIComponent(row.originalCompanyName)}`}>
-    {o.name} <span className={`pM ${styles.sector}`}>{row.sector}</span>
+  <Link to={`/companies/${encodeURIComponent(o.name)}`}>
+    {row.originalCompanyName}{' '}
+    <span className={`pM ${styles.sector}`}>{row.sector}</span>
   </Link>
 );
 

--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -26,7 +26,7 @@ export const getJobTitle = item => {
 };
 
 export const getNameAsCompanyName = (o, row) => (
-  <Link to={`/companies/${encodeURIComponent(o.name)}`}>
+  <Link to={`/companies/${encodeURIComponent(row.originalCompanyName)}`}>
     {o.name} <span className={`pM ${styles.sector}`}>{row.sector}</span>
   </Link>
 );

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -82,6 +82,7 @@ query($jobTitle: String!) {
       company {
         name
       }
+      originalCompanyName
       data_time {
         month
         year


### PR DESCRIPTION
Close #1276   <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

在職稱頁面查看薪資工時，看到列出的公司名稱是 originalCompanyName 連結到 canonical URL

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/job-titles/%E6%B8%AC%E8%A9%A6%E5%B7%A5%E7%A8%8B%E5%B8%AB/salary-work-times 看到 `廣達電腦` 連結到 http://localhost:3000/companies/廣達電腦股份有限公司