### PR TITLE
feat: 調整 EmployerAggregateRating 

### DIFF
--- a/.github/docker-compose-dev.yml
+++ b/.github/docker-compose-dev.yml
@@ -14,3 +14,4 @@ services:
         - RAZZLE_TAP_PAY_APP_ID=125271
         - RAZZLE_TAP_PAY_APP_KEY=app_WBWcR9mkiSMUQ3qZV5tUidkq7vfamUzmdWi5QR33ksT6ttbiZ9BJxbz5Fvma
         - RAZZLE_TAP_PAY_SERVER_TYPE=sandbox
+        - RAZZLE_ORIGIN=https://www-dev.goodjob.life

--- a/.github/docker-compose-production.yml
+++ b/.github/docker-compose-production.yml
@@ -14,3 +14,4 @@ services:
         - RAZZLE_TAP_PAY_APP_ID=125271
         - RAZZLE_TAP_PAY_APP_KEY=app_WBWcR9mkiSMUQ3qZV5tUidkq7vfamUzmdWi5QR33ksT6ttbiZ9BJxbz5Fvma
         - RAZZLE_TAP_PAY_SERVER_TYPE=production
+        - RAZZLE_ORIGIN=https://www.goodjob.life

--- a/.github/docker-compose-stage.yml
+++ b/.github/docker-compose-stage.yml
@@ -11,3 +11,4 @@ services:
         - RAZZLE_GTM_ID=GTM-KVZ7DZQ
         - RAZZLE_GOOGLE_APP_ID=879657963776-nb0kdpkb5sfdf0285ov9o353dnt0l5iq.apps.googleusercontent.com
         - RAZZLE_ENVIRONMENT=stage
+        - RAZZLE_ORIGIN=https://www-stage.goodjob.life

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -19,8 +19,6 @@ import { generateBreadCrumbData } from './utils';
 import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
 import Glike from 'common/icons/Glike';
-import Seo from 'common/Seo/SeoStructure';
-import { ORIGIN } from 'config';
 
 const AverageRating = ({ pageType, pageName }) => {
   const ratingStatistcsBox = useSelector(
@@ -39,22 +37,6 @@ const AverageRating = ({ pageType, pageName }) => {
   const { averageRating, ratingCount } = data;
   return (
     <div className={styles.ratingStatistics}>
-      <Seo
-        data={{
-          '@context': 'https://schema.org/',
-          '@type': 'EmployerAggregateRating',
-          name: pageName,
-          itemReviewed: {
-            '@type': 'Organization',
-            name: pageName,
-            sameAs: ORIGIN,
-          },
-          ratingValue: averageRating.toFixed(1),
-          ratingCount: ratingCount,
-          bestRating: 5,
-          worstRating: 1,
-        }}
-      />
       <span className={styles.averageRating}>{averageRating.toFixed(1)}</span>
       <Glike className={styles.icon} />
       <span className={styles.ratingCount}>({ratingCount})</span>

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -20,6 +20,7 @@ import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
 import Glike from 'common/icons/Glike';
 import Seo from 'common/Seo/SeoStructure';
+import { ORIGIN } from 'config';
 
 const AverageRating = ({ pageType, pageName }) => {
   const ratingStatistcsBox = useSelector(
@@ -42,12 +43,16 @@ const AverageRating = ({ pageType, pageName }) => {
         data={{
           '@context': 'https://schema.org/',
           '@type': 'EmployerAggregateRating',
+          name: pageName,
           itemReviewed: {
             '@type': 'Organization',
             name: pageName,
+            sameAs: ORIGIN,
           },
-          ratingValue: averageRating,
+          ratingValue: averageRating.toFixed(1),
           ratingCount: ratingCount,
+          bestRating: 5,
+          worstRating: 1,
         }}
       />
       <span className={styles.averageRating}>{averageRating.toFixed(1)}</span>

--- a/src/components/CompanyAndJobTitle/Overview/EmployerAggregateRating.js
+++ b/src/components/CompanyAndJobTitle/Overview/EmployerAggregateRating.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Seo from 'common/Seo/SeoStructure';
+import SeoStructure from 'common/Seo/SeoStructure';
 import PropTypes from 'prop-types';
 import { ORIGIN } from 'config';
 
@@ -11,7 +11,7 @@ const EmployerAggregateRating = ({
   ratingCount,
 }) => {
   return (
-    <Seo
+    <SeoStructure
       data={{
         '@context': 'https://schema.org/',
         '@type': 'EmployerAggregateRating',
@@ -22,7 +22,7 @@ const EmployerAggregateRating = ({
           name: companyName,
           sameAs: ORIGIN,
         },
-        ratingValue: averageRating.toFixed(1),
+        ratingValue: parseFloat(averageRating.toFixed(1)),
         ratingCount: ratingCount,
         bestRating: 5,
         worstRating: 1,

--- a/src/components/CompanyAndJobTitle/Overview/EmployerAggregateRating.js
+++ b/src/components/CompanyAndJobTitle/Overview/EmployerAggregateRating.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import Seo from 'common/Seo/SeoStructure';
+import PropTypes from 'prop-types';
+import { ORIGIN } from 'config';
+
+const EmployerAggregateRating = ({
+  title,
+  description,
+  companyName,
+  averageRating,
+  ratingCount,
+}) => {
+  return (
+    <Seo
+      data={{
+        '@context': 'https://schema.org/',
+        '@type': 'EmployerAggregateRating',
+        name: title,
+        description,
+        itemReviewed: {
+          '@type': 'Organization',
+          name: companyName,
+          sameAs: ORIGIN,
+        },
+        ratingValue: averageRating.toFixed(1),
+        ratingCount: ratingCount,
+        bestRating: 5,
+        worstRating: 1,
+      }}
+    />
+  );
+};
+
+EmployerAggregateRating.propTypes = {
+  averageRating: PropTypes.number.isRequired,
+  companyName: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  ratingCount: PropTypes.number.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+export default EmployerAggregateRating;

--- a/src/components/CompanyAndJobTitle/Overview/EmployerAggregateRatingSeo.js
+++ b/src/components/CompanyAndJobTitle/Overview/EmployerAggregateRatingSeo.js
@@ -3,7 +3,7 @@ import SeoStructure from 'common/Seo/SeoStructure';
 import PropTypes from 'prop-types';
 import { ORIGIN } from 'config';
 
-const EmployerAggregateRating = ({
+const EmployerAggregateRatingSeo = ({
   title,
   description,
   companyName,
@@ -31,7 +31,7 @@ const EmployerAggregateRating = ({
   );
 };
 
-EmployerAggregateRating.propTypes = {
+EmployerAggregateRatingSeo.propTypes = {
   averageRating: PropTypes.number.isRequired,
   companyName: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
@@ -39,4 +39,4 @@ EmployerAggregateRating.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-export default EmployerAggregateRating;
+export default EmployerAggregateRatingSeo;

--- a/src/components/CompanyAndJobTitle/Overview/Helmet.js
+++ b/src/components/CompanyAndJobTitle/Overview/Helmet.js
@@ -2,7 +2,10 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { generatePath } from 'react-router';
+import { useSelector } from 'react-redux';
+import EmployerAggregateRating from './EmployerAggregateRating';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
+import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { SITE_NAME } from 'constants/helmetData';
 import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
 
@@ -26,6 +29,10 @@ const CompanyOverviewHelmet = ({
   workExperiencesCount,
   topNJobTitles,
 }) => {
+  const ratingStatistcsBox = useSelector(
+    companyRatingStatisticsBoxSelectorByName(companyName),
+  );
+
   // title
   const title = companyName;
 
@@ -54,17 +61,28 @@ const CompanyOverviewHelmet = ({
   const url = formatCanonicalPath(path);
 
   return (
-    <Helmet>
-      <title itemProp="name" lang="zh-TW">
-        {title}
-      </title>
-      <meta name="description" content={description} />
-      <meta property="og:title" content={formatTitle(title, SITE_NAME)} />
-      <meta property="og:description" content={description} />
-      <meta name="keywords" content={formatKeyword(companyName)} />
-      <meta property="og:url" content={url} />
-      <link rel="canonical" href={url} />
-    </Helmet>
+    <div>
+      <Helmet>
+        <title itemProp="name" lang="zh-TW">
+          {title}
+        </title>
+        <meta name="description" content={description} />
+        <meta property="og:title" content={formatTitle(title, SITE_NAME)} />
+        <meta property="og:description" content={description} />
+        <meta name="keywords" content={formatKeyword(companyName)} />
+        <meta property="og:url" content={url} />
+        <link rel="canonical" href={url} />
+      </Helmet>
+      {ratingStatistcsBox && ratingStatistcsBox.data && (
+        <EmployerAggregateRating
+          title={formatTitle(title, SITE_NAME)}
+          description={description}
+          companyName={companyName}
+          averageRating={ratingStatistcsBox.data.averageRating}
+          ratingCount={ratingStatistcsBox.data.ratingCount}
+        />
+      )}
+    </div>
   );
 };
 

--- a/src/components/CompanyAndJobTitle/Overview/Helmet.js
+++ b/src/components/CompanyAndJobTitle/Overview/Helmet.js
@@ -48,7 +48,7 @@ const CompanyOverviewHelmet = ({
   const jobTitles = topNJobTitles
     ? topNJobTitles.map(item => item.name).join('、')
     : '';
-  const description = `了解${companyName}嗎？由內部員工分享${jobTitles}等職位的${combinedStr}，幫助你更瞭解${companyName}！`;
+  const description = `想了解${companyName}嗎？由內部員工分享${jobTitles}等職位的${combinedStr}，幫助你更瞭解${companyName}！`;
 
   const path = generatePath('/companies/:companyName', { companyName });
   const url = formatCanonicalPath(path);

--- a/src/components/CompanyAndJobTitle/Overview/Helmet.js
+++ b/src/components/CompanyAndJobTitle/Overview/Helmet.js
@@ -3,7 +3,7 @@ import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { generatePath } from 'react-router';
 import { useSelector } from 'react-redux';
-import EmployerAggregateRating from './EmployerAggregateRating';
+import EmployerAggregateRatingSeo from './EmployerAggregateRatingSeo';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { SITE_NAME } from 'constants/helmetData';
@@ -74,7 +74,7 @@ const CompanyOverviewHelmet = ({
         <link rel="canonical" href={url} />
       </Helmet>
       {ratingStatistcsBox && ratingStatistcsBox.data && (
-        <EmployerAggregateRating
+        <EmployerAggregateRatingSeo
           title={formatTitle(title, SITE_NAME)}
           description={description}
           companyName={companyName}

--- a/src/components/CompanyAndJobTitle/Overview/Helmet.js
+++ b/src/components/CompanyAndJobTitle/Overview/Helmet.js
@@ -61,7 +61,7 @@ const CompanyOverviewHelmet = ({
   const url = formatCanonicalPath(path);
 
   return (
-    <div>
+    <>
       <Helmet>
         <title itemProp="name" lang="zh-TW">
           {title}
@@ -82,7 +82,7 @@ const CompanyOverviewHelmet = ({
           ratingCount={ratingStatistcsBox.data.ratingCount}
         />
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -18,4 +18,5 @@ module.exports = {
     process.env.RAZZLE_TAP_PAY_APP_KEY ||
     'app_WBWcR9mkiSMUQ3qZV5tUidkq7vfamUzmdWi5QR33ksT6ttbiZ9BJxbz5Fvma',
   TAP_PAY_SERVER_TYPE: process.env.RAZZLE_TAP_PAY_SERVER_TYPE || 'sandbox',
+  ORIGIN: process.env.RAZZLE_ORIGIN || 'http://localhost:3000',
 };


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

1. 只有 overview 頁面才 render 這個 google structural data，避免 google 有很多頁面選擇，反而不知道要顯示哪一個
2. 加上更多欄位（name, description, worstRating, bestRating 等），基本上是參照 interview dot tw 的下去做，不過沒有放麵包屑結構（interview dot tw 做的 structural data 可參考[這裡](https://search.google.com/test/rich-results/result/r%2Femployer-ratings?id=q_rtY80xOtAXs8jHL-W0TA) )

## Screenshots  <!-- 選填，沒有就刪掉 -->

### before PR
![Screenshot 2025-03-08 at 10 59 17 PM](https://github.com/user-attachments/assets/444a8261-8635-4bc0-83d2-18d02c7e4beb)

### After PR
![Screenshot 2025-03-08 at 10 56 45 PM](https://github.com/user-attachments/assets/970e1c4d-6102-4e3a-819c-645eadbf1d2b)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 進到公司總覽頁面，view page source ，搜尋 `EmployerAggregateRating` 應該要有個 <script type="application/ld+json"> 包 json 
- [ ] 進到公司薪資、面試、評價列表，view page source ，搜尋 `EmployerAggregateRating` 應該找不到東西
- [ ] 職稱的各種列表頁 render 正常