### PR TITLE
hotfix: work experience form crash

### DIFF
--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -472,6 +472,7 @@ export const createSectionsQuestion = () => ({
   ratingLabels: RATING_LABELS,
   footnote: value =>
     `至少 ${SECTION_MIN_LENGTH} 字，現在 ${wordCount(value)} 字`,
+  hasRating: () => true,
 });
 
 const OptionEmoji = ({ value, children }) => (

--- a/src/components/common/FormBuilder/QuestionBuilder/CheckboxRatingTextAreaList/ActiveItem.js
+++ b/src/components/common/FormBuilder/QuestionBuilder/CheckboxRatingTextAreaList/ActiveItem.js
@@ -147,7 +147,7 @@ ActiveItem.propTypes = {
     PropTypes.node,
     PropTypes.func,
   ]),
-  hasRating: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]).isRequired,
+  hasRating: PropTypes.func.isRequired,
   isElseOption: PropTypes.bool.isRequired,
   onCancel: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
@@ -163,7 +163,7 @@ ActiveItem.propTypes = {
 };
 
 ActiveItem.defaultProps = {
-  hasRating: true,
+  hasRating: () => true,
 };
 
 export default ActiveItem;


### PR DESCRIPTION
Close #1501 

## 這個 PR 是？ <!-- 必填 -->

- 修復評價表單最後一題 crash 的問題
- Root cause 是，hasRating default value 不是 func，會導致 ActiveItem crash

## 我應該如何手動測試？ <!-- 必填 -->

- [x] yarn start
- [x] 可以成功上傳面試、評價