### PR TITLE
關閉表單動畫以避免同時渲染多頁

### DIFF
--- a/src/components/common/FormBuilder/AnimatedPager.js
+++ b/src/components/common/FormBuilder/AnimatedPager.js
@@ -7,18 +7,16 @@ import cn from 'classnames';
 import styles from './AnimatedPager.module.css';
 
 const AnimatedPager = ({ page, children, ...props }) => {
-  const [handleRef, { width: frameWidth }] = useMeasure();
+  const [handleRef] = useMeasure();
   return (
     <div ref={handleRef} className={cn(styles.frame, props.className)}>
-      {Children.map(children, ({ props: { children } }, i) => (
-        <div
-          key={i}
-          className={styles.page}
-          style={{ left: `${-frameWidth * page}px` }}
-        >
-          {children}
-        </div>
-      ))}
+      {Children.map(children, ({ props: { children } }, i) =>
+        i === page ? (
+          <div key={i} className={styles.page}>
+            {children}
+          </div>
+        ) : null,
+      )}
     </div>
   );
 };

--- a/src/components/common/FormBuilder/index.js
+++ b/src/components/common/FormBuilder/index.js
@@ -164,21 +164,6 @@ const FormBuilder = ({
     }
   }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Prevent tabbing within the modal so we don't jump between pages
-  // -- which is NOT ideal, as it's not a11y friendly.
-  //
-  // We will need to revisit this later after we are able to not render
-  // all questions at once but the active one only.
-  useEffect(() => {
-    if (!open) return;
-
-    const handler = e => {
-      if (e.key.toLowerCase() === 'tab') e.preventDefault();
-    };
-    window.document.addEventListener('keydown', handler);
-    return () => window.document.removeEventListener('keydown', handler);
-  }, [open]);
-
   if (!shouldRenderQuestion) {
     return null;
   }


### PR DESCRIPTION
Close #1414  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

因為表單將所有頁面都選染出來，以達到簡易動畫效果。
然而卻暴露了能夠透過 tab 非預期跳頁的風險。
沒有全部渲染的動畫不好做，這個PR暫時關掉動畫。

## Screenshots  <!-- 選填，沒有就刪掉 -->


https://github.com/user-attachments/assets/74dc698d-006c-4fb5-bf6b-4cd9a92c91c4




## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/share 在任一表單可使用 tab 換頁，而不影響功能