### PR TITLE
[公司職稱頁面] Overview use pagination api

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -15,7 +15,7 @@ import {
 } from 'selectors/companyAndJobTitle';
 import {
   getCompany as getCompanyApi,
-  queryCompanyOverviewApi,
+  queryCompanyOverview as queryCompanyOverviewApi,
   getCompanyTimeAndSalary,
   queryCompaniesApi,
 } from 'apis/company';

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -15,6 +15,7 @@ import {
 } from 'selectors/companyAndJobTitle';
 import {
   getCompany as getCompanyApi,
+  queryCompanyOverviewApi,
   getCompanyTimeAndSalary,
   queryCompaniesApi,
 } from 'apis/company';
@@ -115,8 +116,12 @@ export const queryCompanyOverview = companyName => async (
   dispatch(setOverview(companyName, toFetching()));
 
   try {
-    // TODO: rewrite to use api with pagination
-    const data = await getCompanyApi(companyName);
+    const data = await queryCompanyOverviewApi({
+      companyName,
+      interviewExperiencesLimit: INTERVIEW_EXPERIENCES_LIMIT,
+      workExperiencesLimit: WORK_EXPERIENCES_LIMIT,
+      salaryWorkTimesLimit: SALARY_WORK_TIMES_LIMIT,
+    });
 
     // Not found case
     if (data == null) {
@@ -125,16 +130,14 @@ export const queryCompanyOverview = companyName => async (
 
     const overviewData = {
       name: data.name,
-      salaryWorkTimes: data.salary_work_times.slice(0, SALARY_WORK_TIMES_LIMIT),
-      salaryWorkTimesCount: data.salary_work_times.length,
+      salaryWorkTimes: data.salaryWorkTimesResult.salaryWorkTimes,
+      salaryWorkTimesCount: data.salaryWorkTimesResult.count,
       salary_work_time_statistics: data.salary_work_time_statistics,
-      interviewExperiences: data.interview_experiences.slice(
-        0,
-        INTERVIEW_EXPERIENCES_LIMIT,
-      ),
-      interviewExperiencesCount: data.interview_experiences.length,
-      workExperiences: data.work_experiences.slice(0, WORK_EXPERIENCES_LIMIT),
-      workExperiencesCount: data.work_experiences.length,
+      interviewExperiences:
+        data.interviewExperiencesResult.interviewExperiences,
+      interviewExperiencesCount: data.interviewExperiencesResult.count,
+      workExperiences: data.workExperiencesResult.workExperiences,
+      workExperiencesCount: data.workExperiencesResult.count,
     };
 
     dispatch(setOverview(companyName, getFetched(overviewData)));

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -15,6 +15,7 @@ import {
 } from 'selectors/companyAndJobTitle';
 import {
   getJobTitle as getJobTitleApi,
+  queryJobTitleOverviewApi,
   getJobTitleTimeAndSalary,
   queryJobTitlesApi,
 } from 'apis/jobTitle';
@@ -112,8 +113,12 @@ export const queryJobTitleOverview = jobTitle => async (dispatch, getState) => {
   dispatch(setOverview(jobTitle, toFetching()));
 
   try {
-    // TODO: rewrite to use api with pagination
-    const data = await getJobTitleApi(jobTitle);
+    const data = await queryJobTitleOverviewApi({
+      jobTitle,
+      interviewExperiencesLimit: INTERVIEW_EXPERIENCES_LIMIT,
+      workExperiencesLimit: WORK_EXPERIENCES_LIMIT,
+      salaryWorkTimesLimit: SALARY_WORK_TIMES_LIMIT,
+    });
 
     // Not found case
     if (data == null) {
@@ -122,17 +127,15 @@ export const queryJobTitleOverview = jobTitle => async (dispatch, getState) => {
 
     const overviewData = {
       name: data.name,
-      salaryWorkTimes: data.salary_work_times.slice(0, SALARY_WORK_TIMES_LIMIT),
-      salaryWorkTimesCount: data.salary_work_times.length,
+      salaryWorkTimes: data.salaryWorkTimesResult.salaryWorkTimes,
+      salaryWorkTimesCount: data.salaryWorkTimesResult.count,
       salary_distribution: data.salary_distribution,
       salary_work_time_statistics: data.salary_work_time_statistics,
-      interviewExperiences: data.interview_experiences.slice(
-        0,
-        INTERVIEW_EXPERIENCES_LIMIT,
-      ),
-      interviewExperiencesCount: data.interview_experiences.length,
-      workExperiences: data.work_experiences.slice(0, WORK_EXPERIENCES_LIMIT),
-      workExperiencesCount: data.work_experiences.length,
+      interviewExperiences:
+        data.interviewExperiencesResult.interviewExperiences,
+      interviewExperiencesCount: data.interviewExperiencesResult.count,
+      workExperiences: data.workExperiencesResult.workExperiences,
+      workExperiencesCount: data.workExperiencesResult.count,
     };
 
     dispatch(setOverview(jobTitle, getFetched(overviewData)));

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -15,7 +15,7 @@ import {
 } from 'selectors/companyAndJobTitle';
 import {
   getJobTitle as getJobTitleApi,
-  queryJobTitleOverviewApi,
+  queryJobTitleOverview as queryJobTitleOverviewApi,
   getJobTitleTimeAndSalary,
   queryJobTitlesApi,
 } from 'apis/jobTitle';

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -2,14 +2,32 @@ import R from 'ramda';
 import graphqlClient from 'utils/graphqlClient';
 import {
   getCompanyQuery,
+  queryCompanyOverviewGql,
   getCompanyTimeAndSalaryQuery,
   queryCompaniesHavingDataGql,
 } from 'graphql/company';
 
+// TODO: DEPRECATED
 export const getCompany = companyName =>
   graphqlClient({
     query: getCompanyQuery,
     variables: { companyName },
+  }).then(R.prop('company'));
+
+export const queryCompanyOverviewApi = ({
+  companyName,
+  interviewExperiencesLimit,
+  workExperiencesLimit,
+  salaryWorkTimesLimit,
+}) =>
+  graphqlClient({
+    query: queryCompanyOverviewGql,
+    variables: {
+      companyName,
+      interviewExperiencesLimit,
+      workExperiencesLimit,
+      salaryWorkTimesLimit,
+    },
   }).then(R.prop('company'));
 
 export const getCompanyTimeAndSalary = ({

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -14,7 +14,7 @@ export const getCompany = companyName =>
     variables: { companyName },
   }).then(R.prop('company'));
 
-export const queryCompanyOverviewApi = ({
+export const queryCompanyOverview = ({
   companyName,
   interviewExperiencesLimit,
   workExperiencesLimit,

--- a/src/apis/jobTitle.js
+++ b/src/apis/jobTitle.js
@@ -2,14 +2,32 @@ import R from 'ramda';
 import graphqlClient from 'utils/graphqlClient';
 import {
   getJobTitleQuery,
+  queryJobTitleOverviewGql,
   getJobTitleTimeAndSalaryQuery,
   queryJobTitlesHavingDataGql,
 } from 'graphql/jobTitle';
 
+// TODO: DEPRECATED
 export const getJobTitle = jobTitle =>
   graphqlClient({
     query: getJobTitleQuery,
     variables: { jobTitle },
+  }).then(R.prop('job_title'));
+
+export const queryJobTitleOverviewApi = ({
+  jobTitle,
+  interviewExperiencesLimit,
+  workExperiencesLimit,
+  salaryWorkTimesLimit,
+}) =>
+  graphqlClient({
+    query: queryJobTitleOverviewGql,
+    variables: {
+      jobTitle,
+      interviewExperiencesLimit,
+      workExperiencesLimit,
+      salaryWorkTimesLimit,
+    },
   }).then(R.prop('job_title'));
 
 export const getJobTitleTimeAndSalary = ({

--- a/src/apis/jobTitle.js
+++ b/src/apis/jobTitle.js
@@ -14,7 +14,7 @@ export const getJobTitle = jobTitle =>
     variables: { jobTitle },
   }).then(R.prop('job_title'));
 
-export const queryJobTitleOverviewApi = ({
+export const queryJobTitleOverview = ({
   jobTitle,
   interviewExperiencesLimit,
   workExperiencesLimit,

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -1,3 +1,4 @@
+// TODO: DEPRECATED
 export const getCompanyQuery = /* GraphQL */ `
   query($companyName: String!) {
     company(name: $companyName) {
@@ -79,6 +80,143 @@ export const getCompanyQuery = /* GraphQL */ `
         data_time {
           month
           year
+        }
+      }
+      salary_work_time_statistics {
+        count
+        average_estimated_hourly_wage
+        average_week_work_time
+        overtime_frequency_count {
+          seldom
+          sometimes
+          usually
+          almost_everyday
+        }
+        is_overtime_salary_legal_count {
+          yes
+          no
+          unknown
+        }
+        has_compensatory_dayoff_count {
+          yes
+          no
+          unknown
+        }
+        has_overtime_salary_count {
+          yes
+          no
+          unknown
+        }
+        job_average_salaries {
+          job_title {
+            name
+          }
+          average_salary {
+            type
+            amount
+          }
+          data_count
+        }
+      }
+    }
+  }
+`;
+
+export const queryCompanyOverviewGql = /* GraphQL */ `
+  query(
+    $companyName: String!
+    $interviewExperiencesLimit: Int!
+    $workExperiencesLimit: Int!
+    $salaryWorkTimesLimit: Int!
+  ) {
+    company(name: $companyName) {
+      name
+      interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
+        count
+        interviewExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          overall_rating
+        }
+      }
+      workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
+        count
+        workExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          recommend_to_others
+        }
+      }
+      salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {
+        count
+        salaryWorkTimes {
+          id
+          week_work_time
+          salary {
+            type
+            amount
+          }
+          sector
+          day_real_work_time
+          day_promised_work_time
+          experience_in_year
+          estimated_hourly_wage
+          overtime_frequency
+          employment_type
+          job_title {
+            name
+          }
+          company {
+            name
+          }
+          data_time {
+            month
+            year
+          }
         }
       }
       salary_work_time_statistics {

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -6,6 +6,7 @@ export const queryJobTitles = /* GraphQL */ `
   }
 `;
 
+// TODO: DEPRECATED
 export const getJobTitleQuery = /* GraphQL */ `
   query($jobTitle: String!) {
     job_title(name: $jobTitle) {
@@ -88,6 +89,144 @@ export const getJobTitleQuery = /* GraphQL */ `
         data_time {
           month
           year
+        }
+      }
+      salary_work_time_statistics {
+        count
+        average_estimated_hourly_wage
+        average_week_work_time
+        overtime_frequency_count {
+          seldom
+          sometimes
+          usually
+          almost_everyday
+        }
+        is_overtime_salary_legal_count {
+          yes
+          no
+          unknown
+        }
+        has_compensatory_dayoff_count {
+          yes
+          no
+          unknown
+        }
+        has_overtime_salary_count {
+          yes
+          no
+          unknown
+        }
+      }
+      salary_distribution {
+        bins {
+          data_count
+          range {
+            type
+            from
+            to
+          }
+        }
+      }
+    }
+  }
+`;
+
+export const queryJobTitleOverviewGql = /* GraphQL */ `
+  query(
+    $jobTitle: String!
+    $interviewExperiencesLimit: Int!
+    $workExperiencesLimit: Int!
+    $salaryWorkTimesLimit: Int!
+  ) {
+    job_title(name: $jobTitle) {
+      name
+      interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
+        count
+        interviewExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          overall_rating
+        }
+      }
+      workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
+        count
+        workExperiences {
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          recommend_to_others
+        }
+      }
+      salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {
+        count
+        salaryWorkTimes {
+          id
+          week_work_time
+          salary {
+            type
+            amount
+          }
+          sector
+          day_real_work_time
+          day_promised_work_time
+          experience_in_year
+          estimated_hourly_wage
+          overtime_frequency
+          employment_type
+          job_title {
+            name
+          }
+          company {
+            name
+          }
+          originalCompanyName
+          data_time {
+            month
+            year
+          }
         }
       }
       salary_work_time_statistics {


### PR DESCRIPTION
related to #1385

## 這個 PR 是？ <!-- 必填 -->

Overview 頁面更換成 pagination api

## Screenshots  <!-- 選填，沒有就刪掉 -->

<img width="897" alt="image" src="https://github.com/user-attachments/assets/2dd70459-7ac1-41a8-9202-d1b4778d53ad">

api 正確

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進入職稱頁面後，點選任一個職稱，可以看到如截圖的 graphql request
- [ ] 進入公司頁面後，點選任一個公司
- [ ] 嘗試將上述 SSR (沒有任何改變，正常運作)