### PR TITLE
[公司頁面] 加上平均分

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -13,6 +13,7 @@ import {
   companyTimeAndSalaryStatisticsBoxSelectorByName,
   companyInterviewExperiencesBoxSelectorByName,
   companyWorkExperiencesBoxSelectorByName,
+  companyRatingStatisticsBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import {
   queryCompanyOverview as queryCompanyOverviewApi,
@@ -21,8 +22,10 @@ import {
   getCompanyWorkExperiences,
   queryCompaniesApi,
   getCompanyTimeAndSalaryStatistics,
+  queryCompanyRatingStatisticsApi,
 } from 'apis/company';
 
+export const SET_RATING_STATISTICS = '@@COMPANY/SET_RATING_STATISTICS';
 export const SET_OVERVIEW = '@@COMPANY/SET_OVERVIEW';
 export const SET_TIME_AND_SALARY = '@@COMPANY/SET_TIME_AND_SALARY';
 export const SET_TIME_AND_SALARY_STATISTICS =
@@ -65,6 +68,39 @@ export const fetchCompanyNames = ({ page, pageSize }) => async (
   } catch (error) {
     if (isGraphqlError(error)) {
       return dispatch(setIndex(page, getError(error)));
+    }
+    throw error;
+  }
+};
+
+const setRatingStatistcs = (companyName, box) => ({
+  type: SET_RATING_STATISTICS,
+  companyName,
+  box,
+});
+
+export const queryRatingStatistcs = pageName => async (dispatch, getState) => {
+  const box = companyRatingStatisticsBoxSelectorByName(pageName)(getState());
+  if (isFetching(box) || isFetched(box)) {
+    return;
+  }
+
+  dispatch(setRatingStatistcs(pageName, toFetching()));
+
+  try {
+    const data = await queryCompanyRatingStatisticsApi({
+      companyName: pageName,
+    });
+
+    // Not found case
+    if (data == null) {
+      return dispatch(setRatingStatistcs(pageName, getFetched(data)));
+    }
+
+    dispatch(setRatingStatistcs(pageName, getFetched(data)));
+  } catch (error) {
+    if (isGraphqlError(error)) {
+      dispatch(setRatingStatistcs(pageName, getError(error)));
     }
     throw error;
   }

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -79,7 +79,7 @@ const setRatingStatistcs = (companyName, box) => ({
   box,
 });
 
-export const queryRatingStatistcs = pageName => async (dispatch, getState) => {
+export const queryRatingStatistics = pageName => async (dispatch, getState) => {
   const box = companyRatingStatisticsBoxSelectorByName(pageName)(getState());
   if (isFetching(box) || isFetched(box)) {
     return;

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -1,6 +1,7 @@
 import R from 'ramda';
 import graphqlClient from 'utils/graphqlClient';
 import {
+  queryCompanyRatingStatisticsGql,
   queryCompanyOverviewGql,
   getCompanyTimeAndSalaryQuery,
   getCompanyInterviewExperiencesQuery,
@@ -8,6 +9,12 @@ import {
   queryCompaniesHavingDataGql,
   getCompanyTimeAndSalaryStatisticsQuery,
 } from 'graphql/company';
+
+export const queryCompanyRatingStatisticsApi = ({ companyName }) =>
+  graphqlClient({
+    query: queryCompanyRatingStatisticsGql,
+    variables: { companyName },
+  }).then(R.path(['company', 'companyStatistics']));
 
 export const queryCompanyOverview = ({
   companyName,

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -14,7 +14,7 @@ export const queryCompanyRatingStatisticsApi = ({ companyName }) =>
   graphqlClient({
     query: queryCompanyRatingStatisticsGql,
     variables: { companyName },
-  }).then(R.path(['company', 'companyStatistics']));
+  }).then(R.path(['company', 'companyRatingStatistics']));
 
 export const queryCompanyOverview = ({
   companyName,

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { toPairs, compose, map } from 'ramda';
 
@@ -7,7 +7,6 @@ import Heading from 'common/base/Heading';
 import FanPageBlock from 'common/FanPageBlock';
 import BreadCrumb from 'common/BreadCrumb';
 
-import { queryRatingStatistics } from 'actions/company';
 import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import {
   tabTypeTranslation,
@@ -26,12 +25,6 @@ const AverageRating = ({ pageType, pageName }) => {
   const ratingStatistcsBox = useSelector(
     companyRatingStatisticsBoxSelectorByName(pageName),
   );
-  const dispatch = useDispatch();
-  useEffect(() => {
-    if (pageType === PAGE_TYPE.COMPANY) {
-      dispatch(queryRatingStatistics(pageName));
-    }
-  }, [dispatch, pageType, pageName]);
 
   if (pageType !== PAGE_TYPE.COMPANY || !isFetched(ratingStatistcsBox)) {
     return null;

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -9,7 +9,11 @@ import BreadCrumb from 'common/BreadCrumb';
 
 import { queryRatingStatistcs } from 'actions/company';
 import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
-import { tabTypeTranslation, generateTabURL } from 'constants/companyJobTitle';
+import {
+  tabTypeTranslation,
+  generateTabURL,
+  pageType as PAGE_TYPE,
+} from 'constants/companyJobTitle';
 import { isFetched } from 'utils/fetchBox';
 import { generateBreadCrumbData } from './utils';
 
@@ -17,14 +21,16 @@ import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
 import Glike from 'common/icons/Glike';
 
-const AverageRating = ({ pageName }) => {
+const AverageRating = ({ pageType, pageName }) => {
   const ratingStatistcsBox = useSelector(
     companyRatingStatisticsBoxSelectorByName(pageName),
   );
   const dispatch = useDispatch();
   useEffect(() => {
-    dispatch(queryRatingStatistcs(pageName));
-  }, [dispatch, pageName]);
+    if (pageType === PAGE_TYPE.COMPANY) {
+      dispatch(queryRatingStatistcs(pageName));
+    }
+  }, [dispatch, pageType, pageName]);
 
   if (!isFetched(ratingStatistcsBox)) {
     return null;
@@ -47,6 +53,7 @@ const AverageRating = ({ pageName }) => {
 
 AverageRating.propTypes = {
   pageName: PropTypes.string.isRequired,
+  pageType: PropTypes.string.isRequired,
 };
 
 const CompanyAndJobTitleWrapper = ({
@@ -80,7 +87,7 @@ const CompanyAndJobTitleWrapper = ({
       </div>
       <Heading style={{ color: '#000000', marginBottom: '30px' }}>
         {pageName}
-        <AverageRating pageName={pageName} />
+        <AverageRating pageType={pageType} pageName={pageName} />
       </Heading>
       <TabLinkGroup
         options={tabLinkOptions}

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -37,11 +37,11 @@ const AverageRating = ({ pageName }) => {
 
   const { averageRating, ratingCount } = data;
   return (
-    <>
+    <div className={styles.ratingStatistics}>
       <span className={styles.averageRating}>{averageRating}</span>
       <Glike className={styles.icon} />
       <span className={styles.ratingCount}>({ratingCount})</span>
-    </>
+    </div>
   );
 };
 
@@ -78,10 +78,7 @@ const CompanyAndJobTitleWrapper = ({
           data={generateBreadCrumbData({ pageType, pageName, tabType })}
         />
       </div>
-      <Heading
-        className={styles.heading}
-        style={{ color: '#000000', marginBottom: '30px' }}
-      >
+      <Heading style={{ color: '#000000', marginBottom: '30px' }}>
         {pageName}
         <AverageRating pageName={pageName} />
       </Heading>

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -1,4 +1,5 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { toPairs, compose, map } from 'ramda';
 
@@ -6,11 +7,47 @@ import Heading from 'common/base/Heading';
 import FanPageBlock from 'common/FanPageBlock';
 import BreadCrumb from 'common/BreadCrumb';
 
+import { queryRatingStatistcs } from 'actions/company';
+import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { tabTypeTranslation, generateTabURL } from 'constants/companyJobTitle';
+import { isFetched } from 'utils/fetchBox';
 import { generateBreadCrumbData } from './utils';
 
 import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
+import Glike from 'common/icons/Glike';
+
+const AverageRating = ({ pageName }) => {
+  const ratingStatistcsBox = useSelector(
+    companyRatingStatisticsBoxSelectorByName(pageName),
+  );
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(queryRatingStatistcs(pageName));
+  }, [dispatch, pageName]);
+
+  if (!isFetched(ratingStatistcsBox)) {
+    return null;
+  }
+
+  const data = ratingStatistcsBox.data;
+  if (!data) {
+    return null;
+  }
+
+  const { averageRating, ratingCount } = data;
+  return (
+    <>
+      <span className={styles.averageRating}>{averageRating}</span>
+      <Glike className={styles.icon} />
+      <span className={styles.ratingCount}>({ratingCount})</span>
+    </>
+  );
+};
+
+AverageRating.propTypes = {
+  pageName: PropTypes.string.isRequired,
+};
 
 const CompanyAndJobTitleWrapper = ({
   children,
@@ -41,8 +78,12 @@ const CompanyAndJobTitleWrapper = ({
           data={generateBreadCrumbData({ pageType, pageName, tabType })}
         />
       </div>
-      <Heading style={{ color: '#000000', marginBottom: '30px' }}>
+      <Heading
+        className={styles.heading}
+        style={{ color: '#000000', marginBottom: '30px' }}
+      >
         {pageName}
+        <AverageRating pageName={pageName} />
       </Heading>
       <TabLinkGroup
         options={tabLinkOptions}

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -20,6 +20,7 @@ import { generateBreadCrumbData } from './utils';
 import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
 import Glike from 'common/icons/Glike';
+import Seo from 'common/Seo/SeoStructure';
 
 const AverageRating = ({ pageType, pageName }) => {
   const ratingStatistcsBox = useSelector(
@@ -32,7 +33,7 @@ const AverageRating = ({ pageType, pageName }) => {
     }
   }, [dispatch, pageType, pageName]);
 
-  if (!isFetched(ratingStatistcsBox)) {
+  if (pageType !== PAGE_TYPE.COMPANY || !isFetched(ratingStatistcsBox)) {
     return null;
   }
 
@@ -44,6 +45,18 @@ const AverageRating = ({ pageType, pageName }) => {
   const { averageRating, ratingCount } = data;
   return (
     <div className={styles.ratingStatistics}>
+      <Seo
+        data={{
+          '@context': 'https://schema.org/',
+          '@type': 'EmployerAggregateRating',
+          itemReviewed: {
+            '@type': 'Organization',
+            name: pageName,
+          },
+          ratingValue: averageRating,
+          ratingCount: ratingCount,
+        }}
+      />
       <span className={styles.averageRating}>{averageRating.toFixed(1)}</span>
       <Glike className={styles.icon} />
       <span className={styles.ratingCount}>({ratingCount})</span>

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -7,7 +7,7 @@ import Heading from 'common/base/Heading';
 import FanPageBlock from 'common/FanPageBlock';
 import BreadCrumb from 'common/BreadCrumb';
 
-import { queryRatingStatistcs } from 'actions/company';
+import { queryRatingStatistics } from 'actions/company';
 import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import {
   tabTypeTranslation,
@@ -28,7 +28,7 @@ const AverageRating = ({ pageType, pageName }) => {
   const dispatch = useDispatch();
   useEffect(() => {
     if (pageType === PAGE_TYPE.COMPANY) {
-      dispatch(queryRatingStatistcs(pageName));
+      dispatch(queryRatingStatistics(pageName));
     }
   }, [dispatch, pageType, pageName]);
 

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -44,7 +44,7 @@ const AverageRating = ({ pageType, pageName }) => {
   const { averageRating, ratingCount } = data;
   return (
     <div className={styles.ratingStatistics}>
-      <span className={styles.averageRating}>{averageRating}</span>
+      <span className={styles.averageRating}>{averageRating.toFixed(1)}</span>
       <Glike className={styles.icon} />
       <span className={styles.ratingCount}>({ratingCount})</span>
     </div>

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
@@ -6,3 +6,21 @@
   margin-top: -30px;
   margin-bottom: 30px;
 }
+
+.heading {
+  .averageRating {
+    display: inline-block;
+    margin-left: 34px;
+    font-size: 17px;
+    font-weight: 500;
+  }
+
+  .icon {
+    width: 20px;
+    height: 20px;
+  }
+
+  .ratingCount {
+    font-size: 15px;
+  }
+}

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
@@ -1,3 +1,5 @@
+@value below-small, above-small from '../common/variables.module.css';
+
 .fanPageBlock {
   margin-bottom: 60px;
 }
@@ -7,10 +9,20 @@
   margin-bottom: 30px;
 }
 
-.heading {
-  .averageRating {
-    display: inline-block;
+.ratingStatistics {
+  align-items: center;
+
+  @media (max-width: below-small) {
+    display: flex;
+    margin-top: 16px;
+  }
+
+  @media (min-width: above-small) {
+    display: inline-flex;
     margin-left: 34px;
+  }
+
+  .averageRating {
     font-size: 17px;
     font-weight: 500;
   }

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -1,3 +1,19 @@
+export const queryCompanyRatingStatisticsGql = /* GraphQL */ `
+  query($companyName: String!) {
+    company(name: $companyName) {
+      name
+      companyStatistics {
+        averageRating
+        ratingDistribution {
+          rating
+          count
+        }
+        ratingCount
+      }
+    }
+  }
+`;
+
 export const queryCompanyOverviewGql = /* GraphQL */ `
   query(
     $companyName: String!

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -2,7 +2,7 @@ export const queryCompanyRatingStatisticsGql = /* GraphQL */ `
   query($companyName: String!) {
     company(name: $companyName) {
       name
-      companyStatistics {
+      companyRatingStatistics {
         averageRating
         ratingDistribution {
           rating

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -51,6 +51,10 @@ const CompanyInterviewExperiencesProvider = () => {
   const limit = PAGE_SIZE;
 
   useEffect(() => {
+    dispatch(queryRatingStatistics(pageName));
+  }, [dispatch, pageName]);
+
+  useEffect(() => {
     dispatch(
       queryCompanyInterviewExperiences({
         companyName: pageName,

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -5,7 +5,10 @@ import { paramsSelector, querySelector } from 'common/routing/selectors';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import { queryCompanyInterviewExperiences } from 'actions/company';
+import {
+  queryCompanyInterviewExperiences,
+  queryRatingStatistics,
+} from 'actions/company';
 import {
   interviewExperiences as interviewExperiencesSelector,
   interviewExperiencesCount as interviewExperiencesCountSelector,
@@ -95,14 +98,17 @@ CompanyInterviewExperiencesProvider.fetchData = ({
   const jobTitle = searchTextFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
-  return dispatch(
-    queryCompanyInterviewExperiences({
-      companyName: pageName,
-      jobTitle,
-      start,
-      limit,
-    }),
-  );
+  return Promise.all([
+    dispatch(
+      queryCompanyInterviewExperiences({
+        companyName: pageName,
+        jobTitle,
+        start,
+        limit,
+      }),
+    ),
+    dispatch(queryRatingStatistics(pageName)),
+  ]);
 };
 
 export default CompanyInterviewExperiencesProvider;

--- a/src/pages/Company/CompanyOverviewProvider.js
+++ b/src/pages/Company/CompanyOverviewProvider.js
@@ -45,6 +45,10 @@ const CompanyOverviewProvider = () => {
   const page = usePage();
 
   useEffect(() => {
+    dispatch(queryRatingStatistics(pageName));
+  }, [dispatch, pageName]);
+
+  useEffect(() => {
     dispatch(queryCompanyOverview(pageName));
   }, [dispatch, pageName]);
 

--- a/src/pages/Company/CompanyOverviewProvider.js
+++ b/src/pages/Company/CompanyOverviewProvider.js
@@ -4,7 +4,7 @@ import Overview from 'components/CompanyAndJobTitle/Overview';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import { queryCompanyOverview } from 'actions/company';
+import { queryCompanyOverview, queryRatingStatistics } from 'actions/company';
 import {
   jobAverageSalaries,
   averageWeekWorkTime,
@@ -70,7 +70,10 @@ const CompanyOverviewProvider = () => {
 CompanyOverviewProvider.fetchData = ({ store: { dispatch }, ...props }) => {
   const params = paramsSelector(props);
   const pageName = pageNameSelector(params);
-  return dispatch(queryCompanyOverview(pageName));
+  return Promise.all([
+    dispatch(queryCompanyOverview(pageName)),
+    dispatch(queryRatingStatistics(pageName)),
+  ]);
 };
 
 export default CompanyOverviewProvider;

--- a/src/pages/Company/CompanyTimeAndSalaryProvider.js
+++ b/src/pages/Company/CompanyTimeAndSalaryProvider.js
@@ -7,6 +7,7 @@ import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
 import {
   queryCompanyTimeAndSalary,
   queryCompanyTimeAndSalaryStatistics,
+  queryRatingStatistics,
 } from 'actions/company';
 import {
   salaryWorkTimes as salaryWorkTimesSelector,
@@ -131,7 +132,12 @@ CompanyTimeAndSalaryProvider.fetchData = ({
       limit,
     }),
   );
-  return Promise.all([dispatchTimeAndSalary, dispatchTimeAndSalaryStatistics]);
+  const dispatchRatingStatistics = dispatch(queryRatingStatistics(pageName));
+  return Promise.all([
+    dispatchTimeAndSalary,
+    dispatchTimeAndSalaryStatistics,
+    dispatchRatingStatistics,
+  ]);
 };
 
 export default CompanyTimeAndSalaryProvider;

--- a/src/pages/Company/CompanyTimeAndSalaryProvider.js
+++ b/src/pages/Company/CompanyTimeAndSalaryProvider.js
@@ -64,6 +64,10 @@ const CompanyTimeAndSalaryProvider = () => {
   const limit = PAGE_SIZE;
 
   useEffect(() => {
+    dispatch(queryRatingStatistics(pageName));
+  }, [dispatch, pageName]);
+
+  useEffect(() => {
     dispatch(
       queryCompanyTimeAndSalaryStatistics({
         companyName: pageName,

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -50,6 +50,10 @@ const CompanyWorkExperiencesProvider = () => {
   const limit = PAGE_SIZE;
 
   useEffect(() => {
+    dispatch(queryRatingStatistics(pageName));
+  }, [dispatch, pageName]);
+
+  useEffect(() => {
     dispatch(
       queryCompanyWorkExperiences({
         companyName: pageName,

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -4,7 +4,10 @@ import WorkExperiences from 'components/CompanyAndJobTitle/WorkExperiences';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
 import { tabType, pageType as PAGE_TYPE } from 'constants/companyJobTitle';
-import { queryCompanyWorkExperiences } from 'actions/company';
+import {
+  queryCompanyWorkExperiences,
+  queryRatingStatistics,
+} from 'actions/company';
 import {
   workExperiences as workExperiencesSelector,
   workExperiencesCount as workExperiencesCountSelector,
@@ -94,14 +97,17 @@ CompanyWorkExperiencesProvider.fetchData = ({
   const jobTitle = searchTextFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
-  return dispatch(
-    queryCompanyWorkExperiences({
-      companyName: pageName,
-      jobTitle,
-      start,
-      limit,
-    }),
-  );
+  return Promise.all([
+    dispatch(
+      queryCompanyWorkExperiences({
+        companyName: pageName,
+        jobTitle,
+        start,
+        limit,
+      }),
+    ),
+    dispatch(queryRatingStatistics(pageName)),
+  ]);
 };
 
 export default CompanyWorkExperiencesProvider;

--- a/src/reducers/companyIndex.js
+++ b/src/reducers/companyIndex.js
@@ -16,7 +16,7 @@ const preloadedState = {
   indexesByPage: {},
   indexCountBox: getUnfetched(),
   // companyName --> box
-  copmanyRatingStatisticsByName: {},
+  ratingStatisticsByName: {},
   overviewByName: {},
   timeAndSalaryByName: {},
   timeAndSalaryStatisticsByName: {},
@@ -41,8 +41,8 @@ const reducer = createReducer(preloadedState, {
   [SET_RATING_STATISTICS]: (state, { companyName, box }) => {
     return {
       ...state,
-      copmanyRatingStatisticsByName: {
-        ...state.copmanyRatingStatisticsByName,
+      ratingStatisticsByName: {
+        ...state.ratingStatisticsByName,
         [companyName]: box,
       },
     };

--- a/src/reducers/companyIndex.js
+++ b/src/reducers/companyIndex.js
@@ -16,7 +16,7 @@ const preloadedState = {
   indexesByPage: {},
   indexCountBox: getUnfetched(),
   // companyName --> box
-  ratingStatisticsByName: {},
+  copmanyRatingStatisticsByName: {},
   overviewByName: {},
   timeAndSalaryByName: {},
   timeAndSalaryStatisticsByName: {},
@@ -41,8 +41,8 @@ const reducer = createReducer(preloadedState, {
   [SET_RATING_STATISTICS]: (state, { companyName, box }) => {
     return {
       ...state,
-      ratingStatisticsByName: {
-        ...state.ratingStatisticsByName,
+      copmanyRatingStatisticsByName: {
+        ...state.copmanyRatingStatisticsByName,
         [companyName]: box,
       },
     };

--- a/src/reducers/companyIndex.js
+++ b/src/reducers/companyIndex.js
@@ -8,13 +8,15 @@ import {
   SET_INTERVIEW_EXPERIENCES,
   SET_WORK_EXPERIENCES,
   SET_TIME_AND_SALARY_STATISTICS,
+  SET_RATING_STATISTICS,
 } from 'actions/company';
 
 const preloadedState = {
   // page --> indexBox
   indexesByPage: {},
   indexCountBox: getUnfetched(),
-  // companyName --> overviewBox
+  // companyName --> box
+  ratingStatisticsByName: {},
   overviewByName: {},
   timeAndSalaryByName: {},
   timeAndSalaryStatisticsByName: {},
@@ -33,6 +35,15 @@ const reducer = createReducer(preloadedState, {
       indexesByPage: {
         ...state.indexesByPage,
         [page]: box,
+      },
+    };
+  },
+  [SET_RATING_STATISTICS]: (state, { companyName, box }) => {
+    return {
+      ...state,
+      ratingStatisticsByName: {
+        ...state.ratingStatisticsByName,
+        [companyName]: box,
       },
     };
   },

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -96,7 +96,8 @@ export const companiesCountSelector = state => {
 
 export const companyRatingStatisticsBoxSelectorByName = companyName => state => {
   return (
-    state.companyIndex.ratingStatisticsByName[companyName] || getUnfetched()
+    state.companyIndex.copmanyRatingStatisticsByName[companyName] ||
+    getUnfetched()
   );
 };
 

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -96,8 +96,7 @@ export const companiesCountSelector = state => {
 
 export const companyRatingStatisticsBoxSelectorByName = companyName => state => {
   return (
-    state.companyIndex.copmanyRatingStatisticsByName[companyName] ||
-    getUnfetched()
+    state.companyIndex.ratingStatisticsByName[companyName] || getUnfetched()
   );
 };
 

--- a/src/selectors/companyAndJobTitle.js
+++ b/src/selectors/companyAndJobTitle.js
@@ -94,6 +94,12 @@ export const companiesCountSelector = state => {
   return isFetched(indexCountBox) ? indexCountBox.data : 0;
 };
 
+export const companyRatingStatisticsBoxSelectorByName = companyName => state => {
+  return (
+    state.companyIndex.ratingStatisticsByName[companyName] || getUnfetched()
+  );
+};
+
 export const companyOverviewBoxSelectorByName = companyName => state => {
   return state.companyIndex.overviewByName[companyName] || getUnfetched();
 };


### PR DESCRIPTION
Close #1390 #1399  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

在公司名稱旁邊加上平均分數+評分數量

## 有哪些 dependency？  <!-- 選填，沒有就刪掉 -->

- Back-end PR： goodjoblife/WorkTimeSurvey-backend#1046

## Screenshots  <!-- 選填，沒有就刪掉 -->

|phone|laptop|
|-|-|
|![畫面擷取於 2024-09-24 01 20 39](https://github.com/user-attachments/assets/a93eb8ab-1521-45a7-b7e5-68b92e555418)|![Screenshot 2024-09-24 at 01-21-17 台灣大學 總覽 GoodJob 職場透明化運動](https://github.com/user-attachments/assets/7f67c9d6-c77c-4e9e-b93f-761a406ed05c)|


## Questions:  <!-- 選填，沒有就刪掉 -->

- `companyStatistics` 感覺要改名叫做 `ratingStatistics`？
- ~~目前 API return 是 null，但明明有經驗和評分？ http://www-dev.goodjob.life/companies/%E5%8F%B0%E7%81%A3%E5%A4%A7%E5%AD%B8~~


~~Tested on api-dev: https://api-dev.goodjob.life/graphql~~
```
{
  company(name:"台灣大學") {
    companyStatistics {
      averageRating
      ratingCount
    }
  }
}
```
```
{
  "data": {
    "company": {
      "companyStatistics": null
    }
  }
}
```

[UPDATE] 後端 null 的問題已經修好了

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/companies/%E5%8F%B0%E7%81%A3%E5%A4%A7%E5%AD%B8 到一個公司頁面，看見名稱旁邊有評分（目前API return null，要等API正常回傳）