### PR TITLE
[經驗單篇] 修正sections

### DIFF
--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -80,11 +80,26 @@ export const patchReply = ({ id, status, token }) =>
     token,
   });
 
-const renameSectionSubtitle = ({ sections, ...rest }) => ({
+const resolveSubtitle = ({ __typename, interview_subtitle, work_subtitle }) => {
+  switch (__typename) {
+    case 'InterviewExperience':
+      return interview_subtitle;
+    case 'WorkExperience':
+      return work_subtitle;
+    default:
+      return null;
+  }
+};
+
+const renameSectionSubtitle = ({ __typename, sections, ...rest }) => ({
   ...rest,
   sections: sections.map(({ interview_subtitle, work_subtitle, ...rest }) => ({
-    subtitle: interview_subtitle || work_subtitle,
     ...rest,
+    subtitle: resolveSubtitle({
+      __typename,
+      interview_subtitle,
+      work_subtitle,
+    }),
   })),
 });
 

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -82,8 +82,8 @@ export const patchReply = ({ id, status, token }) =>
 
 const renameSectionSubtitle = ({ sections, ...rest }) => ({
   ...rest,
-  sections: sections.map(({ interview_subtitle, subtitle, ...rest }) => ({
-    subtitle: interview_subtitle || subtitle,
+  sections: sections.map(({ interview_subtitle, work_subtitle, ...rest }) => ({
+    subtitle: interview_subtitle || work_subtitle,
     ...rest,
   })),
 });

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -80,7 +80,11 @@ export const patchReply = ({ id, status, token }) =>
     token,
   });
 
-const resolveSubtitle = ({ __typename, interview_subtitle, work_subtitle }) => {
+const resolveSubtitleInSection = ({
+  __typename,
+  interview_subtitle,
+  work_subtitle,
+}) => {
   switch (__typename) {
     case 'InterviewExperience':
       return interview_subtitle;
@@ -91,11 +95,11 @@ const resolveSubtitle = ({ __typename, interview_subtitle, work_subtitle }) => {
   }
 };
 
-const renameSectionSubtitle = ({ __typename, sections, ...rest }) => ({
+const resolveSubtitlesInExperience = ({ __typename, sections, ...rest }) => ({
   ...rest,
   sections: sections.map(({ interview_subtitle, work_subtitle, ...rest }) => ({
     ...rest,
-    subtitle: resolveSubtitle({
+    subtitle: resolveSubtitleInSection({
       __typename,
       interview_subtitle,
       work_subtitle,
@@ -109,7 +113,7 @@ export const queryExperience = ({ id }) =>
     variables: { id },
   })
     .then(data => data.experience)
-    .then(renameSectionSubtitle);
+    .then(resolveSubtitlesInExperience);
 
 export const queryExperienceLike = async ({ id, token }) => {
   const data = await graphqlClient({
@@ -140,7 +144,7 @@ export const queryRelatedExperiences = async ({ id, start, limit }) => {
     variables: { id, start, limit },
   });
   const relatedExperiences = data.experience.relatedExperiences;
-  return relatedExperiences.map(renameSectionSubtitle);
+  return relatedExperiences.map(resolveSubtitlesInExperience);
 };
 
 export const queryExperienceCountApi = async () => {

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -80,11 +80,21 @@ export const patchReply = ({ id, status, token }) =>
     token,
   });
 
+const renameSectionSubtitle = ({ sections, ...rest }) => ({
+  ...rest,
+  sections: sections.map(({ interview_subtitle, subtitle, ...rest }) => ({
+    subtitle: interview_subtitle || subtitle,
+    ...rest,
+  })),
+});
+
 export const queryExperience = ({ id }) =>
   graphqlClient({
     query: queryExperienceGql,
     variables: { id },
-  }).then(data => data.experience);
+  })
+    .then(data => data.experience)
+    .then(renameSectionSubtitle);
 
 export const queryExperienceLike = async ({ id, token }) => {
   const data = await graphqlClient({
@@ -114,7 +124,8 @@ export const queryRelatedExperiences = async ({ id, start, limit }) => {
     query: queryRelatedExperiencesGql,
     variables: { id, start, limit },
   });
-  return data.experience.relatedExperiences;
+  const relatedExperiences = data.experience.relatedExperiences;
+  return relatedExperiences.map(renameSectionSubtitle);
 };
 
 export const queryExperienceCountApi = async () => {

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -106,7 +106,7 @@ ExperienceEntry.propTypes = {
     sections: PropTypes.arrayOf(
       PropTypes.shape({
         content: PropTypes.string.isRequired,
-        subtitle: PropTypes.string,
+        subtitle: PropTypes.string.isRequired,
       }),
     ).isRequired,
   }).isRequired,

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -42,6 +42,8 @@ export const queryExperienceGql = /* GraphQL */ `
       title
       created_at
 
+      __typename
+
       ... on InterviewExperience {
         sections {
           interview_subtitle: subtitle
@@ -119,6 +121,8 @@ export const queryRelatedExperiencesGql = /* GraphQL */ `
           type
           amount
         }
+
+        __typename
 
         ... on InterviewExperience {
           sections {

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -40,13 +40,13 @@ export const queryExperienceGql = /* GraphQL */ `
         amount
       }
       title
-      sections {
-        subtitle
-        content
-      }
       created_at
 
       ... on InterviewExperience {
+        sections {
+          interview_subtitle: subtitle
+          content
+        }
         interview_time {
           year
           month
@@ -61,6 +61,10 @@ export const queryExperienceGql = /* GraphQL */ `
       }
 
       ... on WorkExperience {
+        sections {
+          subtitle
+          content
+        }
         week_work_time
         recommend_to_others
       }
@@ -115,16 +119,20 @@ export const queryRelatedExperiencesGql = /* GraphQL */ `
           type
           amount
         }
-        sections {
-          subtitle
-          content
-        }
 
         ... on InterviewExperience {
+          sections {
+            interview_subtitle: subtitle
+            content
+          }
           overall_rating
         }
 
         ... on WorkExperience {
+          sections {
+            subtitle
+            content
+          }
           week_work_time
           recommend_to_others
         }

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -62,7 +62,7 @@ export const queryExperienceGql = /* GraphQL */ `
 
       ... on WorkExperience {
         sections {
-          subtitle
+          work_subtitle: subtitle
           content
         }
         week_work_time
@@ -130,7 +130,7 @@ export const queryRelatedExperiencesGql = /* GraphQL */ `
 
         ... on WorkExperience {
           sections {
-            subtitle
+            work_subtitle: subtitle
             content
           }
           week_work_time


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

https://api-dev.goodjob.life/graphql

由於 experience API 將 sections 從 Experience 移出，變成 WorkExperience 和 InterviewExperience 有各自的 sections，寫 graphql 時要分開指定

由於 WorkExperience.sections.subtitle 和 InterviewExperience.sections.subtitle 有不同的型別，所以在打 api 時先取不同名稱，抓回來後再統一命名為 subtitle 以作最簡單的向前相容


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 任一篇經驗單篇 http://localhost:3000/experiences/6679695df17625166ce78229 應正常渲染而非白屏