### PR TITLE
[ESG] Fix: same industry compare

### DIFF
--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.js
@@ -34,10 +34,8 @@ const EsgItemBlock = ({
       與同業相比
       <span
         className={cn(
-          styles.valie,
-          value >= valueCompared
-            ? styles.value_positive
-            : styles.value_negative,
+          styles.value,
+          value >= valueCompared ? styles.positive : styles.negative,
         )}
       >
         {formatNumberWithSign(

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.js
@@ -8,6 +8,7 @@ import Card from 'common/Card';
 import Info from 'common/icons/Info';
 import styles from './EsgBlock.module.css';
 import overviewStyles from '../../Overview/Overview.module.css';
+import { formatNumberWithSign } from 'utils/stringUtil';
 
 const EsgItemBlock = ({
   className,
@@ -31,8 +32,19 @@ const EsgItemBlock = ({
       style={{ visibility: valueCompared ? 'visible' : 'hidden' }}
     >
       與同業相比
-      <span className={styles.value}>
-        {(((value - valueCompared) / valueCompared) * 100).toFixed(0)}%
+      <span
+        className={cn(
+          styles.valie,
+          value >= valueCompared
+            ? styles.value_positive
+            : styles.value_negative,
+        )}
+      >
+        {formatNumberWithSign(
+          ((value - valueCompared) / valueCompared) * 100,
+          0,
+        )}
+        %
       </span>
     </div>
   </Card>
@@ -87,7 +99,9 @@ const EsgBlock = ({
               title="員工薪資平均數"
               year={avgSalaryStatisticsItem.year}
               value={avgSalaryStatisticsItem.average / 10000}
-              valueCompared={avgSalaryStatisticsItem.sameIndustryAverage}
+              valueCompared={
+                avgSalaryStatisticsItem.sameIndustryAverage / 10000
+              }
               unit="萬 / 年"
             />
           )}
@@ -98,7 +112,7 @@ const EsgBlock = ({
               year={nonManagerAvgSalaryStatisticsItem.year}
               value={nonManagerAvgSalaryStatisticsItem.average / 10000}
               valueCompared={
-                nonManagerAvgSalaryStatisticsItem.sameIndustryAverage
+                nonManagerAvgSalaryStatisticsItem.sameIndustryAverage / 10000
               }
               unit="萬 / 年"
             />

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.js
@@ -24,7 +24,7 @@ const EsgItemBlock = ({
       <Info className={styles.icon} />
     </div>
     <div className={styles.data}>
-      <span className={styles.value}>{value}</span> {unit}
+      <span className={styles.value}>{value.toFixed(1)}</span> {unit}
     </div>
     <div
       className={styles.caption}

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.module.css
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.module.css
@@ -60,7 +60,8 @@
   .caption {
     margin-top: 20px;
 
-    .value {
+    .value_positive,
+    .value_negative {
       margin-left: 8px;
     }
   }
@@ -110,10 +111,16 @@
   font-size: 12px;
   font-weight: 400;
 
-  .value {
+  .value_negative {
     font-size: 16px;
     font-weight: 700;
     color: warning-red;
+  }
+
+  .value_positive {
+    font-size: 16px;
+    font-weight: 700;
+    color: black;
   }
 }
 

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.module.css
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.module.css
@@ -60,8 +60,7 @@
   .caption {
     margin-top: 20px;
 
-    .value_positive,
-    .value_negative {
+    .value {
       margin-left: 8px;
     }
   }
@@ -111,16 +110,15 @@
   font-size: 12px;
   font-weight: 400;
 
-  .value_negative {
+  .value {
     font-size: 16px;
     font-weight: 700;
-    color: warning-red;
-  }
-
-  .value_positive {
-    font-size: 16px;
-    font-weight: 700;
-    color: black;
+    &.negative {
+      color: warning-red;
+    }
+    &.positive {
+      color: black;
+    }
   }
 }
 

--- a/src/utils/stringUtil.js
+++ b/src/utils/stringUtil.js
@@ -31,7 +31,5 @@ export const formatCommaSeparatedNumber = num =>
 
 // 300.0 -> "+300.0"
 export const formatNumberWithSign = (number, decimals) => {
-  return number > 0
-    ? `+${number.toFixed(decimals)}`
-    : `${number.toFixed(decimals)}`;
+  return (number > 0 ? '+' : '') + number.toFixed(decimals);
 };

--- a/src/utils/stringUtil.js
+++ b/src/utils/stringUtil.js
@@ -28,3 +28,10 @@ export const nthIndexOf = (str, substr, n) => {
 // format: 3000 -> "3,000"
 export const formatCommaSeparatedNumber = num =>
   num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
+// 300.0 -> "+300.0"
+export const formatNumberWithSign = (number, decimals) => {
+  return number > 0
+    ? `+${number.toFixed(decimals)}`
+    : `${number.toFixed(decimals)}`;
+};

--- a/src/utils/stringUtil.test.js
+++ b/src/utils/stringUtil.test.js
@@ -1,4 +1,4 @@
-import { toSnakecase, toCamelcase } from './stringUtil';
+import { toSnakecase, toCamelcase, formatNumberWithSign } from './stringUtil';
 
 describe('toSnakecase tests', () => {
   test('toSnakecase', () => {
@@ -9,5 +9,16 @@ describe('toSnakecase tests', () => {
 describe('toCamelcase tests', () => {
   test('toCamelcase', () => {
     expect(toCamelcase('foo_bar_cat')).toBe('fooBarCat');
+  });
+});
+
+describe('formatNumberWithSign tests', () => {
+  test('formatNumberWithSign', () => {
+    expect(formatNumberWithSign(100.0, 0)).toBe('+100');
+    expect(formatNumberWithSign(0.0, 0)).toBe('0');
+    expect(formatNumberWithSign(-100.0, 0)).toBe('-100');
+    expect(formatNumberWithSign(100.0, 1)).toBe('+100.0');
+    expect(formatNumberWithSign(0.0, 1)).toBe('0.0');
+    expect(formatNumberWithSign(-100.0, 1)).toBe('-100.0');
   });
 });


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. 修復同產業平均比較都是 -100% 的問題（傳入的數字沒有同除同樣的數）
2. 如果是正數，加上 `+` 前綴
3. 如果是正數，顯示為黑色，如果是負數，顯示為紅色 (by figma)

## Screenshots  <!-- 選填，沒有就刪掉 -->

![Screenshot 2025-03-08 at 9 00 35 PM](https://github.com/user-attachments/assets/9bd0f2db-73e7-4c6c-b5f3-3311fbbe47dc)
![Screenshot 2025-03-08 at 9 02 20 PM](https://github.com/user-attachments/assets/a5fcbd74-b6f7-4a30-820f-0e2966dfa71f)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 打開一間上市公司的薪資頁面，與同業相比的數字應該要正確
