### PR TITLE
fix: 面談薪資欄位名稱、資料顯示時間

### DIFF
--- a/src/components/ExperienceDetail/Article/ArticleInfo.js
+++ b/src/components/ExperienceDetail/Article/ArticleInfo.js
@@ -31,9 +31,6 @@ const InterviewInfoBlocks = ({ experience, hideContent }) => {
   const expInYearText = formatExperienceInYear(experience.experience_in_year);
   return (
     <Fragment>
-      <div className={styles.date}>
-        {formatDate(new Date(experience.created_at))}
-      </div>
       <InfoBlock
         label="公司"
         to={generatePageURL({
@@ -62,6 +59,11 @@ const InterviewInfoBlocks = ({ experience, hideContent }) => {
       {experience.interview_time ? (
         <InfoBlock label="面試時間">
           {`${experience.interview_time.year} 年 ${experience.interview_time.month} 月`}
+        </InfoBlock>
+      ) : null}
+      {experience.created_at ? (
+        <InfoBlock label="填寫時間">
+          {formatDate(new Date(experience.created_at))}
         </InfoBlock>
       ) : null}
       <InfoBlock label="面試結果">{experience.interview_result}</InfoBlock>
@@ -145,6 +147,11 @@ const WorkInfoBlocks = ({ experience, hideContent }) => {
       >
         {experience.job_title.name}
       </InfoBlock>
+      {experience.created_at ? (
+        <InfoBlock label="填寫時間">
+          {formatDate(new Date(experience.created_at))}
+        </InfoBlock>
+      ) : null}
       {expInYearText ? (
         <InfoBlock label="自身相關職務工作經驗">{expInYearText}</InfoBlock>
       ) : null}
@@ -188,6 +195,7 @@ WorkInfoBlocks.propTypes = {
     company: PropTypes.shape({
       name: PropTypes.string,
     }),
+    created_at: PropTypes.string,
     education: PropTypes.string,
     experience_in_year: PropTypes.number,
     job_title: PropTypes.shape({

--- a/src/components/ShareExperience/InterviewForm/TypeForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/TypeForm/index.js
@@ -69,7 +69,7 @@ const questions = [
   createInterviewCourseQuestion(),
   createInterviewSuggestionsQuestion(),
   createJobTenureQuestion(),
-  createSalaryQuestion(),
+  createSalaryQuestion({ type: tabType.INTERVIEW_EXPERIENCE }),
   createQuestionsQuestion(),
   createSensitiveQuestionsQuestion(),
   createSubmitQuestion({ type: tabType.INTERVIEW_EXPERIENCE }),

--- a/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
+++ b/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
@@ -71,7 +71,7 @@ const questions = [
   createSectorQuestion(),
   createEmployTypeQuestion(),
   createGenderQuestion(),
-  createRequiredSalaryQuestion(),
+  createRequiredSalaryQuestion({ type: tabType.TIME_AND_SALARY }),
   createExperienceInYearQuestion(),
   createDayPromisedWorkTimeQuestion(),
   createDayRealWorkTimeQuestion(),

--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -65,6 +65,7 @@ import Emoji from '../common/icons/Emoji';
 import {
   pageType as PAGE_TYPE,
   tabTypeTranslation,
+  tabType,
 } from '../../constants/companyJobTitle';
 import { QUESTION_TYPE } from '../common/FormBuilder/QuestionBuilder';
 import { salaryHint } from 'utils/formUtils';
@@ -272,8 +273,8 @@ export const createJobTenureQuestion = () => ({
   options: JOB_TENURE_OPTIONS,
 });
 
-export const createRequiredSalaryQuestion = () => ({
-  title: '薪資',
+export const createRequiredSalaryQuestion = ({ type }) => ({
+  title: type === tabType.INTERVIEW_EXPERIENCE ? '面談薪資' : '薪資',
   type: QUESTION_TYPE.SELECT_TEXT,
   dataKey: DATA_KEY_SALARY,
   defaultValue: [null, ''],
@@ -298,15 +299,17 @@ export const createRequiredSalaryQuestion = () => ({
     else return hint;
   },
   footnote:
-    '薪資請以包含平常的薪資、分紅、年終、績效獎金等實質上獲得的價值去計算。',
+    type === tabType.INTERVIEW_EXPERIENCE
+      ? '若錄取，請以包含平常的薪資、分紅、年終、獎金等預期會獲得的價值計算'
+      : '薪資請以包含平常的薪資、分紅、年終、績效獎金等實質上獲得的價值去計算。',
 });
 
-export const createSalaryQuestion = () => {
+export const createSalaryQuestion = ({ type }) => {
   const {
     required,
     validateOrWarn,
     ...question
-  } = createRequiredSalaryQuestion();
+  } = createRequiredSalaryQuestion({ type });
   return {
     ...question,
     validateOrWarn: ([type, amount]) =>


### PR DESCRIPTION
Close #1394 #1393 

## 這個 PR 是？ <!-- 必填 -->

1. 面試經驗填寫表單，薪資欄位 title 改為面談薪資
2. 面試經驗單篇，把右上角的時間，改為在列表裡面明確顯示「填寫時間：0000 年 XX 」，更清楚、排版更整齊
3. 工作心得單篇，列表裡面明確顯示「填寫時間：0000 年 XX 」（原本沒有顯示）

## Screenshots  <!-- 選填，沒有就刪掉 -->

面試表單改為面談薪資
![Screenshot 2024-08-17 at 11 20 25 AM](https://github.com/user-attachments/assets/4e7271df-3bcb-4dbd-b47b-822b59b089e4)

薪資表單沒有被動到
![Screenshot 2024-08-17 at 11 20 46 AM](https://github.com/user-attachments/assets/5c24f015-7c0d-409d-a836-2c46c5bb09dd)

面試單篇的填寫時間改成在列表顯示（手機版一個排版問題修復）
![Screenshot 2024-08-17 at 11 23 37 AM](https://github.com/user-attachments/assets/6c5b4301-6588-48a7-bc94-e9d101f7ecdb)

面試單篇的填寫時間改成在列表顯示
![Screenshot 2024-08-17 at 11 34 45 AM](https://github.com/user-attachments/assets/ff7a5a82-ded6-47ea-946b-63bbf449e3bc)

工作心得的填寫時間在列表顯示
![Screenshot 2024-08-17 at 11 34 57 AM](https://github.com/user-attachments/assets/9a1a3fb6-4a89-4c0f-b891-276bbe19878e)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 面試、薪資表單進去填寫看看 wording 是否正確
- [ ] 面試、工作心得單篇進去看看是否正常 render
- [ ] <!-- 列出給 Reviewer 的 Step By Step Checklist -->