### PR TITLE
feat: send more rollbar message for debugging form submit issue

### DIFF
--- a/src/components/ShareExperience/common/SubmittableFormBuilder.js
+++ b/src/components/ShareExperience/common/SubmittableFormBuilder.js
@@ -9,6 +9,8 @@ import FormBuilder, {
 import ConfirmModal from 'common/FormBuilder/Modals/ConfirmModal';
 import Footer from './TypeFormFooter';
 import { useExperienceCount, useSalaryWorkTimeCount } from 'hooks/useCount';
+import rollbar from 'utils/rollbar';
+import { ERROR_CODE_MSG } from 'constants/errorCodeMsg';
 
 const SubmittableTypeForm = ({
   open,
@@ -35,6 +37,11 @@ const SubmittableTypeForm = ({
         setSubmittedDraft(draft);
         setSubmitStatus('success');
       } catch (error) {
+        const errorCode = 'ER0018';
+        rollbar.error(
+          `[${errorCode}] ${ERROR_CODE_MSG[errorCode].internal} ${error}`,
+          error,
+        );
         setErrorMessage(error.message);
         setSubmitStatus('error');
         await onSubmitError(error);

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -23,6 +23,8 @@ import SubmissionBlock from './SubmissionBlock';
 import AnimatedPager from './AnimatedPager';
 import styles from './FormBuilder.module.css';
 import { OptionPropType } from './QuestionBuilder/Checkbox/PropTypes';
+import rollbar from 'utils/rollbar';
+import { ERROR_CODE_MSG } from 'constants/errorCodeMsg';
 
 const findIfQuestionsAcceptDraft = draft =>
   R.all(
@@ -120,6 +122,12 @@ const FormBuilder = ({
     } else if (isSubmittable) {
       onSubmit(draft);
     } else {
+      const errorCode = 'ER0019';
+      rollbar.error(
+        `[${errorCode}] ${ERROR_CODE_MSG[errorCode].internal}`,
+        null,
+        draft,
+      );
       console.error(`Not submittable`);
     }
   }, [warning, isSubmittable, onValidateFail, dataKey, draft, onSubmit]);

--- a/src/constants/errorCodeMsg.js
+++ b/src/constants/errorCodeMsg.js
@@ -72,4 +72,10 @@ export const ERROR_CODE_MSG = {
     external: LOGIN_ERROR_MSG,
     internal: 'Unknown error during Graphql facebookLogin mutation',
   },
+  ER0018: {
+    internal: 'Unexpected error during submitting form data',
+  },
+  ER0019: {
+    internal: 'Not submittable',
+  },
 };


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

- FB 上還是很常收到使用者回饋面試表單無法成功上傳的問題，試著多加一個 rollbar 觸發點搜集資料，找出 root cause

## Screenshot
![Screenshot 2024-08-23 at 7 49 16 AM](https://github.com/user-attachments/assets/510231c0-41ef-4804-9cbc-c07148aa2863)
![Screenshot 2024-08-23 at 7 50 41 AM](https://github.com/user-attachments/assets/de15b24c-5950-42ef-b4b0-8ce2afc87397)


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] open network tab
- [ ] update codebase to purposely throw error
- [ ] check whether it sends rollbar message