### PR TITLE
feat: add averageSectionRating queryQL query 

### DIFF
--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -73,6 +73,7 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
           reply_count
           like_count
           recommend_to_others
+          averageSectionRating
         }
       }
       salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {
@@ -272,6 +273,7 @@ export const getJobTitleWorkExperiencesQuery = /* GraphQL */ `
           reply_count
           like_count
           recommend_to_others
+          averageSectionRating
         }
       }
     }


### PR DESCRIPTION
Close #1431  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->
1. add averageSectionRating queryQL query to make jobtitle card showing OverallRating。職稱總覽頁面、職稱評價頁面同時顯示新舊版卡片。

<!-- 請簡單說明這個 PR 做了什麼 -->

## Screenshots  <!-- 選填，沒有就刪掉 -->
![image](https://github.com/user-attachments/assets/c86cb5b9-9945-429d-882d-0d0d648d4d07)

![image](https://github.com/user-attachments/assets/a18a3c53-d783-44e0-a98c-111f89a407f9)

## 我應該如何手動測試？ <!-- 必填 -->
起 local 可看到職稱總覽頁面、職稱評價頁面同時顯示新舊版卡片。