### PR TITLE
[公司職稱頁面] Onblur搜尋

### DIFF
--- a/src/components/CompanyAndJobTitle/Searchbar.js
+++ b/src/components/CompanyAndJobTitle/Searchbar.js
@@ -9,7 +9,6 @@ import { useQuery } from 'hooks/routing';
 import TextInput from 'common/form/TextInput';
 import Magnifiner from 'common/icons/Magnifiner';
 import styles from './Searchbar.module.css';
-import { useDebounce } from 'react-use';
 
 import {
   pageType as pageTypes,
@@ -42,31 +41,27 @@ const Searchbar = ({ className, label, placeholder, onSubmit, pageType }) => {
   const [searchText, setSearchText] = useState(searchTextFromQuery);
   const ref = useRef(null);
 
-  useDebounce(
-    () => {
-      onSubmit(searchText);
-      switch (pageType) {
-        case pageTypes.COMPANY:
-          ReactGA.event({
-            category: GA_CATEGORY.COMPANY_PAGE,
-            action: GA_ACTION.SEARCH_JOB_TITLE,
-            label: searchText,
-          });
-          break;
-        case pageTypes.JOB_TITLE:
-          ReactGA.event({
-            category: GA_CATEGORY.JOB_TITLE_PAGE,
-            action: GA_ACTION.SEARCH_COMPANY,
-            label: searchText,
-          });
-          break;
-        default:
-          break;
-      }
-    },
-    1500,
-    [searchText],
-  );
+  const onBlur = useCallback(() => {
+    onSubmit(searchText);
+    switch (pageType) {
+      case pageTypes.COMPANY:
+        ReactGA.event({
+          category: GA_CATEGORY.COMPANY_PAGE,
+          action: GA_ACTION.SEARCH_JOB_TITLE,
+          label: searchText,
+        });
+        break;
+      case pageTypes.JOB_TITLE:
+        ReactGA.event({
+          category: GA_CATEGORY.JOB_TITLE_PAGE,
+          action: GA_ACTION.SEARCH_COMPANY,
+          label: searchText,
+        });
+        break;
+      default:
+        break;
+    }
+  }, [searchText, onSubmit, pageType]);
 
   const handleFormSubmit = useCallback(
     e => {
@@ -89,6 +84,7 @@ const Searchbar = ({ className, label, placeholder, onSubmit, pageType }) => {
         placeholder={placeholder}
         value={searchText}
         onChange={e => setSearchText(e.target.value)}
+        onBlur={onBlur}
       />
       <button type="submit" className={styles.searchBtn}>
         <Magnifiner />


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

原本用 debounce 秒數搜尋
由於現在改用 API 搜尋，搜尋成本變高，切換頁面也影響使用者體驗
於是改用 onBlur 這類更明確的使用者 intention 來觸發搜尋

## Screenshots  <!-- 選填，沒有就刪掉 -->


https://github.com/user-attachments/assets/f8e81391-3db7-4149-8e2b-243f327ab560


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/companies/麥當勞飲食店/work-experiences 搜尋並 blur