### PR TITLE
fix: shorten the upper and lower spacing between the title and thumbs…

### DIFF
--- a/src/components/ExperienceDetail/Article/SectionBlock.module.css
+++ b/src/components/ExperienceDetail/Article/SectionBlock.module.css
@@ -15,5 +15,6 @@
 @media (max-width: below-mobile) {
   .heading {
     flex-direction: column;
+    gap: 0.5rem;
   }
 }


### PR DESCRIPTION
Close #1432   <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->
Shorten the upper and lower spacing between the title and thumbs on mobile screen width

## Screenshots  <!-- 選填，沒有就刪掉 -->
修正後：
![image](https://github.com/user-attachments/assets/ce44a77d-e01e-464e-b77d-eb271761fe09)

## 我應該如何手動測試？ <!-- 必填 -->
檢查小螢幕寬度時，標題與讚的上下間距不會過高。