### PR TITLE
feat: 追蹤看更多 experience 的數據

### DIFF
--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -31,7 +31,7 @@ const ExperienceEntry = ({
   },
   size,
   canView,
-  onClick = () => {},
+  onClick,
 }) => (
   <div className={cn(styles.container, styles[size])} onClick={onClick}>
     <Link to={createLinkTo({ id, pageType })}>
@@ -118,6 +118,7 @@ ExperienceEntry.propTypes = {
 
 ExperienceEntry.defaultProps = {
   size: 'm',
+  onClick: null,
 };
 
 export default ExperienceEntry;

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -31,8 +31,9 @@ const ExperienceEntry = ({
   },
   size,
   canView,
+  onClick = () => {},
 }) => (
-  <div className={cn(styles.container, styles[size])}>
+  <div className={cn(styles.container, styles[size])} onClick={onClick}>
     <Link to={createLinkTo({ id, pageType })}>
       <section className={styles.contentWrapper}>
         <div className={styles.labels}>
@@ -110,6 +111,7 @@ ExperienceEntry.propTypes = {
       }),
     ).isRequired,
   }).isRequired,
+  onClick: PropTypes.func,
   pageType: PropTypes.string,
   size: PropTypes.oneOf(['s', 'm', 'l']),
 };

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -36,7 +36,7 @@ const ExperienceEntry = ({
   },
   size,
   canView,
-  onClick = () => {},
+  onClick,
 }) => (
   <div className={cn(styles.container, styles[size])} onClick={onClick}>
     <Link to={createLinkTo({ id, pageType })}>
@@ -144,6 +144,7 @@ ExperienceEntry.propTypes = {
 
 ExperienceEntry.defaultProps = {
   size: 'm',
+  onClick: null,
 };
 
 export default ExperienceEntry;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -36,8 +36,9 @@ const ExperienceEntry = ({
   },
   size,
   canView,
+  onClick = () => {},
 }) => (
-  <div className={cn(styles.container, styles[size])}>
+  <div className={cn(styles.container, styles[size])} onClick={onClick}>
     <Link to={createLinkTo({ id, pageType })}>
       <section className={styles.contentWrapper}>
         <div className={styles.labels}>
@@ -136,6 +137,7 @@ ExperienceEntry.propTypes = {
     ).isRequired,
     week_work_time: PropTypes.number,
   }).isRequired,
+  onClick: PropTypes.func,
   pageType: PropTypes.string.isRequired,
   size: PropTypes.oneOf(['s', 'm', 'l']),
 };

--- a/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
+++ b/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import InterviewExperienceEntry from '../../CompanyAndJobTitle/InterviewExperiences/ExperienceEntry';
 import WorkExperienceEntry from '../../CompanyAndJobTitle/WorkExperiences/ExperienceEntry';
 import { useLocation } from 'react-router';
+import ReactGA from 'react-ga4';
 import usePermission from 'hooks/usePermission';
 import {
   queryRelatedExperiencesOnExperience,
@@ -11,6 +12,7 @@ import {
 } from 'actions/experience';
 import { relatedExperiencesStateSelector } from 'selectors/experienceSelector';
 import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
 import Button from 'common/button/Button';
 import styles from './MoreExperiencesBlock.module.css';
 
@@ -84,6 +86,12 @@ const MoreExperiencesBlock = ({ experience }) => {
           pageType={pageType}
           data={e}
           canView={canViewPublishId(e.id)}
+          onClick={() => {
+            ReactGA.event({
+              category: GA_CATEGORY.READ_MORE,
+              action: GA_ACTION.CLICK_READ_MORE_EXPERIENCE,
+            });
+          }}
         />
       ))}
       {hasMore && <LoadMoreButton onClick={handleLoadMore} />}

--- a/src/constants/gaConstants.js
+++ b/src/constants/gaConstants.js
@@ -16,6 +16,7 @@ export const GA_CATEGORY = {
   TEST_NEW_FEATURE: 'test_new_feature',
   JOB_TITLE_PAGE: 'job_title_page',
   COMPANY_PAGE: 'company_page',
+  READ_MORE: 'read_more',
 };
 
 export const GA_ACTION = {
@@ -35,4 +36,5 @@ export const GA_ACTION = {
   CLICK_PRIVATE_MESSAGE_BUTTON: 'click_private_message_button',
   SEARCH_COMPANY: 'search_company',
   SEARCH_JOB_TITLE: 'search_job_title',
+  CLICK_READ_MORE_EXPERIENCE: 'click_read_more_experience',
 };


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

- 追蹤單篇文章頁面，點擊看更多 experience 區塊的數據


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 單篇 experience 下方點擊面試或評價區塊，有送 google analytics 事件
![Screenshot 2024-10-26 at 4 02 21 PM](https://github.com/user-attachments/assets/bdb6f6bf-606f-4420-b304-798354dbfb88)
![Screenshot 2024-10-26 at 4 02 28 PM](https://github.com/user-attachments/assets/92b052f9-6753-4137-9ab5-eb4d6bf70bb0)

- [ ] 公司或職稱頁面，下方點擊面試或評價區塊，不會送 `click_read_more_experience` 事件。應該只會有 page view
![Screenshot 2024-10-26 at 4 03 01 PM](https://github.com/user-attachments/assets/f6819e6f-136e-4902-ad39-89cd073add0b)
