### PR TITLE
[最新面試心得] 顯示 originalCompanyName

### DIFF
--- a/src/actions/experience.js
+++ b/src/actions/experience.js
@@ -182,8 +182,7 @@ export const queryPopularExperiences = () => async (dispatch, getState) => {
       setPopularExperiences(
         getFetched(
           experiences.map(({ id, job_title, ...rest }) => ({
-            // TODO 未來 migrate 掉
-            _id: id,
+            id,
             job_title: job_title.name,
             ...rest,
           })),

--- a/src/actions/experience.js
+++ b/src/actions/experience.js
@@ -178,17 +178,7 @@ export const queryPopularExperiences = () => async (dispatch, getState) => {
 
   try {
     const experiences = await queryPopularExperiencesApi();
-    dispatch(
-      setPopularExperiences(
-        getFetched(
-          experiences.map(({ id, job_title, ...rest }) => ({
-            id,
-            job_title: job_title.name,
-            ...rest,
-          })),
-        ),
-      ),
-    );
+    dispatch(setPopularExperiences(getFetched(experiences)));
   } catch (error) {
     dispatch(setPopularExperiences(getError(error)));
   }

--- a/src/components/LandingPage/ExperienceBlock/index.js
+++ b/src/components/LandingPage/ExperienceBlock/index.js
@@ -34,7 +34,7 @@ const ExperienceBlock = ({ data, size, backable }) => {
           size={size === 'l' ? 'sl' : 'sm'}
           className={styles.heading}
         >
-          {data.originalCompanyName} {data.job_title}
+          {data.originalCompanyName} {data.job_title.name}
         </Heading>
 
         {size === 'l' || size === 'm' ? (
@@ -55,7 +55,9 @@ ExperienceBlock.propTypes = {
   data: PropTypes.shape({
     created_at: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
-    job_title: PropTypes.string.isRequired,
+    job_title: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }).isRequired,
     like_count: PropTypes.number.isRequired,
     originalCompanyName: PropTypes.string.isRequired,
     preview: PropTypes.string.isRequired,

--- a/src/components/LandingPage/ExperienceBlock/index.js
+++ b/src/components/LandingPage/ExperienceBlock/index.js
@@ -11,7 +11,7 @@ import { formatType, formatCreatedAt } from './helper';
 
 const ExperienceBlock = ({ data, size, backable }) => {
   const {
-    _id,
+    id,
     type,
     created_at: createdAt,
     like_count: likeCount,
@@ -21,7 +21,7 @@ const ExperienceBlock = ({ data, size, backable }) => {
 
   return (
     <Link
-      to={{ pathname: `/experiences/${_id}`, state: { backable } }}
+      to={{ pathname: `/experiences/${id}`, state: { backable } }}
       className={cn(styles.container, styles[size])}
     >
       <section className={styles.contentWrapper}>
@@ -53,8 +53,8 @@ const ExperienceBlock = ({ data, size, backable }) => {
 ExperienceBlock.propTypes = {
   backable: PropTypes.bool.isRequired,
   data: PropTypes.shape({
-    _id: PropTypes.string.isRequired,
     created_at: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
     job_title: PropTypes.string.isRequired,
     like_count: PropTypes.number.isRequired,
     originalCompanyName: PropTypes.string.isRequired,

--- a/src/components/LandingPage/ExperienceBlock/index.js
+++ b/src/components/LandingPage/ExperienceBlock/index.js
@@ -34,7 +34,7 @@ const ExperienceBlock = ({ data, size, backable }) => {
           size={size === 'l' ? 'sl' : 'sm'}
           className={styles.heading}
         >
-          {data.company.name} {data.job_title}
+          {data.originalCompanyName} {data.job_title}
         </Heading>
 
         {size === 'l' || size === 'm' ? (
@@ -51,9 +51,18 @@ const ExperienceBlock = ({ data, size, backable }) => {
 };
 
 ExperienceBlock.propTypes = {
-  backable: PropTypes.bool,
-  data: PropTypes.object.isRequired,
-  size: PropTypes.oneOf(['s', 'm', 'l']),
+  backable: PropTypes.bool.isRequired,
+  data: PropTypes.shape({
+    _id: PropTypes.string.isRequired,
+    created_at: PropTypes.string.isRequired,
+    job_title: PropTypes.string.isRequired,
+    like_count: PropTypes.number.isRequired,
+    originalCompanyName: PropTypes.string.isRequired,
+    preview: PropTypes.string.isRequired,
+    reply_count: PropTypes.number.isRequired,
+    type: PropTypes.string.isRequired,
+  }).isRequired,
+  size: PropTypes.oneOf(['s', 'm', 'l']).isRequired,
 };
 
 ExperienceBlock.defaultProps = {

--- a/src/graphql/popularExperience.js
+++ b/src/graphql/popularExperience.js
@@ -9,6 +9,7 @@ export const getPopularExperiencesQuery = `
     job_title {
       name
     }
+    originalCompanyName
     company {
       name
     }


### PR DESCRIPTION
Close #1342  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

`popular_experience` 取 `originalCompanyName`
加上 prop types

## Screenshots  <!-- 選填，沒有就刪掉 -->

![畫面擷取於 2024-06-19 23 30 20](https://github.com/goodjoblife/GoodJobShare/assets/7566586/7d1de749-34bd-41be-acab-5fcd6f5b4991)



## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/ 首頁檢查最新面試與心得的卡片顯示的是 originalCompanyName