### PR TITLE
feat: tweak website h1,h2,h3 structure

### DIFF
--- a/src/components/App/Footer/LinkItem.js
+++ b/src/components/App/Footer/LinkItem.js
@@ -3,14 +3,15 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import styles from './LinkItem.module.css';
 import { useDispatch } from 'react-redux';
+import { P } from 'common/base';
 
 const LinkItem = ({ title, items }) => {
   const dispatch = useDispatch();
   return (
     <div className={styles.linkItem}>
-      <h4 size="l" className={styles.heading}>
+      <P size="l" className={styles.heading}>
         {title}
-      </h4>
+      </P>
       {items.map(({ to, text, anchor }, index) => {
         if (typeof to === 'function') {
           const onClick = () => to({ dispatch });

--- a/src/components/App/Footer/index.js
+++ b/src/components/App/Footer/index.js
@@ -39,10 +39,10 @@ const Footer = () => (
     <section className={styles.header}>
       <Wrapper size="l" className={styles.inner}>
         <img src={GjLogo} className={styles.logo} alt="GoodJob" />
-        <h1 className={styles.heading}>職場透明化運動</h1>
-        <h5 className={styles.subheading}>
+        <div className={styles.heading}>職場透明化運動</div>
+        <div className={styles.subheading}>
           —— 共享薪水、面試情報，求職不再面議！
-        </h5>
+        </div>
         <span
           className={cn('fb-like', styles.fbLike)}
           data-href="https://www.facebook.com/goodjob.life/"
@@ -61,7 +61,7 @@ const Footer = () => (
         <LinkItem title="GoodJob" items={link3} />
       </section>
       <section className={styles.medias}>
-        <h4 className={styles.heading}>\ 感謝各大媒體採訪報導 /</h4>
+        <P className={styles.heading}>\ 感謝各大媒體採訪報導 /</P>
         <Link to="/about">
           <img src={MediasImg} alt="cheers yahoo 蘋果日報 數位時代" />
         </Link>

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -91,10 +91,10 @@ const CompanyAndJobTitleWrapper = ({
           data={generateBreadCrumbData({ pageType, pageName, tabType })}
         />
       </div>
-      <Heading style={{ color: '#000000', marginBottom: '30px' }}>
-        {pageName}
+      <div>
+        <Heading className={styles.title}>{pageName}</Heading>
         <AverageRating pageType={pageType} pageName={pageName} />
-      </Heading>
+      </div>
       <TabLinkGroup
         options={tabLinkOptions}
         style={{

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.module.css
@@ -1,5 +1,11 @@
 @value below-small, above-small from '../common/variables.module.css';
 
+.title {
+  color: black;
+  margin-bottom: 30px;
+  display: inline-block;
+}
+
 .fanPageBlock {
   margin-bottom: 60px;
 }
@@ -14,13 +20,14 @@
 
   @media (max-width: below-small) {
     display: flex;
-    margin-top: 16px;
+    margin-top: -16px;
+    margin-bottom: 40px;
   }
 
   @media (min-width: above-small) {
     display: inline-flex;
-    margin-left: 34px;
-    vertical-align: top;
+    margin-left: 25px;
+    vertical-align: text-top;
   }
 
   .averageRating {

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/ExperienceEntry.js
@@ -67,7 +67,7 @@ const ExperienceEntry = ({
         </div>
 
         <Heading
-          Tag="h2"
+          Tag="h3"
           size={size === 'l' ? 'sl' : 'sm'}
           className={styles.heading}
         >

--- a/src/components/CompanyAndJobTitle/Overview/SnippetBlock.js
+++ b/src/components/CompanyAndJobTitle/Overview/SnippetBlock.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 
 import EmptyView from '../EmptyView';
 import styles from './Overview.module.css';
+import { Heading } from 'common/base';
 
 const SnippetBlock = ({
   title,
@@ -16,7 +17,9 @@ const SnippetBlock = ({
   tabType,
 }) => (
   <div className={styles.snippet}>
-    <div className={styles.title}>{title}</div>
+    <Heading className={styles.title} Tag="h2">
+      {title}
+    </Heading>
     {isEmpty ? (
       <EmptyView tabType={tabType} pageName={pageName} pageType={pageType} />
     ) : (

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/InfoModal.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/InfoModal.js
@@ -6,6 +6,7 @@ import Question from 'common/icons/Question';
 import editorStyles from 'common/Editor.module.css';
 import Button from 'common/button/Button';
 import styles from './InfoModal.module.css';
+import { P } from 'common/base';
 
 const InfoModal = ({ isOpen, close, title, children }) => (
   <Modal
@@ -25,14 +26,14 @@ const InfoModal = ({ isOpen, close, title, children }) => (
         }}
       />
     </div>
-    <h2
+    <P
       style={{
         fontSize: '2rem',
         marginBottom: '47px',
       }}
     >
       {title}
-    </h2>
+    </P>
     <div className={cn(editorStyles.editor, 'alignLeft')}>
       {children}
       <div

--- a/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/ExperienceEntry.js
@@ -91,7 +91,7 @@ const ExperienceEntry = ({
         </div>
 
         <Heading
-          Tag="h2"
+          Tag="h3"
           size={size === 'l' ? 'sl' : 'sm'}
           className={styles.heading}
         >

--- a/src/components/ExperienceDetail/Article/SectionBlock.js
+++ b/src/components/ExperienceDetail/Article/SectionBlock.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { P } from 'common/base';
+import { Heading, P } from 'common/base';
 import styles from './SectionBlock.module.css';
 import OverallRating from 'common/OverallRating';
 
 const SectionBlock = ({ subtitle, content, rating }) => (
   <section>
     {subtitle && (
-      <P size="l" bold className={styles.heading}>
-        <div>{subtitle}</div>
+      <Heading size="sm" bold Tag="h2" className={styles.heading}>
+        {subtitle}
         {rating ? <OverallRating rating={rating} /> : null}
-      </P>
+      </Heading>
     )}
     <P size="l" className={styles.content}>
       {content}

--- a/src/components/ExperienceDetail/Heading/index.js
+++ b/src/components/ExperienceDetail/Heading/index.js
@@ -24,7 +24,7 @@ const formatType = type => {
 
 const ExperienceHeading = ({ experience, className }) => (
   <div className={cn(styles.heading, className)}>
-    <P Tag="h2" size="l" className={styles.badge}>
+    <P size="l" className={styles.badge}>
       {experience && formatType(experience.type)}
     </P>
     <Heading size="l">

--- a/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
+++ b/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
@@ -77,7 +77,7 @@ const MoreExperiencesBlock = ({ experience }) => {
 
   return (
     <div className={styles.container}>
-      <Heading className={styles.title} Tag={'h2'}>
+      <Heading className={styles.title} Tag="h2">
         更多{experience.originalCompanyName}、{experience.job_title.name}
         的面試及評價...
       </Heading>

--- a/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
+++ b/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
@@ -15,6 +15,7 @@ import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
 import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
 import Button from 'common/button/Button';
 import styles from './MoreExperiencesBlock.module.css';
+import { Heading } from 'common/base';
 
 const ExperienceEntry = props => {
   switch (props.data.type) {
@@ -76,10 +77,10 @@ const MoreExperiencesBlock = ({ experience }) => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>
+      <Heading className={styles.title} Tag={'h2'}>
         更多{experience.originalCompanyName}、{experience.job_title.name}
         的面試及評價...
-      </div>
+      </Heading>
       {experiences.map(e => (
         <ExperienceEntry
           key={e.id}

--- a/src/components/ExperienceDetail/ReactionZone/ReportInspectModal.js
+++ b/src/components/ExperienceDetail/ReactionZone/ReportInspectModal.js
@@ -31,7 +31,7 @@ const ReportInspectModal = ({ experienceId, isOpen, setIsOpen }) => {
       hasClose
       closableOnClickOutside
     >
-      <Heading size="l" marginBottomS center>
+      <Heading size="l" Tag="div" marginBottomS center>
         查看檢舉
       </Heading>
       {reportsState.loading && <Loader size="s" />}

--- a/src/components/TimeAndSalary/common/OvertimeBlock.js
+++ b/src/components/TimeAndSalary/common/OvertimeBlock.js
@@ -14,9 +14,11 @@ const formatNum = num => {
 
 const OvertimeBlock = ({ type, heading, statistics }) => (
   <div className={styles.overtimeBlock}>
-    <P Tag="h4" size="m" bold className={styles.heading}>
+    <P className={styles.heading}>
       {type === 'salary' ? <Coin2 /> : <Clock />}
-      <span>{heading}</span>
+      <P Tag="h3" size="m" bold>
+        {heading}
+      </P>
     </P>
     {statistics.count >= 5 ? (
       <div className={styles.item}>

--- a/src/components/common/LoginModal/index.js
+++ b/src/components/common/LoginModal/index.js
@@ -5,6 +5,7 @@ import Modal from 'common/Modal.js';
 import FacebookLoginButton from 'common/Login/FacebookLoginButton';
 import GoogleLoginButton from 'common/Login/GoogleLoginButton';
 import styles from './LoginModal.module.css';
+import { P } from 'common/base';
 
 const LoginModal = () => {
   const { isLoginModalDisplayed: isOpen, setLoginModalDisplayed } = useContext(
@@ -25,7 +26,7 @@ const LoginModal = () => {
   return (
     <Modal isOpen={isOpen} hasClose close={close} closableOnClickOutside>
       <div className={styles.container}>
-        <h2 style={{ fontSize: '1.4em', marginBottom: '34px' }}>登入</h2>
+        <P style={{ fontSize: '1.4em', marginBottom: '34px' }}>登入</P>
         <div className={styles.loginBtnContainer}>
           <FacebookLoginButton />
           <GoogleLoginButton />

--- a/src/components/common/PermissionBlock/LoginToUnlock.js
+++ b/src/components/common/PermissionBlock/LoginToUnlock.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import cn from 'classnames';
 import PropTypes from 'prop-types';
-import { Heading, P } from 'common/base';
+import { P } from 'common/base';
 import { useExperienceCount, useSalaryWorkTimeCount } from 'hooks/useCount';
 import styles from './PermissionBlock.module.css';
 import linkStyles from 'common/base/Link.module.css';
@@ -18,9 +18,9 @@ const LoginToUnlock = ({ to, onAuthenticatedClick }) => {
   return (
     <React.Fragment>
       <div className={styles.headingContainer}>
-        <Heading size="sl" Tag="h3" center>
+        <P size="xl" center>
           留下一筆資料，馬上{unlockedDescription}
-        </Heading>
+        </P>
       </div>
       <P size="l" className={styles.ctaText}>
         解鎖全站共 {timeAndSalaryCount + experienceCount} 筆薪資、面試資料

--- a/src/components/common/PermissionBlock/PermissionBlock.module.css
+++ b/src/components/common/PermissionBlock/PermissionBlock.module.css
@@ -9,7 +9,7 @@
     border: 1px solid #fcd406;
     border-radius: 4px;
     background-color: white;
-    padding: 50px 40px;
+    padding: 50px 30px;
     margin: auto;
   }
 }

--- a/src/components/common/base/Heading.js
+++ b/src/components/common/base/Heading.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 import styles from './Heading.module.css';
 
-const sizeOptions = ['l', 'm', 'sl', 'sm', 'sx'];
+const sizeOptions = ['l', 'm', 'sl', 'sm'];
 
 const Heading = ({
   Tag,

--- a/src/components/common/base/Heading.js
+++ b/src/components/common/base/Heading.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 import styles from './Heading.module.css';
 
-const sizeOptions = ['l', 'm', 'sl', 'sm'];
+const sizeOptions = ['l', 'm', 'sl', 'sm', 'sx'];
 
 const Heading = ({
   Tag,

--- a/src/components/common/base/Heading.module.css
+++ b/src/components/common/base/Heading.module.css
@@ -41,6 +41,10 @@
   }
 }
 
+.sx {
+  font-size: 1em;
+}
+
 .bold {
   font-weight: 700;
 }

--- a/src/components/common/base/P.js
+++ b/src/components/common/base/P.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import cn from 'classnames';
 import styles from './P.module.css';
 
-const sizeOptions = ['l', 'm', 's'];
+const sizeOptions = ['xl', 'l', 'm', 's'];
 
 const P = ({
   Tag,

--- a/src/components/common/base/P.module.css
+++ b/src/components/common/base/P.module.css
@@ -6,6 +6,15 @@
   text-align: center;
 }
 
+.xl {
+  font-size: 1.375em;
+  line-height: 1.4em;
+
+  strong {
+    font-weight: 700;
+  }
+}
+
 .l {
   font-size: 1.1em;
   line-height: 1.6em;


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

1. 讓網站的 h1, h2, h3 結構更符合 SEO 優化的需求
2. 更動的頁面與元件至少包含：
   a. 公司的總覽/薪資/面試/評價列表頁面
   b. 職稱的總覽/薪資/面試/評價列表頁面
   c. 職場經驗單篇
   d. footer

## Screenshots  <!-- 選填，沒有就刪掉 -->

使用 [Detail SEO chrome extension](https://detailed.com/extension/) 協助檢測

### 公司總覽頁
![Screenshot 2025-03-09 at 12 03 37 PM](https://github.com/user-attachments/assets/364d8d18-f981-4ef4-88f5-30c29aa361ad)

### 公司薪資列表頁
![Screenshot 2025-03-09 at 12 04 02 PM](https://github.com/user-attachments/assets/d1bc3b0c-5d8c-4fd1-8c9f-9080cbb88269)

### 公司面試列表頁
![Screenshot 2025-03-09 at 12 04 19 PM](https://github.com/user-attachments/assets/72fdb81a-ea39-48de-b283-0434e2426d3c)

### 公司評價列表頁
![Screenshot 2025-03-09 at 12 04 50 PM](https://github.com/user-attachments/assets/78e4464d-f26a-4097-a415-2e2c980dab2e)

### 經驗單篇頁
![Screenshot 2025-03-09 at 12 03 25 PM](https://github.com/user-attachments/assets/ddf0000c-6788-4c3d-af9f-896dc357e8a8)

## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 公司的總覽/薪資/面試/評價列表頁 正常 render、手機版 UI 正常
- [ ] 職稱的總覽/薪資/面試/評價列表頁 正常 render、手機版 UI 正常
- [ ] 單篇頁面正常 render 、手機版 UI 正常