### PR TITLE
feat: Query.search_companies add limits

### DIFF
--- a/src/apis/timeAndSalaryApi.js
+++ b/src/apis/timeAndSalaryApi.js
@@ -8,10 +8,10 @@ import {
 
 const endpoint = '/workings';
 
-export const fetchSearchCompany = ({ companyName, hasData }) =>
+export const fetchSearchCompany = ({ companyName, hasData, limit }) =>
   graphqlClient({
     query: getSearchCompanyQuery,
-    variables: { companyName, hasData },
+    variables: { companyName, hasData, limit },
   }).then(data => data.search_companies);
 
 export const fetchSearchJobTitle = ({ jobTitle }) =>

--- a/src/components/ShareExperience/common/CompanyQuery.js
+++ b/src/components/ShareExperience/common/CompanyQuery.js
@@ -35,7 +35,11 @@ class CompanyQuery extends React.Component {
 
   search = debounce((e, value) => {
     if (value) {
-      return fetchSearchCompany({ companyName: value, hasData: false })
+      return fetchSearchCompany({
+        companyName: value,
+        hasData: false,
+        limit: 10,
+      })
         .then(r =>
           Array.isArray(r)
             ? this.handleAutocompleteItems(r.map(mapToAutocompleteList))

--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -88,7 +88,7 @@ export const createCompanyQuestion = ({ header }) => ({
   validateOrWarn: value => isEmpty(value) && '請填寫公司名稱',
   placeholder: 'ＯＯ 股份有限公司',
   search: value =>
-    fetchSearchCompany({ companyName: value, hasData: false }).then(
+    fetchSearchCompany({ companyName: value, hasData: false, limit: 10 }).then(
       map(({ name, businessNumber }) => ({
         label: (
           <AutoCompleteItem

--- a/src/components/common/form/TextInput/SearchTextInput.js
+++ b/src/components/common/form/TextInput/SearchTextInput.js
@@ -16,7 +16,8 @@ const SearchTextInput = ({ value, onChange, onSelected, ...restProps }) => {
   const eleRef = useRef(null);
 
   const searchCompanyNames = useCallback(
-    value => fetchSearchCompany({ companyName: value, hasData: true }),
+    value =>
+      fetchSearchCompany({ companyName: value, hasData: true, limit: 5 }),
     [],
   );
   const searchJobTitles = useCallback(

--- a/src/graphql/timeAndSalary.js
+++ b/src/graphql/timeAndSalary.js
@@ -1,6 +1,6 @@
 export const getSearchCompanyQuery = /* GraphQL */ `
-  query($companyName: String!, $hasData: Boolean!) {
-    search_companies(query: $companyName, hasData: $hasData) {
+  query($companyName: String!, $hasData: Boolean!, $limit: Int) {
+    search_companies(query: $companyName, hasData: $hasData, limit: $limit) {
       name
       businessNumber
       dataCount


### PR DESCRIPTION
Close #1319

## 這個 PR 是？ <!-- 必填 -->

接上後端的 Query.search_companies 的 limit 參數

## Screenshots  <!-- 選填，沒有就刪掉 -->

### search bar

!有成功套用 limit!

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/95603736-9634-4ebe-b112-e0db41e64f60">

```js
{
  "query":"\n  query($companyName: String!, $hasData: Boolean!, $limit: Int) {\n    search_companies(query: $companyName, hasData: $hasData, limit: $limit) {\n      name\n      businessNumber\n      dataCount\n    }\n  }\n",
  "variables":{"companyName":"台","hasData":true,"limit":5}}
```

<img width="758" alt="image" src="https://github.com/user-attachments/assets/f292359d-41e3-45ec-93b0-ed6c24c7a4b6">

### 搜尋頁

!沒有改動，要不影響行為!

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/316b7970-da41-4446-bdd0-059fd2f8bd02">

Query 保持一樣，不會卡 limit
```js
{
  "query":"\n  query($companyName: String!, $hasData: Boolean!, $limit: Int) {\n    search_companies(query: $companyName, hasData: $hasData, limit: $limit) {\n      name\n      businessNumber\n      dataCount\n    }\n  }\n",
  "variables":{"companyName":"台積","hasData":true}
}
```

### 表單的 autocomplete

!有成功套用 limit!

<img width="1570" alt="image" src="https://github.com/user-attachments/assets/a6b1e481-4b9e-42de-aaff-3d6cddca2263">


```js
{
  "query":"\n  query($companyName: String!, $hasData: Boolean!, $limit: Int) {\n    search_companies(query: $companyName, hasData: $hasData, limit: $limit) {\n      name\n      businessNumber\n      dataCount\n    }\n  }\n",
  "variables":{"companyName":"台大","hasData":false,"limit":10}
}
```

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 到上述的幾個網頁測試，開啟 console 看 network log