### PR TITLE
search query變動時不改變捲軸位置

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { hydrate } from 'react-dom';
 import { createBrowserHistory as createHistory } from 'history';
 import R from 'ramda';
+import qs from 'qs';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router-dom';
 import { ScrollContext } from 'react-router-scroll-4';
@@ -12,7 +13,13 @@ import Root from './components/Root';
 import configureStore from './store/configureStore';
 
 function shouldUpdateScroll(prevProps, props) {
+  const mapSearch = ({ search, ...rest }) => {
+    let s = qs.parse(search, { ignoreQueryPrefix: true });
+    s = R.omit(['q'], s); // We don't reset scroll on search query change
+    return { search: s, ...rest };
+  };
   const getSignature = R.compose(
+    mapSearch,
     R.omit(['state', 'key']),
     R.path(['location']),
   );


### PR DESCRIPTION
Close #1439

## 這個 PR 是？ <!-- 必填 -->

原本，location有任何變化時，就會重設捲軸位置。

但搜尋經驗時產生的 `?q` 變化，並不適合重設捲軸位置。

本 PR 將 `?q` 作為例外。

## Screenshots  <!-- 選填，沒有就刪掉 -->


https://github.com/user-attachments/assets/c2168c09-a81e-45b7-970f-293abe0c68d2




## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/companies/A/interview-experiences 輸入搜尋字串，捲軸不應改變。換頁、跳其他頁面，維持重設捲軸。