### PR TITLE
chore: remove legacy url

### DIFF
--- a/src/components/TimeAndSalary/NotFound.js
+++ b/src/components/TimeAndSalary/NotFound.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import Redirect from 'common/routing/Redirect';
-
-const NotFound = () => <Redirect to="/salary-work-times/latest" />;
-
-export default NotFound;

--- a/src/routes.js
+++ b/src/routes.js
@@ -4,7 +4,6 @@ import LaborRightsMenu from './components/LaborRightsMenu';
 import LaborRightsSingle from './components/LaborRightsSingle';
 import TimeAndSalary from './components/TimeAndSalary';
 import SalaryWorkTimeSearchScreen from './components/TimeAndSalary/SearchScreen';
-import TimeAndSalaryNotFound from './components/TimeAndSalary/NotFound';
 import ExperienceSearchPage from './containers/ExperienceSearchPage';
 import ExperienceDetail from './containers/ExperienceDetail';
 import NotFound from './components/common/NotFound';
@@ -117,43 +116,15 @@ const routes = [
     ],
   },
   {
-    path: '/time-and-salary',
-    component: TimeAndSalary,
-    routes: [
-      {
-        path: '/time-and-salary/company/:keyword',
-        exact: false,
-        component: ({ match }) => (
-          <Redirect
-            to={`/salary-work-times?q=${match.params.keyword}&s_by=company`}
-          />
-        ),
-      },
-      {
-        path: '/time-and-salary/job-title/:keyword',
-        exact: false,
-        component: ({ match }) => (
-          <Redirect
-            to={`/salary-work-times?q=${match.params.keyword}&s_by=job_title`}
-          />
-        ),
-      },
-      {
-        component: TimeAndSalaryNotFound,
-      },
-    ],
-  },
-  {
     path: '/search',
+    exact: true,
+    // TODO: remove TimeAndSalary
     component: TimeAndSalary,
     routes: [
       {
         path: '/search',
         exact: true,
         component: SalaryWorkTimeSearchScreen,
-      },
-      {
-        component: TimeAndSalaryNotFound,
       },
     ],
   },


### PR DESCRIPTION
followed #1318

由於 /salary-work-times 於 #1318 移除，
所以

* `/time-and-salary/company/:keyword` 會導到 /salary-work-times，最後是 NotFound
* `/time-and-salary/job-title/:keyword` 會導到 /salary-work-times，最後是 NotFound
* `/search/xxxxx` 會導到 /salary-work-times，最後是 NotFound

所以移除這個 PR 幾個相關的路徑

ref:

```
curl -i https://www.goodjob.life/time-and-salary/company/台積
HTTP/2 301 
location: /salary-work-times?q=%E5%8F%B0%E7%A9%8D&s_by=company

curl -i "https://www.goodjob.life/salary-work-times?q=%E5%8F%B0%E7%A9%8D&s_by=company"
HTTP/2 301 
location: /salary-work-times/latest
```