### PR TITLE
fix: working time field validation

### DIFF
--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -330,28 +330,38 @@ export const createExperienceInYearQuestion = () => ({
   validateOrWarn: value => isNil(value) && '需填寫工作經歷',
 });
 
+const validateWorkingTime = (fieldName, min, max) => value => {
+  if (isNot(isNumber, value)) {
+    return `請填寫${fieldName}`;
+  }
+  if (value < min || value > max) {
+    return `${fieldName}必須在${min}~${max}之間`;
+  }
+};
+
 export const createDayPromisedWorkTimeQuestion = () => ({
-  title: '工作日表訂工時',
+  title: '工作日表訂工時(一日)',
   type: QUESTION_TYPE.TEXT,
   dataKey: DATA_KEY_DAY_PROMISED_WORK_TIME,
   required: true,
   defaultValue: '',
-  validateOrWarn: value => isNot(isNumber, value) && '請填寫表定工時',
+  validateOrWarn: validateWorkingTime('工作日表訂工時', 0, 24),
   placeholder: '8 或 8.5',
-  footnote: '工作日指與雇主約定的上班日，或是排班排定的日子。',
+  footnote:
+    '工作日指與雇主約定的上班日，或是排班排定的日子。一天表訂要工作多久。',
 });
 
 export const createDayRealWorkTimeQuestion = () => ({
-  title: '工作日實際平均工時',
+  title: '工作日實際平均工時(一日)',
   type: QUESTION_TYPE.TEXT,
   dataKey: DATA_KEY_DAY_REAL_WORK_TIME,
   required: true,
   defaultValue: '',
-  validateOrWarn: value => isNot(isNumber, value) && '請填寫實際工時',
+  validateOrWarn: validateWorkingTime('工作日實際平均工時', 0, 24),
   placeholder: '8 或 8.5',
   footnote: (
     <Fragment>
-      實際平均工時包含在家工作、待命的時間。
+      一天實際平均工時，包含在家工作、待命的時間。
       <WorkTimeExample>
         例如: 公司規定 9:00上班，18:00 下班，午休 1 小時。 那麼表訂工作時間為
         (18:00-9:00)-1=8 小時。 若實際上平均 20:00 才下班，則實際工作時間為
@@ -367,7 +377,7 @@ export const createWeekWorkTimeQuestion = () => ({
   dataKey: DATA_KEY_WEEK_WORK_TIME,
   required: true,
   defaultValue: '',
-  validateOrWarn: value => isNot(isNumber, value) && '請填寫週總工時',
+  validateOrWarn: validateWorkingTime('一週總工時', 0, 168),
   placeholder: '40 或 40.5',
   footnote: (
     <Fragment>


### PR DESCRIPTION
Close #1403 

## 這個 PR 是？ <!-- 必填 -->

- `工作日表訂工時` 標題以及解釋文字，加上一日、一天的提示。前端檢查是否在 0~24。
- `工作日實際平均工時` 標題以及解釋文字，加上一日、一天的提示。前端檢查是否在 0~24。
- `一週總工時`，前端檢查是否在 0~168。

## Screenshots  <!-- 選填，沒有就刪掉 -->

![Screenshot 2024-08-22 at 9 57 07 PM](https://github.com/user-attachments/assets/71ad14b4-2cea-4b23-8117-82a8f5915b18)
![Screenshot 2024-08-22 at 9 57 13 PM](https://github.com/user-attachments/assets/4267735d-c91c-45a0-9d83-d2d848b5bb58)
![Screenshot 2024-08-22 at 9 57 22 PM](https://github.com/user-attachments/assets/4fd25bff-01d6-45ae-a98a-57bf074e83b1)
![Screenshot 2024-08-22 at 9 57 27 PM](https://github.com/user-attachments/assets/665dcb13-d97e-4322-8e3d-b953a4776def)
![Screenshot 2024-08-22 at 9 57 38 PM](https://github.com/user-attachments/assets/a45adec1-4aa1-49a6-91f3-57b6a29858f7)
![Screenshot 2024-08-22 at 9 57 45 PM](https://github.com/user-attachments/assets/7cf618fa-49e7-48a7-915a-72fe7ff8243d)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] `工作日表訂工時` 測試 -1, 25 要不過，0~24 要過，且最後能上傳成功
- [ ] `工作日實際平均工時` 測試 -1, 25 要不過，0~24 要過，且最後能上傳成功
- [ ] `一週總工時` 測試 -1, 169 要不過，0~168 要過，且最後能上傳成功
