### PR TITLE
feat: send submit salary/interview error to rollbar

### DIFF
--- a/src/components/ShareExperience/InterviewForm/TypeForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/TypeForm/index.js
@@ -9,6 +9,7 @@ import Header, { CompanyJobTitleHeader } from '../../common/TypeFormHeader';
 import SubmittableFormBuilder from '../../common/SubmittableFormBuilder';
 import { createInterviewExperience } from 'actions/experiences';
 import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
+import { ERROR_CODE_MSG } from 'constants/errorCodeMsg';
 import {
   DATA_KEY_COMPANY_NAME,
   DATA_KEY_JOB_TITLE,
@@ -44,6 +45,7 @@ import {
 } from '../../questionCreators';
 import { sendEvent } from 'utils/hotjarUtil';
 import { getUserPseudoId } from 'utils/GAUtils';
+import rollbar from 'utils/rollbar';
 
 import { GA_MEASUREMENT_ID } from '../../../../config';
 import { tabType } from '../../../../constants/companyJobTitle';
@@ -156,11 +158,16 @@ const TypeForm = ({ open, onClose }) => {
     [dispatch],
   );
 
-  const onSubmitError = useCallback(async () => {
+  const onSubmitError = useCallback(async error => {
     ReactGA.event({
       category: GA_CATEGORY.SHARE_INTERVIEW_TYPE_FORM,
       action: GA_ACTION.UPLOAD_FAIL,
     });
+    const errorCode = 'ER0008';
+    rollbar.error(
+      `[${errorCode}] ${ERROR_CODE_MSG[errorCode].internal} ${error.message}`,
+      error,
+    );
   }, []);
 
   useEffect(() => {

--- a/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
+++ b/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
@@ -38,6 +38,7 @@ import {
   DATA_KEY_HAS_OVERTIME_SALARY,
   DATA_KEY_HAS_COMPENSATORY_DAYOFF,
 } from '../constants';
+import { ERROR_CODE_MSG } from 'constants/errorCodeMsg';
 
 import { evolve } from '../utils';
 import { generateTabURL, pageType, tabType } from 'constants/companyJobTitle';
@@ -48,6 +49,7 @@ import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
 
 import { sendEvent } from 'utils/hotjarUtil';
 import { getUserPseudoId } from 'utils/GAUtils';
+import rollbar from 'utils/rollbar';
 
 import { GA_MEASUREMENT_ID } from '../../../config';
 
@@ -153,6 +155,7 @@ const TypeForm = ({ open, onClose, hideProgressBar = false }) => {
     },
     [dispatch, hideProgressBar],
   );
+
   const onSubmitError = useCallback(
     async error => {
       ReactGA.event({
@@ -161,6 +164,11 @@ const TypeForm = ({ open, onClose, hideProgressBar = false }) => {
           : GA_CATEGORY.SHARE_TIME_SALARY_TYPE_FORM,
         action: GA_ACTION.UPLOAD_FAIL,
       });
+      const errorCode = 'ER0007';
+      rollbar.error(
+        `[${errorCode}] ${ERROR_CODE_MSG[errorCode].internal} ${error.message}`,
+        error,
+      );
     },
     [hideProgressBar],
   );

--- a/src/constants/errorCodeMsg.js
+++ b/src/constants/errorCodeMsg.js
@@ -30,4 +30,10 @@ export const ERROR_CODE_MSG = {
     external: LOGIN_ERROR_MSG_CLEAN_BROWSER_DATA,
     internal: 'FB login failed: unknown auth status',
   },
+  ER0007: {
+    internal: 'Submit salary failed',
+  },
+  ER0008: {
+    internal: 'Submit interview failed',
+  },
 };


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. 上傳薪資、面試時，如果出現錯誤，把錯誤訊息送到 rollbar ，瞭解發生的原因
2. 工作心得的部分等表單改版再做，現在上傳次數較少

## Screenshots  <!-- 選填，沒有就刪掉 -->

面試經驗的部分，我把兩篇七天內的面試經驗設為 is_archived = true ，讓 API 判定太多垃圾資訊回錯誤去模擬
![Screenshot 2024-06-13 at 9 38 41 PM](https://github.com/goodjoblife/GoodJobShare/assets/3805975/ff4445ae-e62c-42ef-8e58-89acec91f31d)

薪資的部分，我把實際日工時填寫 100 ，模擬後端回錯誤（這個其實是我們表單可以改進的地方）
![Screenshot 2024-06-13 at 9 44 59 PM](https://github.com/goodjoblife/GoodJobShare/assets/3805975/1d7cf15b-1000-434c-8281-e45dffad1c87)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start
- [ ] 薪資表單故意填寫實際日工時到很長 (e.g. 100 小時)
- 面試表單比較麻煩，可先不測