### PR TITLE
[公司職稱頁面] 評價分頁

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -12,16 +12,19 @@ import {
   companyIndexesBoxSelectorAtPage,
   companyOverviewBoxSelectorByName,
   companyTimeAndSalaryBoxSelectorByName,
+  companyWorkExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import {
   getCompany as getCompanyApi,
   getCompanyTimeAndSalary,
+  getCompanyWorkExperiences,
   queryCompaniesApi,
 } from 'apis/company';
 
 export const SET_STATUS = '@@company/SET_STATUS';
 export const SET_OVERVIEW = '@@COMPANY/SET_OVERVIEW';
 export const SET_TIME_AND_SALARY = '@@COMPANY/SET_TIME_AND_SALARY';
+export const SET_WORK_EXPERIENCES = '@@COMPANY/SET_WORK_EXPERIENCES';
 export const SET_INDEX = '@@COMPANY/SET_INDEX';
 export const SET_INDEX_COUNT = '@@COMPANY/SET_INDEX_COUNT';
 
@@ -162,6 +165,7 @@ export const queryCompanyTimeAndSalary = ({
   if (
     isFetching(box) ||
     (isFetched(box) &&
+      box.name === companyName &&
       box.data.jobTitle === jobTitle &&
       box.data.start === start &&
       box.data.limit === limit)
@@ -197,5 +201,59 @@ export const queryCompanyTimeAndSalary = ({
     dispatch(setTimeAndSalary(companyName, getFetched(timeAndSalaryData)));
   } catch (error) {
     dispatch(setTimeAndSalary(companyName, getError(error)));
+  }
+};
+
+const setWorkExperiences = (companyName, box) => ({
+  type: SET_WORK_EXPERIENCES,
+  companyName,
+  box,
+});
+
+export const queryCompanyWorkExperiences = ({
+  companyName,
+  jobTitle,
+  start,
+  limit,
+}) => async (dispatch, getState) => {
+  const box = companyWorkExperiencesBoxSelectorByName(companyName)(getState());
+  if (
+    isFetching(box) ||
+    (isFetched(box) &&
+      box.data.name === companyName &&
+      box.data.jobTitle === jobTitle &&
+      box.data.start === start &&
+      box.data.limit === limit)
+  ) {
+    return;
+  }
+
+  dispatch(setWorkExperiences(companyName, toFetching()));
+
+  try {
+    const data = await getCompanyWorkExperiences({
+      companyName,
+      jobTitle,
+      start,
+      limit,
+    });
+
+    // Not found case
+    if (data == null) {
+      return dispatch(setWorkExperiences(companyName, getFetched(data)));
+    }
+
+    const workExperiencesData = {
+      name: data.name,
+      jobTitle,
+      start,
+      limit,
+      work_experiences: data.workExperiencesResult.workExperiences,
+      work_experiences_count: data.workExperiencesResult.count,
+    };
+
+    dispatch(setWorkExperiences(companyName, getFetched(workExperiencesData)));
+  } catch (error) {
+    dispatch(setWorkExperiences(companyName, getError(error)));
   }
 };

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -12,16 +12,19 @@ import {
   jobTitleIndexesBoxSelectorAtPage,
   jobTitleOverviewBoxSelectorByName,
   jobTitleTimeAndSalaryBoxSelectorByName,
+  jobTitleWorkExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import {
   getJobTitle as getJobTitleApi,
   getJobTitleTimeAndSalary,
+  getJobTitleWorkExperiences,
   queryJobTitlesApi,
 } from 'apis/jobTitle';
 
 export const SET_STATUS = '@@JOB_TITLE/SET_STATUS';
 export const SET_OVERVIEW = '@@JOB_TITLE/SET_OVERVIEW';
 export const SET_TIME_AND_SALARY = '@@JOB_TITLE/SET_TIME_AND_SALARY';
+export const SET_WORK_EXPERIENCES = '@@JOB_TITLE/SET_WORK_EXPERIENCES';
 export const SET_INDEX = '@@JOB_TITLE/SET_INDEX';
 export const SET_INDEX_COUNT = '@@JOB_TITLE/SET_INDEX_COUNT';
 
@@ -160,6 +163,7 @@ export const queryJobTitleTimeAndSalary = ({
   if (
     isFetching(box) ||
     (isFetched(box) &&
+      box.data.name === jobTitle &&
       box.data.companyName === companyName &&
       box.data.start === start &&
       box.data.limit === limit)
@@ -195,5 +199,59 @@ export const queryJobTitleTimeAndSalary = ({
     dispatch(setTimeAndSalary(jobTitle, getFetched(timeAndSalaryData)));
   } catch (error) {
     dispatch(setTimeAndSalary(jobTitle, getError(error)));
+  }
+};
+
+const setWorkExperiences = (jobTitle, box) => ({
+  type: SET_WORK_EXPERIENCES,
+  jobTitle,
+  box,
+});
+
+export const queryJobTitleWorkExperiences = ({
+  companyName,
+  jobTitle,
+  start,
+  limit,
+}) => async (dispatch, getState) => {
+  const box = jobTitleWorkExperiencesBoxSelectorByName(jobTitle)(getState());
+  if (
+    isFetching(box) ||
+    (isFetched(box) &&
+      box.data.name === jobTitle &&
+      box.data.companyName === companyName &&
+      box.data.start === start &&
+      box.data.limit === limit)
+  ) {
+    return;
+  }
+
+  dispatch(setWorkExperiences(jobTitle, toFetching()));
+
+  try {
+    const data = await getJobTitleWorkExperiences({
+      jobTitle,
+      companyName,
+      start,
+      limit,
+    });
+
+    // Not found case
+    if (data == null) {
+      return dispatch(setWorkExperiences(jobTitle, getFetched(data)));
+    }
+
+    const workExperiencesData = {
+      name: data.name,
+      companyName,
+      start,
+      limit,
+      work_experiences: data.workExperiencesResult.workExperiences,
+      work_experiences_count: data.workExperiencesResult.count,
+    };
+
+    dispatch(setWorkExperiences(jobTitle, getFetched(workExperiencesData)));
+  } catch (error) {
+    dispatch(setWorkExperiences(jobTitle, getError(error)));
   }
 };

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -3,6 +3,7 @@ import graphqlClient from 'utils/graphqlClient';
 import {
   getCompanyQuery,
   getCompanyTimeAndSalaryQuery,
+  getCompanyWorkExperiencesQuery,
   queryCompaniesHavingDataGql,
 } from 'graphql/company';
 
@@ -20,6 +21,17 @@ export const getCompanyTimeAndSalary = ({
 }) =>
   graphqlClient({
     query: getCompanyTimeAndSalaryQuery,
+    variables: { companyName, jobTitle, start, limit },
+  }).then(R.prop('company'));
+
+export const getCompanyWorkExperiences = ({
+  companyName,
+  jobTitle,
+  start,
+  limit,
+}) =>
+  graphqlClient({
+    query: getCompanyWorkExperiencesQuery,
     variables: { companyName, jobTitle, start, limit },
   }).then(R.prop('company'));
 

--- a/src/apis/jobTitle.js
+++ b/src/apis/jobTitle.js
@@ -3,6 +3,7 @@ import graphqlClient from 'utils/graphqlClient';
 import {
   getJobTitleQuery,
   getJobTitleTimeAndSalaryQuery,
+  getJobTitleWorkExperiencesQuery,
   queryJobTitlesHavingDataGql,
 } from 'graphql/jobTitle';
 
@@ -20,6 +21,17 @@ export const getJobTitleTimeAndSalary = ({
 }) =>
   graphqlClient({
     query: getJobTitleTimeAndSalaryQuery,
+    variables: { jobTitle, companyName, start, limit },
+  }).then(R.prop('job_title'));
+
+export const getJobTitleWorkExperiences = ({
+  jobTitle,
+  companyName,
+  start,
+  limit,
+}) =>
+  graphqlClient({
+    query: getJobTitleWorkExperiencesQuery,
     variables: { jobTitle, companyName, start, limit },
   }).then(R.prop('job_title'));
 

--- a/src/components/Company/CompanyPageProvider.js
+++ b/src/components/Company/CompanyPageProvider.js
@@ -3,21 +3,16 @@ import { useSelector, useDispatch } from 'react-redux';
 import { generatePath } from 'react-router';
 import { Switch, Route } from 'react-router-dom';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
-import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import NotFound from 'common/NotFound';
 import Redirect from 'common/routing/Redirect';
 import { paramsSelector } from 'common/routing/selectors';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import {
-  companyInterviewExperiencesPath,
-  companyWorkExperiencesPath,
-} from 'constants/linkTo';
+import { companyInterviewExperiencesPath } from 'constants/linkTo';
 import { fetchCompany } from 'actions/company';
 import {
   interviewExperiences as interviewExperiencesSelector,
-  workExperiences as workExperiencesSelector,
   status as statusSelector,
   company as companySelector,
 } from 'selectors/companyAndJobTitle';
@@ -44,14 +39,11 @@ const CompanyPageProvider = () => {
       return {
         status: statusSelector(company),
         interviewExperiences: interviewExperiencesSelector(company),
-        workExperiences: workExperiencesSelector(company),
       };
     },
     [pageName],
   );
-  const { status, interviewExperiences, workExperiences } = useSelector(
-    selector,
-  );
+  const { status, interviewExperiences } = useSelector(selector);
 
   return (
     <Switch>
@@ -77,21 +69,6 @@ const CompanyPageProvider = () => {
             tabType={tabType.INTERVIEW_EXPERIENCE}
             status={status}
             interviewExperiences={interviewExperiences}
-          />
-        )}
-      />
-      <Route
-        path={companyWorkExperiencesPath}
-        exact
-        render={() => (
-          <WorkExperiences
-            pageType={pageType}
-            pageName={pageName}
-            page={page}
-            canView={canView}
-            tabType={tabType.WORK_EXPERIENCE}
-            status={status}
-            workExperiences={workExperiences}
           />
         )}
       />

--- a/src/components/Company/CompanyWorkExperiencesProvider.js
+++ b/src/components/Company/CompanyWorkExperiencesProvider.js
@@ -1,0 +1,108 @@
+import React, { useCallback, useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
+import usePermission from 'hooks/usePermission';
+import { usePage } from 'hooks/routing/page';
+import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import {
+  queryCompanyTimeAndSalary,
+  queryCompanyWorkExperiences,
+} from 'actions/company';
+import {
+  workExperiences as workExperiencesSelector,
+  workExperiencesCount as workExperiencesCountSelector,
+  status as statusSelector,
+  companyWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorByName,
+} from 'selectors/companyAndJobTitle';
+import { paramsSelector, querySelector } from 'common/routing/selectors';
+import { usePageName, pageNameSelector } from './usePageName';
+import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  searchTextFromQuerySelector,
+  useSearchTextFromQuery,
+} from 'components/CompanyAndJobTitle/useSearchbar';
+
+const useTimeAndSalaryBox = pageName => {
+  const selector = useCallback(
+    state => {
+      const company = workExperiencesBoxSelectorByName(pageName)(state);
+      return {
+        status: statusSelector(company),
+        workExperiences: workExperiencesSelector(company),
+        workExperiencesCount: workExperiencesCountSelector(company),
+      };
+    },
+    [pageName],
+  );
+
+  return useSelector(selector);
+};
+
+const PAGE_SIZE = 10;
+
+const CompanyTimeAndSalaryProvider = () => {
+  const dispatch = useDispatch();
+  const pageType = PAGE_TYPE.COMPANY;
+  const pageName = usePageName();
+  const [jobTitle] = useSearchTextFromQuery();
+  const page = usePage();
+  const start = (page - 1) * PAGE_SIZE;
+  const limit = PAGE_SIZE;
+
+  useEffect(() => {
+    dispatch(
+      queryCompanyWorkExperiences({
+        companyName: pageName,
+        jobTitle: jobTitle || undefined,
+        start,
+        limit,
+      }),
+    );
+  }, [dispatch, pageName, jobTitle, start, limit]);
+
+  const [, fetchPermission, canView] = usePermission();
+  useEffect(() => {
+    fetchPermission();
+  }, [pageType, pageName, fetchPermission]);
+
+  const { status, workExperiences, workExperiencesCount } = useTimeAndSalaryBox(
+    pageName,
+  );
+
+  return (
+    <WorkExperiences
+      pageType={pageType}
+      pageName={pageName}
+      page={page}
+      pageSize={PAGE_SIZE}
+      totalCount={workExperiencesCount}
+      canView={canView}
+      tabType={tabType.WORK_EXPERIENCE}
+      status={status}
+      workExperiences={workExperiences}
+    />
+  );
+};
+
+CompanyTimeAndSalaryProvider.fetchData = ({
+  store: { dispatch },
+  ...props
+}) => {
+  const params = paramsSelector(props);
+  const pageName = pageNameSelector(params);
+  const query = querySelector(props);
+  const page = pageFromQuerySelector(query);
+  const jobTitle = searchTextFromQuerySelector(query) || undefined;
+  const start = (page - 1) * PAGE_SIZE;
+  const limit = PAGE_SIZE;
+  return dispatch(
+    queryCompanyTimeAndSalary({
+      companyName: pageName,
+      jobTitle,
+      start,
+      limit,
+    }),
+  );
+};
+
+export default CompanyTimeAndSalaryProvider;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
@@ -1,13 +1,13 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
+import qs from 'qs';
 import ExperienceEntry from './ExperienceEntry';
 import EmptyView from '../EmptyView';
 
 import { Section } from 'common/base';
 import Pagination from 'common/Pagination';
 import useSearchbar from '../useSearchbar';
-
-const pageSize = 10;
+import { useQuery } from 'hooks/routing';
 
 const WorkExperiences = ({
   pageType,
@@ -15,14 +15,15 @@ const WorkExperiences = ({
   tabType,
   data,
   page,
+  pageSize,
+  totalCount,
   canView,
 }) => {
-  const { Searchbar, matchesFilter } = useSearchbar({
+  const queryParams = useQuery();
+  const { Searchbar } = useSearchbar({
     pageType,
     tabType,
   });
-
-  data = useMemo(() => data.filter(matchesFilter), [data, matchesFilter]);
 
   if (data.length === 0) {
     return (
@@ -32,11 +33,10 @@ const WorkExperiences = ({
       </Section>
     );
   }
-  const visibleData = data.slice((page - 1) * pageSize, page * pageSize);
   return (
     <Section Tag="main" paddingBottom>
       <Searchbar />
-      {visibleData.map(d => (
+      {data.map(d => (
         <ExperienceEntry
           key={d.id}
           pageType={pageType}
@@ -45,10 +45,12 @@ const WorkExperiences = ({
         />
       ))}
       <Pagination
-        totalCount={data.length}
+        totalCount={totalCount}
         unit={pageSize}
         currentPage={page}
-        createPageLinkTo={page => `?p=${page}`}
+        createPageLinkTo={p =>
+          qs.stringify({ ...queryParams, p }, { addQueryPrefix: true })
+        }
       />
     </Section>
   );
@@ -59,8 +61,10 @@ WorkExperiences.propTypes = {
   data: PropTypes.arrayOf(PropTypes.object),
   page: PropTypes.number.isRequired,
   pageName: PropTypes.string.isRequired,
+  pageSize: PropTypes.number.isRequired,
   pageType: PropTypes.string.isRequired,
   tabType: PropTypes.string.isRequired,
+  totalCount: PropTypes.number.isRequired,
 };
 
 export default WorkExperiences;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/index.js
@@ -12,6 +12,8 @@ const WorkExperiences = ({
   workExperiences,
   status,
   page,
+  pageSize,
+  totalCount,
   canView,
 }) => (
   <CompanyAndJobTitleWrapper
@@ -32,6 +34,8 @@ const WorkExperiences = ({
         tabType={tabType}
         data={workExperiences}
         page={page}
+        pageSize={pageSize}
+        totalCount={totalCount}
         canView={canView}
       />
     </StatusRenderer>
@@ -42,9 +46,11 @@ WorkExperiences.propTypes = {
   canView: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
   pageName: PropTypes.string.isRequired,
+  pageSize: PropTypes.number.isRequired,
   pageType: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
   tabType: PropTypes.string.isRequired,
+  totalCount: PropTypes.number.isRequired,
   workExperiences: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/src/components/JobTitle/JobTitlePageProvider.js
+++ b/src/components/JobTitle/JobTitlePageProvider.js
@@ -3,21 +3,16 @@ import { useSelector, useDispatch } from 'react-redux';
 import { generatePath } from 'react-router';
 import { Switch, Route } from 'react-router-dom';
 import InterviewExperiences from '../CompanyAndJobTitle/InterviewExperiences';
-import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import NotFound from 'common/NotFound';
 import Redirect from 'common/routing/Redirect';
 import { paramsSelector } from 'common/routing/selectors';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import {
-  jobTitleInterviewExperiencesPath,
-  jobTitleWorkExperiencesPath,
-} from 'constants/linkTo';
+import { jobTitleInterviewExperiencesPath } from 'constants/linkTo';
 import { fetchJobTitle } from 'actions/jobTitle';
 import {
   interviewExperiences as interviewExperiencesSelector,
-  workExperiences as workExperiencesSelector,
   status as statusSelector,
   jobTitle as jobTitleSelector,
 } from 'selectors/companyAndJobTitle';
@@ -44,14 +39,11 @@ const JobTitlePageProvider = () => {
       return {
         status: statusSelector(jobTitle),
         interviewExperiences: interviewExperiencesSelector(jobTitle),
-        workExperiences: workExperiencesSelector(jobTitle),
       };
     },
     [pageName],
   );
-  const { status, interviewExperiences, workExperiences } = useSelector(
-    selector,
-  );
+  const { status, interviewExperiences } = useSelector(selector);
 
   return (
     <Switch>
@@ -77,21 +69,6 @@ const JobTitlePageProvider = () => {
             tabType={tabType.INTERVIEW_EXPERIENCE}
             status={status}
             interviewExperiences={interviewExperiences}
-          />
-        )}
-      />
-      <Route
-        path={jobTitleWorkExperiencesPath}
-        exact
-        render={() => (
-          <WorkExperiences
-            pageType={pageType}
-            pageName={pageName}
-            page={page}
-            canView={canView}
-            tabType={tabType.WORK_EXPERIENCE}
-            status={status}
-            workExperiences={workExperiences}
           />
         )}
       />

--- a/src/components/JobTitle/JobTitleWorkExperiencesProvider.js
+++ b/src/components/JobTitle/JobTitleWorkExperiencesProvider.js
@@ -4,15 +4,12 @@ import WorkExperiences from '../CompanyAndJobTitle/WorkExperiences';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import {
-  queryCompanyTimeAndSalary,
-  queryCompanyWorkExperiences,
-} from 'actions/company';
+import { queryJobTitleWorkExperiences } from 'actions/jobTitle';
 import {
   workExperiences as workExperiencesSelector,
   workExperiencesCount as workExperiencesCountSelector,
   status as statusSelector,
-  companyWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorByName,
+  jobTitleWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import { usePageName, pageNameSelector } from './usePageName';
@@ -25,11 +22,11 @@ import {
 const useWorkExperiencesBox = pageName => {
   const selector = useCallback(
     state => {
-      const company = workExperiencesBoxSelectorByName(pageName)(state);
+      const jobTitle = workExperiencesBoxSelectorByName(pageName)(state);
       return {
-        status: statusSelector(company),
-        workExperiences: workExperiencesSelector(company),
-        workExperiencesCount: workExperiencesCountSelector(company),
+        status: statusSelector(jobTitle),
+        workExperiences: workExperiencesSelector(jobTitle),
+        workExperiencesCount: workExperiencesCountSelector(jobTitle),
       };
     },
     [pageName],
@@ -40,25 +37,25 @@ const useWorkExperiencesBox = pageName => {
 
 const PAGE_SIZE = 10;
 
-const CompanyWorkExperiencesProvider = () => {
+const JobTitleWorkExperiencesProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.COMPANY;
+  const pageType = PAGE_TYPE.JOB_TITLE;
   const pageName = usePageName();
-  const [jobTitle] = useSearchTextFromQuery();
+  const [companyName] = useSearchTextFromQuery();
   const page = usePage();
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
 
   useEffect(() => {
     dispatch(
-      queryCompanyWorkExperiences({
-        companyName: pageName,
-        jobTitle: jobTitle || undefined,
+      queryJobTitleWorkExperiences({
+        jobTitle: pageName,
+        companyName: companyName || undefined,
         start,
         limit,
       }),
     );
-  }, [dispatch, pageName, jobTitle, start, limit]);
+  }, [dispatch, pageName, companyName, start, limit]);
 
   const [, fetchPermission, canView] = usePermission();
   useEffect(() => {
@@ -86,7 +83,7 @@ const CompanyWorkExperiencesProvider = () => {
   );
 };
 
-CompanyWorkExperiencesProvider.fetchData = ({
+JobTitleWorkExperiencesProvider.fetchData = ({
   store: { dispatch },
   ...props
 }) => {
@@ -94,17 +91,17 @@ CompanyWorkExperiencesProvider.fetchData = ({
   const pageName = pageNameSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const jobTitle = searchTextFromQuerySelector(query) || undefined;
+  const companyName = searchTextFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return dispatch(
-    queryCompanyTimeAndSalary({
-      companyName: pageName,
-      jobTitle,
+    queryJobTitleWorkExperiences({
+      jobTitle: pageName,
+      companyName,
       start,
       limit,
     }),
   );
 };
 
-export default CompanyWorkExperiencesProvider;
+export default JobTitleWorkExperiencesProvider;

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -194,6 +194,45 @@ export const getCompanyTimeAndSalaryQuery = /* GraphQL */ `
   }
 `;
 
+export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
+  query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
+    company(name: $companyName) {
+      name
+      workExperiencesResult(jobTitle: $jobTitle, start: $start, limit: $limit) {
+        count
+        workExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          recommend_to_others
+          averageSectionRating
+        }
+      }
+    }
+  }
+`;
+
 export const queryCompaniesHavingDataGql = /* GraphQL */ `
   query($start: Int!, $limit: Int!) {
     companiesHavingData(start: $start, limit: $limit) {

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -207,6 +207,48 @@ export const getJobTitleTimeAndSalaryQuery = /* GraphQL */ `
   }
 `;
 
+export const getJobTitleWorkExperiencesQuery = /* GraphQL */ `
+  query($jobTitle: String!, $companyName: String, $start: Int!, $limit: Int!) {
+    job_title(name: $jobTitle) {
+      name
+      workExperiencesResult(
+        companyQuery: $companyName
+        start: $start
+        limit: $limit
+      ) {
+        count
+        workExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          recommend_to_others
+        }
+      }
+    }
+  }
+`;
+
 export const queryJobTitlesHavingDataGql = /* GraphQL */ `
   query($start: Int!, $limit: Int!) {
     jobTitlesHavingData(start: $start, limit: $limit) {

--- a/src/reducers/companyIndex.js
+++ b/src/reducers/companyIndex.js
@@ -5,6 +5,7 @@ import {
   SET_INDEX,
   SET_OVERVIEW,
   SET_TIME_AND_SALARY,
+  SET_WORK_EXPERIENCES,
 } from 'actions/company';
 
 const preloadedState = {
@@ -14,6 +15,7 @@ const preloadedState = {
   // companyName --> overviewBox
   overviewByName: {},
   timeAndSalaryByName: {},
+  workExperiencesByName: {},
 };
 
 const reducer = createReducer(preloadedState, {
@@ -44,6 +46,15 @@ const reducer = createReducer(preloadedState, {
       ...state,
       timeAndSalaryByName: {
         ...state.timeAndSalaryByName,
+        [companyName]: box,
+      },
+    };
+  },
+  [SET_WORK_EXPERIENCES]: (state, { companyName, box }) => {
+    return {
+      ...state,
+      workExperiencesByName: {
+        ...state.workExperiencesByName,
         [companyName]: box,
       },
     };

--- a/src/reducers/jobTitleIndex.js
+++ b/src/reducers/jobTitleIndex.js
@@ -5,6 +5,7 @@ import {
   SET_INDEX,
   SET_OVERVIEW,
   SET_TIME_AND_SALARY,
+  SET_WORK_EXPERIENCES,
 } from 'actions/jobTitle';
 
 const preloadedState = {
@@ -14,6 +15,7 @@ const preloadedState = {
   // jobTitle --> overviewBox
   overviewByName: {},
   timeAndSalaryByName: {},
+  workExperiencesByName: {},
 };
 
 const reducer = createReducer(preloadedState, {
@@ -44,6 +46,15 @@ const reducer = createReducer(preloadedState, {
       ...state,
       timeAndSalaryByName: {
         ...state.timeAndSalaryByName,
+        [jobTitle]: box,
+      },
+    };
+  },
+  [SET_WORK_EXPERIENCES]: (state, { jobTitle, box }) => {
+    return {
+      ...state,
+      workExperiencesByName: {
+        ...state.workExperiencesByName,
         [jobTitle]: box,
       },
     };

--- a/src/routes.js
+++ b/src/routes.js
@@ -30,6 +30,7 @@ import JobTitlePageProvider from './components/JobTitle/JobTitlePageProvider';
 import JobTitleIndexProvider from './components/JobTitle/JobTitleIndexProvider';
 import JobTitleOverviewProvider from 'components/JobTitle/JobTitleOverviewProvider';
 import JobTitleTimeAndSalaryProvider from 'components/JobTitle/JobTitleTimeAndSalaryProvider';
+import JobTitleWorkExperiencesProvider from 'components/JobTitle/JobTitleWorkExperiencesProvider';
 
 import PlanPage from './components/PlanPage';
 import BuyResultPage from './components/BuyResultPage';
@@ -38,6 +39,7 @@ import SubscriptionsPage from './components/Me/SubscriptionsPage';
 import {
   jobTitleOverviewPath,
   jobTitleSalaryWorkTimesPath,
+  jobTitleWorkExperiencesPath,
   companyOverviewPath,
   companySalaryWorkTimesPath,
   companyWorkExperiencesPath,
@@ -159,6 +161,11 @@ const routes = [
       {
         path: jobTitleSalaryWorkTimesPath,
         component: JobTitleTimeAndSalaryProvider,
+        exact: true,
+      },
+      {
+        path: jobTitleWorkExperiencesPath,
+        component: JobTitleWorkExperiencesProvider,
         exact: true,
       },
       {

--- a/src/routes.js
+++ b/src/routes.js
@@ -25,6 +25,7 @@ import CompanyPageProvider from './components/Company/CompanyPageProvider';
 import CompanyIndexProvider from './components/Company/CompanyIndexProvider';
 import CompanyOverviewProvider from 'components/Company/CompanyOverviewProvider';
 import CompanyTimeAndSalaryProvider from 'components/Company/CompanyTimeAndSalaryProvider';
+import CompanyWorkExperiencesProvider from 'components/Company/CompanyWorkExperiencesProvider';
 import JobTitlePageProvider from './components/JobTitle/JobTitlePageProvider';
 import JobTitleIndexProvider from './components/JobTitle/JobTitleIndexProvider';
 import JobTitleOverviewProvider from 'components/JobTitle/JobTitleOverviewProvider';
@@ -39,6 +40,7 @@ import {
   jobTitleSalaryWorkTimesPath,
   companyOverviewPath,
   companySalaryWorkTimesPath,
+  companyWorkExperiencesPath,
 } from 'constants/linkTo';
 
 const routes = [
@@ -124,6 +126,11 @@ const routes = [
       {
         path: companySalaryWorkTimesPath,
         component: CompanyTimeAndSalaryProvider,
+        exact: true,
+      },
+      {
+        path: companyWorkExperiencesPath,
+        component: CompanyWorkExperiencesProvider,
         exact: true,
       },
       {

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -25,6 +25,12 @@ export const workExperiences = R.pipe(
   R.defaultTo([]),
 );
 
+export const workExperiencesCount = R.pipe(
+  data,
+  R.when(R.is(Object), R.prop('work_experiences_count')),
+  R.defaultTo(0),
+);
+
 export const salaryWorkTimes = R.pipe(
   data,
   R.when(R.is(Object), R.prop('salary_work_times')),
@@ -109,6 +115,12 @@ export const companyOverviewBoxSelectorByName = companyName => state => {
 
 export const companyTimeAndSalaryBoxSelectorByName = companyName => state => {
   return state.companyIndex.timeAndSalaryByName[companyName] || getUnfetched();
+};
+
+export const companyWorkExperiencesBoxSelectorByName = companyName => state => {
+  return (
+    state.companyIndex.workExperiencesByName[companyName] || getUnfetched()
+  );
 };
 
 export const jobTitleIndexesBoxSelectorAtPage = page => state => {

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -139,3 +139,7 @@ export const jobTitleOverviewBoxSelectorByName = jobTitle => state => {
 export const jobTitleTimeAndSalaryBoxSelectorByName = jobTitle => state => {
   return state.jobTitleIndex.timeAndSalaryByName[jobTitle] || getUnfetched();
 };
+
+export const jobTitleWorkExperiencesBoxSelectorByName = jobTitle => state => {
+  return state.jobTitleIndex.workExperiencesByName[jobTitle] || getUnfetched();
+};


### PR DESCRIPTION
#1385 

## 這個 PR 是？ <!-- 必填 -->

讓公司/職稱頁面的面試經驗標籤頁做分頁，包含搜尋。

### 技術細節

原本公司頁面的資料都放在 `state.company.[name].status|data|error`，資料包含薪資、面試、經驗。

由於薪資會獨立獲取，現將薪資移至 `state.companyIndex.workExperiencesByName.[name].status|data|error`。

### TODO

搜尋時，應該只有底下的 table 會 loading，但目前會連 search bar 一起 reload，影響使用者體驗。

本 PR 先專注在抽換 API，後續 UI 優化會由 #1416 處理。

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

https://github.com/goodjoblife/WorkTimeSurvey-backend/pull/1043

## Screenshots  <!-- 選填，沒有就刪掉 -->




https://github.com/user-attachments/assets/975138b2-d87f-46f1-ad88-f77bc5641a0a





## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/job-titles/%E5%B7%A5%E8%AE%80%E7%94%9F/work-experiences