### PR TITLE
feat: handle google & facebook login error

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -105,17 +105,16 @@ export const loginWithFB = FBSDK => async (dispatch, getState) => {
         });
         await dispatch(loginWithToken(token));
       } catch (error) {
-        if (error instanceof GraphqlError) {
-          if (error && error.codes) {
-            if (error.codes[0] === 'UNAUTHENTICATED') {
-              dispatch(toastNotificationAndRollbarAndThrowError('ER0014'));
-            } else if (error.codes[0] === 'FORBIDDEN') {
-              dispatch(toastNotificationAndRollbarAndThrowError('ER0015'));
-            }
+        if (error instanceof GraphqlError && error.codes) {
+          if (error.codes[0] === 'UNAUTHENTICATED') {
+            dispatch(toastNotificationAndRollbarAndThrowError('ER0014'));
+            break;
+          } else if (error.codes[0] === 'FORBIDDEN') {
+            dispatch(toastNotificationAndRollbarAndThrowError('ER0015'));
+            break;
           }
-        } else {
-          dispatch(toastNotificationAndRollbarAndThrowError('ER0016', error));
         }
+        dispatch(toastNotificationAndRollbarAndThrowError('ER0016', error));
       }
       break;
     default:
@@ -147,22 +146,22 @@ export const loginWithGoogle = credentialResponse => async (
   const idToken = credentialResponse.credential;
   try {
     const response = await postAuthGoogleApi({ idToken });
-    if (!response || !response.token) {
+    if (response && response.token) {
+      await dispatch(loginWithToken(response.token));
+    } else {
       dispatch(toastNotificationAndRollbarAndThrowError('ER0010'));
     }
-    await dispatch(loginWithToken(response.token));
   } catch (error) {
-    if (error instanceof GraphqlError) {
-      if (error && error.codes) {
-        if (error.codes[0] === 'UNAUTHENTICATED') {
-          dispatch(toastNotificationAndRollbarAndThrowError('ER0011'));
-        } else if (error.codes[0] === 'FORBIDDEN') {
-          dispatch(toastNotificationAndRollbarAndThrowError('ER0012'));
-        }
+    if (error instanceof GraphqlError && error.codes) {
+      if (error.codes[0] === 'UNAUTHENTICATED') {
+        dispatch(toastNotificationAndRollbarAndThrowError('ER0011'));
+        return;
+      } else if (error.codes[0] === 'FORBIDDEN') {
+        dispatch(toastNotificationAndRollbarAndThrowError('ER0012'));
+        return;
       }
-    } else {
-      dispatch(toastNotificationAndRollbarAndThrowError('ER0013', error));
     }
+    dispatch(toastNotificationAndRollbarAndThrowError('ER0013', error));
   }
 };
 

--- a/src/constants/errorCodeMsg.js
+++ b/src/constants/errorCodeMsg.js
@@ -36,4 +36,40 @@ export const ERROR_CODE_MSG = {
   ER0008: {
     internal: 'Submit interview failed',
   },
+  ER0009: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'Cannot get id_token from Google auth API',
+  },
+  ER0010: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'Cannot get token from Graphql googleLogin mutation response',
+  },
+  ER0011: {
+    external: LOGIN_ERROR_MSG,
+    internal:
+      'Graphql googleLogin mutation API failed with codes=UNAUTHENTICATED',
+  },
+  ER0012: {
+    external: LOGIN_ERROR_MSG,
+    internal:
+      'Graphql googleLogin mutation API failed with codes=FORBIDDEN, probably this user is deactivated',
+  },
+  ER0013: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'Unknown error during Graphql googleLogin mutation',
+  },
+  ER0014: {
+    external: LOGIN_ERROR_MSG,
+    internal:
+      'Graphql facebookLogin mutation API failed with codes=UNAUTHENTICATED',
+  },
+  ER0015: {
+    external: LOGIN_ERROR_MSG,
+    internal:
+      'Graphql facebookLogin mutation API failed with codes=FORBIDDEN, probably this user is deactivated',
+  },
+  ER0016: {
+    external: LOGIN_ERROR_MSG,
+    internal: 'Unknown error during Graphql facebookLogin mutation',
+  },
 };


### PR DESCRIPTION
Close #1265 

## 這個 PR 是？ <!-- 必填 -->

1. google login 如果有發生錯誤，用 rollbar 記錄，並且跳 toast 給使用者
2. 針對 deactivated user ，目前是在 googleLogin & facebookLogin 兩個 mutation 去回 Forbidden error code （如果未來有我們主動停權帳號的話，也會是一樣的 code）。前端拿到這個 Forbidden code ，傳不同的訊息到 rollbar 以分辨不同種的錯誤

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR：https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/1036

## Screenshots  <!-- 選填，沒有就刪掉 -->

分別是 deactivated google user & deactivated facebook user 試圖再次登入的錯誤訊息
![Screenshot 2024-07-19 at 4 50 56 PM](https://github.com/user-attachments/assets/0e6b9b53-b9fb-41a2-8f6f-30dd2f7622a2)
![Screenshot 2024-07-19 at 4 51 04 PM](https://github.com/user-attachments/assets/38807852-bd6d-4f36-8ed5-e2b04bc61037)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start
- [ ] 需要故意丟錯誤訊息，模擬錯誤 case 做測試