### PR TITLE
feat: add new share link generation option and update action probabil…

### DIFF
--- a/src/hooks/experiments/useShareLink.js
+++ b/src/hooks/experiments/useShareLink.js
@@ -9,15 +9,15 @@ import {
 
 const ACTIONS = [
   {
-    prob: 0.25,
+    prob: 0.45,
     generateTo: generateShareTimeSalaryTypeForm,
   },
   {
-    prob: 0.25,
+    prob: 0.45,
     generateTo: generateShareInterviewTypeForm,
   },
   {
-    prob: 0.5,
+    prob: 0.1,
     generateTo: generateShareWork,
   },
 ];

--- a/src/hooks/experiments/useShareLink.js
+++ b/src/hooks/experiments/useShareLink.js
@@ -4,19 +4,23 @@ import { path } from 'ramda';
 import {
   generateShareTimeSalaryTypeForm,
   generateShareInterviewTypeForm,
+  generateShareWork,
 } from 'common/ShareExpSection/shareLinkTo';
 
 const ACTIONS = [
   {
-    prob: 0.5,
+    prob: 0.25,
     generateTo: generateShareTimeSalaryTypeForm,
   },
   {
-    prob: 0.5,
+    prob: 0.25,
     generateTo: generateShareInterviewTypeForm,
   },
+  {
+    prob: 0.5,
+    generateTo: generateShareWork,
+  },
 ];
-
 const randomAction = actions => {
   const r = Math.random();
   let accuProb = 0.0;

--- a/src/hooks/experiments/useShareLink.js
+++ b/src/hooks/experiments/useShareLink.js
@@ -21,6 +21,7 @@ const ACTIONS = [
     generateTo: generateShareWork,
   },
 ];
+
 const randomAction = actions => {
   const r = Math.random();
   let accuProb = 0.0;


### PR DESCRIPTION
Close #1285 

## 這個 PR 是？
前端表單導流，提升評價表單比例
- 評價：0% → 50%
- 薪資：50% → 25%
- 面試：50% → 25％

## Screenshots
![2024-08-18 15 58 54](https://github.com/user-attachments/assets/b2411d88-377e-415f-b740-daab7f4dc560)

## 我應該如何手動測試？
1. 在搜尋框輸入公司名稱 (台積電) -> 點選「開始分享」-> 會到上一頁 -> 再點選「開始分享」
反覆操作，可發現評價頁面，出現機率最高，

2. 也可在 local 將特定頁面調整成 100% 出現，只會出現特定頁面，來驗證該功能正常運作。