### PR TITLE
fix: do not show option longer than 10 years

### DIFF
--- a/src/components/common/FormBuilder/QuestionBuilder/Date.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/Date.js
@@ -12,7 +12,7 @@ const monthOptions = Array(12)
   .map((_, i) => i + 1)
   .map(n => ({ value: n, label: n }));
 
-const yearOptions = Array(12)
+const yearOptions = Array(10)
   .fill(0)
   .map((_, i) => new Date().getFullYear() - i)
   .map(n => ({ value: n, label: n }));


### PR DESCRIPTION
Close #1401 

## 這個 PR 是？ <!-- 必填 -->

- rollbar 顯示這個錯誤滿多次的，對使用者來說會有點困擾，前端沒擋，到最後才跳錯誤訊息
- 不如一開始就不要顯示選項。基本上我認為 10 年前的資訊已經不具參考價值了

## Screenshots  <!-- 選填，沒有就刪掉 -->

以現在的時間來說，只顯示到 2015 年
![Screenshot 2024-08-22 at 9 37 56 PM](https://github.com/user-attachments/assets/75348300-5e06-4d05-aac0-9ff343f91d54)

![Screenshot 2024-08-22 at 9 38 06 PM](https://github.com/user-attachments/assets/09b51340-433d-477f-a067-cd1f111d693f)


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 填寫 2015 年 1 月，薪資、面試表單要能成功送出資料。我這邊測是可以的
