### PR TITLE
[經驗單篇] 加上區塊評分

### DIFF
--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -48,6 +48,7 @@ export const queryExperienceGql = /* GraphQL */ `
         sections {
           interview_subtitle: subtitle
           content
+          rating
         }
         interview_time {
           year


### PR DESCRIPTION
Close #1458  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

單篇的區塊評分，沿用工作經驗的元件，只要補上面試經驗API取得區塊評分就行

## Screenshots  <!-- 選填，沒有就刪掉 -->

|Before|After|
|-|-|
|![localhost_3000_companies_A](https://github.com/user-attachments/assets/9a2d812d-2e9c-4a3d-9abb-bea57e039b14)|![localhost_3000_experiences_678dab4e3f763016fdfca35a](https://github.com/user-attachments/assets/abf6bbe9-a19f-40be-b63b-bbb19bcbd946)|

## Questions:  <!-- 選填，沒有就刪掉 -->

- 我發現被 paywall 擋住的工作經驗，不會顯示 section ratings，這是預期的嗎？ @YongChenSu @barry800414 

![localhost_3000_experiences_678dab4e3f763016fdfca35a (1)](https://github.com/user-attachments/assets/7fd9f039-976e-49f0-8cf5-85852b808950)



## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/experiences/678dab4e3f763016fdfca35a 登入後應可看到 section ratings