### PR TITLE
[公司職稱頁面] 面試經驗分頁

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -171,6 +171,7 @@ export const queryCompanyTimeAndSalary = ({
   if (
     isFetching(box) ||
     (isFetched(box) &&
+      box.data.name === companyName &&
       box.data.jobTitle === jobTitle &&
       box.data.start === start &&
       box.data.limit === limit)
@@ -221,6 +222,7 @@ export const queryCompanyInterviewExperiences = ({
   if (
     isFetching(box) ||
     (isFetched(box) &&
+      box.data.name === companyName &&
       box.data.jobTitle === jobTitle &&
       box.data.start === start &&
       box.data.limit === limit)
@@ -244,14 +246,12 @@ export const queryCompanyInterviewExperiences = ({
     }
 
     const interviewExperiencesData = {
+      name: data.name,
       jobTitle,
       start,
       limit,
-      name: data.name,
-      interview_experiences: data.interviewExperiencesResult.interviewExperiences.slice(
-        0,
-        INTERVIEW_EXPERIENCES_LIMIT,
-      ),
+      interview_experiences:
+        data.interviewExperiencesResult.interviewExperiences,
       interview_experiences_count: data.interviewExperiencesResult.count,
     };
 

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -12,16 +12,20 @@ import {
   jobTitleIndexesBoxSelectorAtPage,
   jobTitleOverviewBoxSelectorByName,
   jobTitleTimeAndSalaryBoxSelectorByName,
+  jobTitleInterviewExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import {
   getJobTitle as getJobTitleApi,
   getJobTitleTimeAndSalary,
+  getJobTitleInterviewExperiences,
   queryJobTitlesApi,
 } from 'apis/jobTitle';
 
 export const SET_STATUS = '@@JOB_TITLE/SET_STATUS';
 export const SET_OVERVIEW = '@@JOB_TITLE/SET_OVERVIEW';
 export const SET_TIME_AND_SALARY = '@@JOB_TITLE/SET_TIME_AND_SALARY';
+export const SET_INTERVIEW_EXPERIENCES =
+  '@@JOB_TITLE/SET_INTERVIEW_EXPERIENCES';
 export const SET_INDEX = '@@JOB_TITLE/SET_INDEX';
 export const SET_INDEX_COUNT = '@@JOB_TITLE/SET_INDEX_COUNT';
 
@@ -195,5 +199,63 @@ export const queryJobTitleTimeAndSalary = ({
     dispatch(setTimeAndSalary(jobTitle, getFetched(timeAndSalaryData)));
   } catch (error) {
     dispatch(setTimeAndSalary(jobTitle, getError(error)));
+  }
+};
+
+const setInterviewExperiences = (jobTitle, box) => ({
+  type: SET_INTERVIEW_EXPERIENCES,
+  jobTitle,
+  box,
+});
+
+export const queryJobTitleInterviewExperiences = ({
+  companyName,
+  jobTitle,
+  start,
+  limit,
+}) => async (dispatch, getState) => {
+  const box = jobTitleInterviewExperiencesBoxSelectorByName(jobTitle)(
+    getState(),
+  );
+  if (
+    isFetching(box) ||
+    (isFetched(box) &&
+      box.data.companyName === companyName &&
+      box.data.start === start &&
+      box.data.limit === limit)
+  ) {
+    return;
+  }
+
+  dispatch(setInterviewExperiences(jobTitle, toFetching()));
+
+  try {
+    const data = await getJobTitleInterviewExperiences({
+      jobTitle,
+      companyName,
+      start,
+      limit,
+    });
+
+    // Not found case
+    if (data == null) {
+      return dispatch(setInterviewExperiences(jobTitle, getFetched(data)));
+    }
+
+    const interviewExperiencesyData = {
+      name: data.name,
+      companyName,
+      start,
+      limit,
+      interview_experiences:
+        data.interviewExperiencesResult.interviewExperiences,
+      interview_experiences_count: data.interviewExperiencesResult.count,
+    };
+
+    dispatch(
+      setInterviewExperiences(jobTitle, getFetched(interviewExperiencesyData)),
+    );
+  } catch (error) {
+    dispatch(setInterviewExperiences(jobTitle, getError(error)));
   }
 };

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -1,11 +1,26 @@
 import R from 'ramda';
 import graphqlClient from 'utils/graphqlClient';
-import { getCompanyQuery, queryCompaniesHavingDataGql } from 'graphql/company';
+import {
+  getCompanyInterviewExperiencesQuery,
+  getCompanyQuery,
+  queryCompaniesHavingDataGql,
+} from 'graphql/company';
 
 export const getCompany = companyName =>
   graphqlClient({
     query: getCompanyQuery,
     variables: { companyName },
+  }).then(R.prop('company'));
+
+export const getCompanyInterviewExperiences = ({
+  companyName,
+  jobTitle,
+  start,
+  limit,
+}) =>
+  graphqlClient({
+    query: getCompanyInterviewExperiencesQuery,
+    variables: { companyName, jobTitle, start, limit },
   }).then(R.prop('company'));
 
 export const queryCompaniesApi = ({ start, limit }) =>

--- a/src/apis/jobTitle.js
+++ b/src/apis/jobTitle.js
@@ -1,6 +1,7 @@
 import R from 'ramda';
 import graphqlClient from 'utils/graphqlClient';
 import {
+  getJobTitleInterviewExperiencesQuery,
   getJobTitleQuery,
   getJobTitleTimeAndSalaryQuery,
   queryJobTitlesHavingDataGql,
@@ -20,6 +21,17 @@ export const getJobTitleTimeAndSalary = ({
 }) =>
   graphqlClient({
     query: getJobTitleTimeAndSalaryQuery,
+    variables: { jobTitle, companyName, start, limit },
+  }).then(R.prop('job_title'));
+
+export const getJobTitleInterviewExperiences = ({
+  jobTitle,
+  companyName,
+  start,
+  limit,
+}) =>
+  graphqlClient({
+    query: getJobTitleInterviewExperiencesQuery,
     variables: { jobTitle, companyName, start, limit },
   }).then(R.prop('job_title'));
 

--- a/src/components/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/components/Company/CompanyInterviewExperiencesProvider.js
@@ -1,0 +1,83 @@
+import React, { useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
+import { paramsSelector } from 'common/routing/selectors';
+import usePermission from 'hooks/usePermission';
+import { usePage } from 'hooks/routing/page';
+import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { queryCompanyInterviewExperiences } from 'actions/company';
+import {
+  interviewExperiences as interviewExperiencesSelector,
+  status as statusSelector,
+  companyInterviewExperiencesBoxSelectorByName,
+} from 'selectors/companyAndJobTitle';
+import { usePageName, pageNameSelector } from './usePageName';
+
+const useInterviewExperiencesBox = pageName => {
+  const selector = useCallback(
+    state => {
+      const company = companyInterviewExperiencesBoxSelectorByName(pageName)(
+        state,
+      );
+      return {
+        status: statusSelector(company),
+        interviewExperiences: interviewExperiencesSelector(company),
+      };
+    },
+    [pageName],
+  );
+  return useSelector(selector);
+};
+
+const CompanyInterviewExperiencesProvider = () => {
+  const dispatch = useDispatch();
+  const pageType = PAGE_TYPE.COMPANY;
+  const pageName = usePageName();
+  const page = usePage();
+
+  useEffect(() => {
+    dispatch(
+      queryCompanyInterviewExperiences({
+        companyName: pageName,
+        start: 0,
+        limit: 10,
+      }),
+    );
+  }, [dispatch, pageName]);
+
+  const [, fetchPermission, canView] = usePermission();
+  useEffect(() => {
+    fetchPermission();
+  }, [pageType, pageName, fetchPermission]);
+
+  const { status, interviewExperiences } = useInterviewExperiencesBox(pageName);
+
+  return (
+    <InterviewExperiences
+      pageType={pageType}
+      pageName={pageName}
+      page={page}
+      canView={canView}
+      tabType={tabType.INTERVIEW_EXPERIENCE}
+      status={status}
+      interviewExperiences={interviewExperiences}
+    />
+  );
+};
+
+CompanyInterviewExperiencesProvider.fetchData = ({
+  store: { dispatch },
+  ...props
+}) => {
+  const params = paramsSelector(props);
+  const pageName = pageNameSelector(params);
+  return dispatch(
+    queryCompanyInterviewExperiences({
+      companyName: pageName,
+      start: 0,
+      limit: 10,
+    }),
+  );
+};
+
+export default CompanyInterviewExperiencesProvider;

--- a/src/components/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/components/Company/CompanyInterviewExperiencesProvider.js
@@ -1,17 +1,23 @@
 import React, { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
-import { paramsSelector } from 'common/routing/selectors';
+import { paramsSelector, querySelector } from 'common/routing/selectors';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
 import { queryCompanyInterviewExperiences } from 'actions/company';
 import {
   interviewExperiences as interviewExperiencesSelector,
+  interviewExperiencesCount as interviewExperiencesCountSelector,
   status as statusSelector,
   companyInterviewExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import { usePageName, pageNameSelector } from './usePageName';
+import {
+  searchTextFromQuerySelector,
+  useSearchTextFromQuery,
+} from 'components/CompanyAndJobTitle/useSearchbar';
+import { pageFromQuerySelector } from 'selectors/routing/page';
 
 const useInterviewExperiencesBox = pageName => {
   const selector = useCallback(
@@ -22,6 +28,7 @@ const useInterviewExperiencesBox = pageName => {
       return {
         status: statusSelector(company),
         interviewExperiences: interviewExperiencesSelector(company),
+        interviewExperiencesCount: interviewExperiencesCountSelector(company),
       };
     },
     [pageName],
@@ -29,34 +36,46 @@ const useInterviewExperiencesBox = pageName => {
   return useSelector(selector);
 };
 
+const PAGE_SIZE = 10;
+
 const CompanyInterviewExperiencesProvider = () => {
   const dispatch = useDispatch();
   const pageType = PAGE_TYPE.COMPANY;
   const pageName = usePageName();
+  const [jobTitle] = useSearchTextFromQuery();
   const page = usePage();
+  const start = (page - 1) * PAGE_SIZE;
+  const limit = PAGE_SIZE;
 
   useEffect(() => {
     dispatch(
       queryCompanyInterviewExperiences({
         companyName: pageName,
-        start: 0,
-        limit: 10,
+        jobTitle: jobTitle || undefined,
+        start,
+        limit,
       }),
     );
-  }, [dispatch, pageName]);
+  }, [dispatch, pageName, jobTitle, start, limit]);
 
   const [, fetchPermission, canView] = usePermission();
   useEffect(() => {
     fetchPermission();
   }, [pageType, pageName, fetchPermission]);
 
-  const { status, interviewExperiences } = useInterviewExperiencesBox(pageName);
+  const {
+    status,
+    interviewExperiences,
+    interviewExperiencesCount,
+  } = useInterviewExperiencesBox(pageName);
 
   return (
     <InterviewExperiences
       pageType={pageType}
       pageName={pageName}
       page={page}
+      pageSize={PAGE_SIZE}
+      totalCount={interviewExperiencesCount}
       canView={canView}
       tabType={tabType.INTERVIEW_EXPERIENCE}
       status={status}
@@ -71,11 +90,17 @@ CompanyInterviewExperiencesProvider.fetchData = ({
 }) => {
   const params = paramsSelector(props);
   const pageName = pageNameSelector(params);
+  const query = querySelector(props);
+  const page = pageFromQuerySelector(query);
+  const jobTitle = searchTextFromQuerySelector(query) || undefined;
+  const start = (page - 1) * PAGE_SIZE;
+  const limit = PAGE_SIZE;
   return dispatch(
     queryCompanyInterviewExperiences({
       companyName: pageName,
-      start: 0,
-      limit: 10,
+      jobTitle,
+      start,
+      limit,
     }),
   );
 };

--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { generatePath } from 'react-router';
 import { Switch, Route } from 'react-router-dom';
-import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import CompanyJobTitleTimeAndSalary from '../CompanyAndJobTitle/TimeAndSalary';
 import NotFound from 'common/NotFound';
@@ -13,19 +12,14 @@ import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
 import {
   companySalaryWorkTimesPath,
-  companyInterviewExperiencesPath,
   companyWorkExperiencesPath,
 } from 'constants/linkTo';
 import { fetchCompany } from 'actions/company';
 import {
-  interviewExperiences,
-  workExperiences,
-  salaryWorkTimes,
-  salaryWorkTimeStatistics,
-  jobAverageSalaries,
-  averageWeekWorkTime,
-  overtimeFrequencyCount,
-  status,
+  workExperiences as workExperiencesSelector,
+  salaryWorkTimes as salaryWorkTimesSelector,
+  salaryWorkTimeStatistics as salaryWorkTimeStatisticsSelector,
+  status as statusSelector,
   company as companySelector,
 } from 'selectors/companyAndJobTitle';
 import { usePageName, pageNameSelector } from './usePageName';
@@ -49,19 +43,20 @@ const CompanyPageProvider = () => {
     state => {
       const company = companySelector(pageName)(state);
       return {
-        status: status(company),
-        interviewExperiences: interviewExperiences(company),
-        workExperiences: workExperiences(company),
-        salaryWorkTimes: salaryWorkTimes(company),
-        salaryWorkTimeStatistics: salaryWorkTimeStatistics(company),
-        jobAverageSalaries: jobAverageSalaries(company),
-        averageWeekWorkTime: averageWeekWorkTime(company),
-        overtimeFrequencyCount: overtimeFrequencyCount(company),
+        status: statusSelector(company),
+        workExperiences: workExperiencesSelector(company),
+        salaryWorkTimes: salaryWorkTimesSelector(company),
+        salaryWorkTimeStatistics: salaryWorkTimeStatisticsSelector(company),
       };
     },
     [pageName],
   );
-  const data = useSelector(selector);
+  const {
+    status,
+    workExperiences,
+    salaryWorkTimes,
+    salaryWorkTimeStatistics,
+  } = useSelector(selector);
 
   return (
     <Switch>
@@ -80,26 +75,13 @@ const CompanyPageProvider = () => {
         exact
         render={() => (
           <CompanyJobTitleTimeAndSalary
-            {...data}
             pageType={pageType}
             pageName={pageName}
             page={page}
-            canView={canView}
             tabType={tabType.TIME_AND_SALARY}
-          />
-        )}
-      />
-      <Route
-        path={companyInterviewExperiencesPath}
-        exact
-        render={() => (
-          <InterviewExperiences
-            {...data}
-            pageType={pageType}
-            pageName={pageName}
-            page={page}
-            canView={canView}
-            tabType={tabType.INTERVIEW_EXPERIENCE}
+            status={status}
+            salaryWorkTimes={salaryWorkTimes}
+            salaryWorkTimeStatistics={salaryWorkTimeStatistics}
           />
         )}
       />
@@ -108,12 +90,13 @@ const CompanyPageProvider = () => {
         exact
         render={() => (
           <WorkExperiences
-            {...data}
             pageType={pageType}
             pageName={pageName}
             page={page}
             canView={canView}
             tabType={tabType.WORK_EXPERIENCE}
+            status={status}
+            workExperiences={workExperiences}
           />
         )}
       />

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import qs from 'qs';
 
 import Pagination from 'common/Pagination';
 import { Section } from 'common/base';
@@ -8,8 +9,7 @@ import EmptyView from '../EmptyView';
 import ExperienceEntry from './ExperienceEntry';
 
 import useSearchbar from '../useSearchbar';
-
-const pageSize = 10;
+import { useQuery } from 'hooks/routing';
 
 const InterviewExperiences = ({
   pageType,
@@ -17,14 +17,15 @@ const InterviewExperiences = ({
   tabType,
   data,
   page,
+  pageSize,
+  totalCount,
   canView,
 }) => {
-  const { Searchbar, matchesFilter } = useSearchbar({
+  const queryParams = useQuery();
+  const { Searchbar } = useSearchbar({
     pageType,
     tabType,
   });
-
-  data = useMemo(() => data.filter(matchesFilter), [data, matchesFilter]);
 
   if (data.length === 0) {
     return (
@@ -34,11 +35,10 @@ const InterviewExperiences = ({
       </Section>
     );
   }
-  const visibleData = data.slice((page - 1) * pageSize, page * pageSize);
   return (
     <Section Tag="main" paddingBottom>
       <Searchbar />
-      {visibleData.map(d => (
+      {data.map(d => (
         <ExperienceEntry
           key={d.id}
           pageType={pageType}
@@ -47,10 +47,12 @@ const InterviewExperiences = ({
         />
       ))}
       <Pagination
-        totalCount={data.length}
+        totalCount={totalCount}
         unit={pageSize}
         currentPage={page}
-        createPageLinkTo={page => `?p=${page}`}
+        createPageLinkTo={p =>
+          qs.stringify({ ...queryParams, p }, { addQueryPrefix: true })
+        }
       />
     </Section>
   );
@@ -61,8 +63,10 @@ InterviewExperiences.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
   page: PropTypes.number.isRequired,
   pageName: PropTypes.string.isRequired,
+  pageSize: PropTypes.number.isRequired,
   pageType: PropTypes.string.isRequired,
   tabType: PropTypes.string.isRequired,
+  totalCount: PropTypes.number.isRequired,
 };
 
 export default InterviewExperiences;

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
@@ -12,6 +12,8 @@ const InterviewExperiences = ({
   interviewExperiences,
   status,
   page,
+  pageSize,
+  totalCount,
   canView,
 }) => (
   <CompanyAndJobTitleWrapper
@@ -32,6 +34,8 @@ const InterviewExperiences = ({
         tabType={tabType}
         data={interviewExperiences}
         page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
         canView={canView}
       />
     </StatusRenderer>
@@ -43,9 +47,11 @@ InterviewExperiences.propTypes = {
   interviewExperiences: PropTypes.arrayOf(PropTypes.object),
   page: PropTypes.number.isRequired,
   pageName: PropTypes.string.isRequired,
+  pageSize: PropTypes.number.isRequired,
   pageType: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   tabType: PropTypes.string.isRequired,
+  totalCount: PropTypes.number.isRequired,
 };
 
 export default InterviewExperiences;

--- a/src/components/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/components/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -1,0 +1,109 @@
+import React, { useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
+import usePermission from 'hooks/usePermission';
+import { usePage } from 'hooks/routing/page';
+import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { queryJobTitleInterviewExperiences } from 'actions/jobTitle';
+import {
+  interviewExperiences as interviewExperiencesSelector,
+  interviewExperiencesCount as interviewExperiencesCountSelector,
+  status as statusSelector,
+  jobTitleInterviewExperiencesBoxSelectorByName,
+} from 'selectors/companyAndJobTitle';
+import { paramsSelector, querySelector } from 'common/routing/selectors';
+import { usePageName, pageNameSelector } from './usePageName';
+import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  searchTextFromQuerySelector,
+  useSearchTextFromQuery,
+} from 'components/CompanyAndJobTitle/useSearchbar';
+
+const useInterviewExperiencesBox = pageName => {
+  const selector = useCallback(
+    state => {
+      const jobTitle = jobTitleInterviewExperiencesBoxSelectorByName(pageName)(
+        state,
+      );
+      return {
+        status: statusSelector(jobTitle),
+        interviewExperiences: interviewExperiencesSelector(jobTitle),
+        interviewExperiencesCount: interviewExperiencesCountSelector(jobTitle),
+      };
+    },
+    [pageName],
+  );
+
+  return useSelector(selector);
+};
+
+const PAGE_SIZE = 10;
+
+const JobTitleTimeAndSalaryProvider = () => {
+  const dispatch = useDispatch();
+  const pageType = PAGE_TYPE.JOB_TITLE;
+  const pageName = usePageName();
+  const [companyName] = useSearchTextFromQuery();
+  const page = usePage();
+  const start = (page - 1) * PAGE_SIZE;
+  const limit = PAGE_SIZE;
+
+  useEffect(() => {
+    dispatch(
+      queryJobTitleInterviewExperiences({
+        jobTitle: pageName,
+        companyName: companyName || undefined,
+        start,
+        limit,
+      }),
+    );
+  }, [dispatch, pageName, companyName, start, limit]);
+
+  const [, fetchPermission, canView] = usePermission();
+  useEffect(() => {
+    fetchPermission();
+  }, [pageType, pageName, fetchPermission]);
+
+  const {
+    status,
+    interviewExperiences,
+    interviewExperiencesCount,
+  } = useInterviewExperiencesBox(pageName);
+
+  return (
+    <InterviewExperiences
+      pageType={pageType}
+      pageName={pageName}
+      page={page}
+      pageSize={PAGE_SIZE}
+      totalCount={interviewExperiencesCount}
+      canView={canView}
+      tabType={tabType.INTERVIEW_EXPERIENCE}
+      status={status}
+      interviewExperiences={interviewExperiences}
+    />
+  );
+};
+
+JobTitleTimeAndSalaryProvider.fetchData = ({
+  store: { dispatch },
+  ...props
+}) => {
+  const params = paramsSelector(props);
+  const pageName = pageNameSelector(params);
+  const query = querySelector(props);
+  const page = pageFromQuerySelector(query);
+  const companyName = searchTextFromQuerySelector(query) || undefined;
+  const start = (page - 1) * PAGE_SIZE;
+  const limit = PAGE_SIZE;
+  return dispatch(
+    queryJobTitleInterviewExperiences({
+      jobTitle: pageName,
+      companyName,
+      start,
+      limit,
+    }),
+  );
+};
+
+export default JobTitleTimeAndSalaryProvider;

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { generatePath } from 'react-router';
 import { Switch, Route } from 'react-router-dom';
-import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
 import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import NotFound from 'common/NotFound';
 import Redirect from 'common/routing/Redirect';
@@ -10,13 +9,9 @@ import { paramsSelector } from 'common/routing/selectors';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import {
-  jobTitleInterviewExperiencesPath,
-  jobTitleWorkExperiencesPath,
-} from 'constants/linkTo';
+import { jobTitleWorkExperiencesPath } from 'constants/linkTo';
 import { fetchJobTitle } from 'actions/jobTitle';
 import {
-  interviewExperiences as interviewExperiencesSelector,
   workExperiences as workExperiencesSelector,
   status as statusSelector,
   jobTitle as jobTitleSelector,
@@ -43,15 +38,12 @@ const JobTitlePageProvider = () => {
       const jobTitle = jobTitleSelector(pageName)(state);
       return {
         status: statusSelector(jobTitle),
-        interviewExperiences: interviewExperiencesSelector(jobTitle),
         workExperiences: workExperiencesSelector(jobTitle),
       };
     },
     [pageName],
   );
-  const { status, interviewExperiences, workExperiences } = useSelector(
-    selector,
-  );
+  const { status, workExperiences } = useSelector(selector);
 
   return (
     <Switch>
@@ -64,21 +56,6 @@ const JobTitlePageProvider = () => {
           const path = generatePath('/job-titles/:jobTitle', { jobTitle });
           return <Redirect to={path} />;
         }}
-      />
-      <Route
-        path={jobTitleInterviewExperiencesPath}
-        exact
-        render={() => (
-          <InterviewExperiences
-            pageType={pageType}
-            pageName={pageName}
-            page={page}
-            canView={canView}
-            tabType={tabType.INTERVIEW_EXPERIENCE}
-            status={status}
-            interviewExperiences={interviewExperiences}
-          />
-        )}
       />
       <Route
         path={jobTitleWorkExperiencesPath}

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -122,6 +122,48 @@ export const getCompanyQuery = /* GraphQL */ `
   }
 `;
 
+export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
+  query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
+    company(name: $companyName) {
+      name
+      interviewExperiencesResult(
+        jobTitle: $jobTitle
+        start: $start
+        limit: $limit
+      ) {
+        count
+        interviewExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          overall_rating
+        }
+      }
+    }
+  }
+`;
+
 export const queryCompaniesHavingDataGql = /* GraphQL */ `
   query($start: Int!, $limit: Int!) {
     companiesHavingData(start: $start, limit: $limit) {

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -207,6 +207,48 @@ export const getJobTitleTimeAndSalaryQuery = /* GraphQL */ `
   }
 `;
 
+export const getJobTitleInterviewExperiencesQuery = /* GraphQL */ `
+  query($jobTitle: String!, $companyName: String, $start: Int!, $limit: Int!) {
+    job_title(name: $jobTitle) {
+      name
+      interviewExperiencesResult(
+        companyQuery: $companyName
+        start: $start
+        limit: $limit
+      ) {
+        count
+        interviewExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          overall_rating
+        }
+      }
+    }
+  }
+`;
+
 export const queryJobTitlesHavingDataGql = /* GraphQL */ `
   query($start: Int!, $limit: Int!) {
     jobTitlesHavingData(start: $start, limit: $limit) {

--- a/src/reducers/companyIndex.js
+++ b/src/reducers/companyIndex.js
@@ -1,6 +1,11 @@
 import createReducer from 'utils/createReducer';
 import { getUnfetched } from 'utils/fetchBox';
-import { SET_INDEX_COUNT, SET_INDEX, SET_OVERVIEW } from 'actions/company';
+import {
+  SET_INDEX_COUNT,
+  SET_INDEX,
+  SET_OVERVIEW,
+  SET_INTERVIEW_EXPERIENCES,
+} from 'actions/company';
 
 const preloadedState = {
   // page --> indexBox
@@ -8,6 +13,7 @@ const preloadedState = {
   indexCountBox: getUnfetched(),
   // companyName --> overviewBox
   overviewByName: {},
+  interviewExperiencesByName: {},
 };
 
 const reducer = createReducer(preloadedState, {
@@ -29,6 +35,15 @@ const reducer = createReducer(preloadedState, {
       ...state,
       overviewByName: {
         ...state.overviewByName,
+        [companyName]: box,
+      },
+    };
+  },
+  [SET_INTERVIEW_EXPERIENCES]: (state, { companyName, box }) => {
+    return {
+      ...state,
+      interviewExperiencesByName: {
+        ...state.interviewExperiencesByName,
         [companyName]: box,
       },
     };

--- a/src/reducers/jobTitleIndex.js
+++ b/src/reducers/jobTitleIndex.js
@@ -5,6 +5,7 @@ import {
   SET_INDEX,
   SET_OVERVIEW,
   SET_TIME_AND_SALARY,
+  SET_INTERVIEW_EXPERIENCES,
 } from 'actions/jobTitle';
 
 const preloadedState = {
@@ -14,6 +15,7 @@ const preloadedState = {
   // jobTitle --> overviewBox
   overviewByName: {},
   timeAndSalaryByName: {},
+  interviewExperiencesByName: {},
 };
 
 const reducer = createReducer(preloadedState, {
@@ -44,6 +46,15 @@ const reducer = createReducer(preloadedState, {
       ...state,
       timeAndSalaryByName: {
         ...state.timeAndSalaryByName,
+        [jobTitle]: box,
+      },
+    };
+  },
+  [SET_INTERVIEW_EXPERIENCES]: (state, { jobTitle, box }) => {
+    return {
+      ...state,
+      interviewExperiencesByName: {
+        ...state.interviewExperiencesByName,
         [jobTitle]: box,
       },
     };

--- a/src/routes.js
+++ b/src/routes.js
@@ -24,6 +24,7 @@ import CompanyAndJobTitlePageContainer from './components/CompanyAndJobTitle';
 import CompanyPageProvider from './components/Company/CompanyPageProvider';
 import CompanyIndexProvider from './components/Company/CompanyIndexProvider';
 import CompanyOverviewProvider from 'components/Company/CompanyOverviewProvider';
+import CompanyInterviewExperiencesProvider from 'components/Company/CompanyInterviewExperiencesProvider';
 import JobTitlePageProvider from './components/JobTitle/JobTitlePageProvider';
 import JobTitleIndexProvider from './components/JobTitle/JobTitleIndexProvider';
 import JobTitleOverviewProvider from 'components/JobTitle/JobTitleOverviewProvider';
@@ -32,7 +33,11 @@ import PlanPage from './components/PlanPage';
 import BuyResultPage from './components/BuyResultPage';
 import CurrentSubscriptionPage from './components/Me/CurrentSubscriptionPage';
 import SubscriptionsPage from './components/Me/SubscriptionsPage';
-import { jobTitleOverviewPath, companyOverviewPath } from 'constants/linkTo';
+import {
+  jobTitleOverviewPath,
+  companyOverviewPath,
+  companyInterviewExperiencesPath,
+} from 'constants/linkTo';
 
 const routes = [
   {
@@ -112,6 +117,11 @@ const routes = [
       {
         path: companyOverviewPath,
         component: CompanyOverviewProvider,
+        exact: true,
+      },
+      {
+        path: companyInterviewExperiencesPath,
+        component: CompanyInterviewExperiencesProvider,
         exact: true,
       },
       {

--- a/src/routes.js
+++ b/src/routes.js
@@ -30,6 +30,7 @@ import JobTitlePageProvider from './components/JobTitle/JobTitlePageProvider';
 import JobTitleIndexProvider from './components/JobTitle/JobTitleIndexProvider';
 import JobTitleOverviewProvider from 'components/JobTitle/JobTitleOverviewProvider';
 import JobTitleTimeAndSalaryProvider from 'components/JobTitle/JobTitleTimeAndSalaryProvider';
+import JobTitleInterviewExperiencesProvider from 'components/JobTitle/JobTitleInterviewExperiencesProvider';
 
 import PlanPage from './components/PlanPage';
 import BuyResultPage from './components/BuyResultPage';
@@ -41,6 +42,7 @@ import {
   companyOverviewPath,
   companySalaryWorkTimesPath,
   companyInterviewExperiencesPath,
+  jobTitleInterviewExperiencesPath,
 } from 'constants/linkTo';
 
 const routes = [
@@ -159,6 +161,11 @@ const routes = [
       {
         path: jobTitleSalaryWorkTimesPath,
         component: JobTitleTimeAndSalaryProvider,
+        exact: true,
+      },
+      {
+        path: jobTitleInterviewExperiencesPath,
+        component: JobTitleInterviewExperiencesProvider,
         exact: true,
       },
       {

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -23,7 +23,7 @@ export const interviewExperiences = R.pipe(
 export const interviewExperiencesCount = R.pipe(
   data,
   R.when(R.is(Object), R.prop('interview_experiences_count')),
-  R.defaultTo([]),
+  R.defaultTo(0),
 );
 
 export const workExperiences = R.pipe(
@@ -139,4 +139,10 @@ export const jobTitleOverviewBoxSelectorByName = jobTitle => state => {
 
 export const jobTitleTimeAndSalaryBoxSelectorByName = jobTitle => state => {
   return state.jobTitleIndex.timeAndSalaryByName[jobTitle] || getUnfetched();
+};
+
+export const jobTitleInterviewExperiencesBoxSelectorByName = jobTitle => state => {
+  return (
+    state.jobTitleIndex.interviewExperiencesByName[jobTitle] || getUnfetched()
+  );
 };

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -19,6 +19,13 @@ export const interviewExperiences = R.pipe(
   R.when(R.is(Object), R.prop('interview_experiences')),
   R.defaultTo([]),
 );
+
+export const interviewExperiencesCount = R.pipe(
+  data,
+  R.when(R.is(Object), R.prop('interview_experiences_count')),
+  R.defaultTo([]),
+);
+
 export const workExperiences = R.pipe(
   data,
   R.when(R.is(Object), R.prop('work_experiences')),

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -101,6 +101,12 @@ export const companyOverviewBoxSelectorByName = companyName => state => {
   return state.companyIndex.overviewByName[companyName] || getUnfetched();
 };
 
+export const companyInterviewExperiencesBoxSelectorByName = companyName => state => {
+  return (
+    state.companyIndex.interviewExperiencesByName[companyName] || getUnfetched()
+  );
+};
+
 export const jobTitleIndexesBoxSelectorAtPage = page => state => {
   return state.jobTitleIndex.indexesByPage[page] || getUnfetched();
 };


### PR DESCRIPTION
#1385 

## 這個 PR 是？ <!-- 必填 -->

讓公司/職稱頁面的面試經驗標籤頁做分頁，包含搜尋。

### 技術細節

原本公司頁面的資料都放在 `state.company.[name].status|data|error`，資料包含薪資、面試、經驗。

由於薪資會獨立獲取，現將薪資移至 `state.companyIndex.interviewExperiencesByName.[name].status|data|error`。

### TODO

搜尋時，應該只有底下的 table 會 loading，但目前會連 search bar 一起 reload，影響使用者體驗。

本 PR 先專注在抽換 API，後續 UI 優化會由 #1416 處理。

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/1043

## Screenshots  <!-- 選填，沒有就刪掉 -->


https://github.com/user-attachments/assets/e06368b6-3a2c-40a5-bd2c-65d21dc351c1




## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/companies/%E5%B7%A5%E6%A5%AD%E6%8A%80%E8%A1%93%E7%A0%94%E7%A9%B6%E9%99%A2/interview-experiences