### PR TITLE
bugfix: fix ExpandedModal proptype warning

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -67,7 +67,7 @@ const App = () => {
         render={({ handleToggleModalOpen }) => (
           <ExpandedModal handleToggleModalOpen={handleToggleModalOpen} />
         )}
-      ></CollapsedDrawer>
+      />
     </Fragment>
   );
 };

--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -6,7 +6,8 @@ import StaticHelmet from 'common/StaticHelmet';
 import LoginModal from 'common/LoginModal';
 import useLocStateToastObserver from 'hooks/toastNotification/useLocStateToastObserver';
 import { STATE_SHARE } from 'common/ShareExpSection/shareLinkTo';
-
+import CollapsedDrawer from 'common/Questionnaire/CollapsedDrawer';
+import ExpandedModal from 'common/Questionnaire/ExpandedModal';
 import ToastNotification from '../ToastNotification/ToastNotification';
 import { AppRouteWithSubRoutes } from '../route';
 import styles from './App.module.css';
@@ -15,8 +16,6 @@ import Footer from './Footer';
 import ShareInterviewModal from '../ShareExperience/InterviewForm/TypeForm';
 import ShareSalaryWorkTimesModal from '../ShareExperience/TimeSalaryForm/TypeForm';
 import routes from '../../routes';
-import CollapsedDrawer from 'common/Questionnaire/CollapsedDrawer';
-import NetPromoter from 'common/Questionnaire/ExpandedModal';
 
 const useShare = () => {
   const location = useLocation();
@@ -64,9 +63,11 @@ const App = () => {
         hideProgressBar={share === STATE_SHARE.SALARY_WORK_TIME_NO_PROGRESS_BAR}
       />
       <LoginModal />
-      <CollapsedDrawer>
-        <NetPromoter />
-      </CollapsedDrawer>
+      <CollapsedDrawer
+        render={({ handleToggleModalOpen }) => (
+          <ExpandedModal handleToggleModalOpen={handleToggleModalOpen} />
+        )}
+      ></CollapsedDrawer>
     </Fragment>
   );
 };

--- a/src/components/common/Questionnaire/CollapsedDrawer/index.js
+++ b/src/components/common/Questionnaire/CollapsedDrawer/index.js
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 const MILLISECONDS_OF_TWO_SUBMISSION_SPAN = 1000 * 60 * 60 * 24 * 30;
 
-const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
+const CollapsedDrawer = ({ title, render }) => {
   const isOpen = useSelector(state => state.questionnaireExpandedModal.isOpen);
   const dispatch = useDispatch();
   const handleToggleModalOpen = useCallback(() => {
@@ -30,11 +30,9 @@ const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
     }
   }
 
-  const childrenWithProps = React.Children.map(children, child =>
-    React.cloneElement(child, { handleToggleModalOpen }),
-  );
-
-  if (isOpen) return childrenWithProps;
+  if (isOpen) {
+    return render({ handleToggleModalOpen });
+  }
 
   return (
     <div className={styles.container} onClick={handleToggleModalOpen}>
@@ -44,8 +42,12 @@ const CollapsedDrawer = ({ title = '給我們回饋', children }) => {
 };
 
 CollapsedDrawer.propTypes = {
-  children: PropTypes.node.isRequired,
+  render: PropTypes.func.isRequired,
   title: PropTypes.string,
+};
+
+CollapsedDrawer.defaultProps = {
+  title: '給我們回饋',
 };
 
 export default CollapsedDrawer;


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

由於 ExpandedModal 需要 `handleToggleModalOpen`，採用 renderProp 的方式來寫，避免還需要操作較底層的 cloneElement

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Front-end PR：<!-- 這個 PR 需要先等其它前端 PR merge 之後才能 merge -->
- Back-end PR：<!-- 這個 PR 需要 checkout 這個 back-end 才能 work -->

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="396" alt="image" src="https://github.com/goodjoblife/GoodJobShare/assets/1908007/00363254-f44e-4c60-8ea7-34d1862d998a">

<img width="469" alt="image" src="https://github.com/goodjoblife/GoodJobShare/assets/1908007/412a3403-a722-488e-b936-fabcfb8cf270">

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 將 LocalStorage 清除，可以看見 "給我們回饋"，操作看看是否正常