### PR TITLE
feat: send error to rollbar when submit work experience form failed

### DIFF
--- a/src/components/ShareExperience/WorkExperiencesForm/TypeForm.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/TypeForm.js
@@ -37,8 +37,10 @@ import { tabType } from '../../../constants/companyJobTitle';
 import { createWorkExperienceWithRating } from 'actions/experiences';
 import { transferKeyToSnakecase } from 'utils/objectUtil';
 import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
+import { ERROR_CODE_MSG } from 'constants/errorCodeMsg';
 
 import { sendEvent } from 'utils/hotjarUtil';
+import rollbar from 'utils/rollbar';
 
 const header = <Header title="分享你的工作心得(評價)" />;
 
@@ -137,6 +139,11 @@ const TypeForm = ({ open, onClose, hideProgressBar = false }) => {
       category: GA_CATEGORY.SHARE_WORK,
       action: GA_ACTION.UPLOAD_FAIL,
     });
+    const errorCode = 'ER0020';
+    rollbar.error(
+      `[${errorCode}] ${ERROR_CODE_MSG[errorCode].internal} ${error.message}`,
+      error,
+    );
   }, []);
 
   return (

--- a/src/constants/errorCodeMsg.js
+++ b/src/constants/errorCodeMsg.js
@@ -78,4 +78,7 @@ export const ERROR_CODE_MSG = {
   ER0019: {
     internal: 'Not submittable',
   },
+  ER0020: {
+    internal: 'Submit work experience failed',
+  },
 };


### PR DESCRIPTION
Close #1428 

## 這個 PR 是？ <!-- 必填 -->

1. 送出評價表單時如果有錯誤，送 error 到 rollbar 
2. 原本以為要加 hotjar trigger event ，但其實原本的實作就已經有，因此不用更動

## Screenshots  <!-- 選填，沒有就刪掉 -->

故意 throw 一個 error 可以看到打 rollbar API
![Screenshot 2024-09-01 at 10 53 48 AM](https://github.com/user-attachments/assets/9f8acf1d-7607-4d55-bd71-b8235cd4d5c9)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 在 submit 評價表單時，故意 trigger 一個錯誤，看 network tab 是否有送 request
