### PR TITLE
fix: wording of experience in years

### DIFF
--- a/src/components/ExperienceDetail/Article/ArticleInfo.js
+++ b/src/components/ExperienceDetail/Article/ArticleInfo.js
@@ -50,7 +50,7 @@ const InterviewInfoBlocks = ({ experience, hideContent }) => {
         {experience.job_title.name}
       </InfoBlock>
       {expInYearText !== null ? (
-        <InfoBlock label="相關職務評價">{expInYearText}</InfoBlock>
+        <InfoBlock label="相關職務經驗">{expInYearText}</InfoBlock>
       ) : null}
       {experience.education ? (
         <InfoBlock label="最高學歷">{experience.education}</InfoBlock>
@@ -152,7 +152,7 @@ const WorkInfoBlocks = ({ experience, hideContent }) => {
         </InfoBlock>
       ) : null}
       {expInYearText ? (
-        <InfoBlock label="自身相關職務評價">{expInYearText}</InfoBlock>
+        <InfoBlock label="相關職務經驗">{expInYearText}</InfoBlock>
       ) : null}
       {experience.education ? (
         <InfoBlock label="最高學歷">{experience.education}</InfoBlock>

--- a/src/components/ExperienceDetail/experienceSelector.js
+++ b/src/components/ExperienceDetail/experienceSelector.js
@@ -77,7 +77,7 @@ const interviewMetaDescriptionSelector = experience => {
       content += `面試地區：${region}。`;
     }
     if (experience.experience_in_year) {
-      content += `相關職務評價：${experience_in_year} 年。`;
+      content += `相關職務經驗：${experience_in_year} 年。`;
     }
     if (interviewYear && interviewMonth) {
       content += `面試時間：${interviewYear} 年 ${interviewMonth} 月。`;
@@ -113,7 +113,7 @@ const workMetaDescriptionSelector = experience => {
       content += `工作地區：${region}。`;
     }
     if (experience.experience_in_year) {
-      content += `相關職務評價：${experience_in_year} 年。`;
+      content += `相關職務經驗：${experience_in_year} 年。`;
     }
     if (experience.education) {
       content += `最高學歷：${experience.education}。`;

--- a/src/components/ShareExperience/common/ExperienceInYear.js
+++ b/src/components/ShareExperience/common/ExperienceInYear.js
@@ -12,7 +12,7 @@ const ExperienceInYear = ({ jobTitle, experienceInYear, onChange }) => (
   <div>
     <InputTitle
       text={
-        jobTitle ? `當時已經有幾年擔任${jobTitle}的經驗？` : '自身相關職務評價'
+        jobTitle ? `當時已經有幾年擔任${jobTitle}的經驗？` : '自身相關職務經驗'
       }
     />
     <div


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

現在單篇顯示 experience in year 的名稱是 "相關職務評價"，somehow 有點怪，修正之
![Screenshot 2024-11-12 at 5 14 35 PM](https://github.com/user-attachments/assets/b6d58ee6-3900-4921-b04f-b2152ba8e9fc)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] yarn start 
- [ ] 看一下經驗、評價單篇頁面
- [ ] 看一下經驗、評價表單