### PR TITLE
Fix: company rating position

### DIFF
--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
@@ -20,6 +20,7 @@
   @media (min-width: above-small) {
     display: inline-flex;
     margin-left: 34px;
+    vertical-align: top;
   }
 
   .averageRating {


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

- 對齊一下 company rating 的垂直位置

## Screenshots  <!-- 選填，沒有就刪掉 -->

before:
<img width="572" alt="Screenshot 2024-10-18 at 8 05 13 AM" src="https://github.com/user-attachments/assets/bf433ef6-077b-467d-9083-2aec903cc82d">


after:
<img width="524" alt="Screenshot 2024-10-18 at 8 03 27 AM" src="https://github.com/user-attachments/assets/7e8c81d7-ec92-401e-90b7-e204c36904ee">

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start 看一下
