### PR TITLE
chore: fix LaborRightsSingle propTypes

### DIFF
--- a/src/components/LaborRightsSingle/Body.js
+++ b/src/components/LaborRightsSingle/Body.js
@@ -44,12 +44,10 @@ Body.propTypes = {
   description: PropTypes.string.isRequired,
   permissionBlock: PropTypes.element,
   seoText: PropTypes.string,
-  title: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };
+
 Body.defaultProps = {
-  title: '',
-  description: '',
-  content: '',
   permissionBlock: null,
 };
 

--- a/src/components/LaborRightsSingle/index.js
+++ b/src/components/LaborRightsSingle/index.js
@@ -45,8 +45,10 @@ const LaborRightsSingle = () => {
         <Fragment>
           <Helmet
             entryId={entryId}
-            seoTitle={entryBox.data.seoTitle}
-            seoDescription={entryBox.data.seoDescription}
+            seoTitle={entryBox.data.seoTitle || entryBox.data.title}
+            seoDescription={
+              entryBox.data.seoDescription || entryBox.data.description
+            }
             coverUrl={entryBox.data.coverUrl}
           />
           <div>


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

小修正一些 propTypes, 但發現一些問題（都是小問題）

1. 做 Helmet 的 seoTitle 在這個 [PR](https://github.com/goodjoblife/GoodJobShare/pull/58/files#diff-4572b688704fd378d2832c7e1ec6fd71cfd98b4d1314b666d07ed554e449d57cR31) 是拿 title 欄位，沒用到 seoTitle 欄位 <--- 要請 @barry800414 幫忙確認，理論上應該要用 seoTitle

    所以調整成拿 seoTitle 欄位優先當 helmet title, 若無，則拿 title 欄位

3. seoDescription 有可能是 null，沒有的話，拿 description 欄位 （雖然實際上 seoDescription 都有資料，但避免困混就修正）

## Screenshots  <!-- 選填，沒有就刪掉 -->

打開小教室的原始碼，Helmet 依然有資料

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/387be90b-8d67-4587-ab8e-210c87934ffa" />

## 我應該如何手動測試？ <!-- 必填 -->

- [x] 打開每篇小教室的原始碼，檢查 helmet
- [x] 打開 console，沒有跳出任何 Proptypes 錯誤警告