### PR TITLE
hotfix: fix github ci docker image build problem

### DIFF
--- a/.github/docker-compose-dev.yml
+++ b/.github/docker-compose-dev.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   node:
     image: goodjobshare:dev

--- a/.github/docker-compose-production.yml
+++ b/.github/docker-compose-production.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   node:
     image: goodjobshare:production

--- a/.github/docker-compose-stage.yml
+++ b/.github/docker-compose-stage.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   node:
     image: goodjobshare:stage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: docker login ${REGISTRY} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-      - run: docker-compose -f .github/docker-compose-production.yml build
+      - run: docker compose -f .github/docker-compose-production.yml build
       - run: docker tag ${IMAGE} ${REGISTRY}/${REPO}:production-${GITHUB_SHA}
       - run: docker push ${REGISTRY}/${REPO}:production-${GITHUB_SHA}
   docker-stage:
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: docker login ${REGISTRY} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-      - run: docker-compose -f .github/docker-compose-stage.yml build
+      - run: docker compose -f .github/docker-compose-stage.yml build
       - run: docker tag ${IMAGE} ${REGISTRY}/${REPO}:stage
       - run: docker push ${REGISTRY}/${REPO}:stage
   docker-dev:
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: docker login ${REGISTRY} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
-      - run: docker-compose -f .github/docker-compose-dev.yml build
+      - run: docker compose -f .github/docker-compose-dev.yml build
       - run: docker tag ${IMAGE} ${REGISTRY}/${REPO}:dev
       - run: docker push ${REGISTRY}/${REPO}:dev
   deploy-stage:


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

fix github action building docker image bug

It looks like ubuntu used by github ci removed `docker-compose` and is instead using `docker compose`.

same as https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/1045