### PR TITLE
[一頁一題表單] 阻擋 tab 事件

### DIFF
--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -155,6 +155,16 @@ const FormBuilder = ({
     }
   }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    if (!open) return;
+
+    const handler = e => {
+      if (e.key.toLowerCase() === 'tab') e.preventDefault();
+    };
+    window.document.addEventListener('keydown', handler);
+    return () => window.document.removeEventListener('keydown', handler);
+  }, [open]);
+
   if (!shouldRenderQuestion) {
     return null;
   }

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -155,6 +155,11 @@ const FormBuilder = ({
     }
   }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // Prevent tabbing within the modal so we don't jump between pages
+  // -- which is NOT ideal, as it's not a11y friendly.
+  //
+  // We will need to revisit this later after we are able to not render
+  // all questions at once but the active one only.
   useEffect(() => {
     if (!open) return;
 


### PR DESCRIPTION
Close #1358 

## 這個 PR 是？ <!-- 必填 -->

在一頁一題開啟時，阻擋 tab 事件
有點暴力，但剛剛有試過傳統的 tabIndex 發現不太容易擋全部



## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share 打開一頁一題式表單，用 tab 導航