### PR TITLE
[公司搜尋] 有另外顯示統一編號時，移除公司名稱內的統一編號

### DIFF
--- a/src/components/ShareExperience/AutoCompleteItem.js
+++ b/src/components/ShareExperience/AutoCompleteItem.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { replace } from 'ramda';
 import styles from './AutoCompleteItem.module.css';
 import { pageTypeTranslation } from 'constants/companyJobTitle';
+
+const dropBusinessNumber = replace(/ \(\d+\)$/, '');
 
 const AutoCompleteItem = ({ pageType, name, businessNumber }) => (
   <div className={styles.container}>
@@ -9,7 +12,7 @@ const AutoCompleteItem = ({ pageType, name, businessNumber }) => (
       <span className={styles.badge}>{pageTypeTranslation[pageType]}</span>
     </div>
     <div className={styles.name}>
-      <span>{name}</span>
+      <span>{dropBusinessNumber(name)}</span>
       <span>{businessNumber && `（統編：${businessNumber}）`}</span>
     </div>
   </div>


### PR DESCRIPTION
Close #1352  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

後端會保留統一編號在同名的公司名稱
前端遇到統一編號會另外顯示的時候，就移除名稱內的統一編號


## Screenshots  <!-- 選填，沒有就刪掉 -->

|Before|After|
|-|-|
|![截圖 2024-06-22 凌晨12 59 42](https://github.com/goodjoblife/GoodJobShare/assets/7566586/e3e70248-461a-4109-94da-b8aead90aefb)|![截圖 2024-06-22 凌晨12 55 40](https://github.com/goodjoblife/GoodJobShare/assets/7566586/4f223c5b-ce53-4e2c-9aec-b70a15e659c8)|



## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share 搜尋台積電，可以看到 `台積電氣` 和 `台積電梯` 的統一編號不再重複顯示