### PR TITLE
[面試/經驗/單篇] 統一資料位置

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -461,6 +461,7 @@ export const queryCompanyInterviewExperiences = ({
       ),
     );
 
+    // Update state.experiences which is the source of truth for all experiences
     data.interviewExperiencesResult.interviewExperiences.forEach(e => {
       dispatch(setExperience(e.id, getFetched(e)));
     });
@@ -525,6 +526,7 @@ export const queryCompanyWorkExperiences = ({
 
     dispatch(setWorkExperiences(companyName, getFetched(workExperiencesData)));
 
+    // Update state.experiences which is the source of truth for all experiences
     data.workExperiencesResult.workExperiences.forEach(e => {
       dispatch(setExperience(e.id, getFetched(e)));
     });

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -167,14 +167,6 @@ export const queryCompanyOverview = (
     };
 
     dispatch(setOverview(companyName, getFetched(overviewData)));
-
-    data.interviewExperiencesResult.interviewExperiences.forEach(e => {
-      dispatch(setExperience(e.id, getFetched(e)));
-    });
-
-    data.workExperiencesResult.workExperiences.forEach(e => {
-      dispatch(setExperience(e.id, getFetched(e)));
-    });
   } catch (error) {
     if (isGraphqlError(error)) {
       dispatch(setOverview(companyName, getError(error)));

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -30,6 +30,7 @@ import {
   getCompanyEsgSalaryData,
   queryCompanyOverviewStatistics as queryCompanyOverviewStatisticsApi,
 } from 'apis/company';
+import { setExperience } from './experience';
 
 export const SET_RATING_STATISTICS = '@@COMPANY/SET_RATING_STATISTICS';
 export const SET_OVERVIEW = '@@COMPANY/SET_OVERVIEW';
@@ -166,6 +167,14 @@ export const queryCompanyOverview = (
     };
 
     dispatch(setOverview(companyName, getFetched(overviewData)));
+
+    data.interviewExperiencesResult.interviewExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
+
+    data.workExperiencesResult.workExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
   } catch (error) {
     if (isGraphqlError(error)) {
       dispatch(setOverview(companyName, getError(error)));
@@ -455,6 +464,10 @@ export const queryCompanyInterviewExperiences = ({
         getFetched(interviewExperiencesData),
       ),
     );
+
+    data.interviewExperiencesResult.interviewExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
   } catch (error) {
     dispatch(setInterviewExperiences(companyName, getError(error)));
     throw error;
@@ -511,6 +524,10 @@ export const queryCompanyWorkExperiences = ({
     };
 
     dispatch(setWorkExperiences(companyName, getFetched(workExperiencesData)));
+
+    data.workExperiencesResult.workExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
   } catch (error) {
     dispatch(setWorkExperiences(companyName, getError(error)));
   }

--- a/src/actions/experience.js
+++ b/src/actions/experience.js
@@ -25,7 +25,7 @@ export const SET_RELATED_EXPERIENCES = '@@EXPERIENCE/SET_RELATED_EXPERIENCES';
 export const SET_POPULAR_EXPERIENCES = '@@EXPERIENCE/SET_POPULAR_EXPERIENCES';
 
 // state is related to experienceId
-const setExperience = (experienceId, box) => ({
+export const setExperience = (experienceId, box) => ({
   type: SET_EXPERIENCE,
   experienceId,
   box,

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -335,6 +335,7 @@ export const queryJobTitleInterviewExperiences = ({
       setInterviewExperiences(jobTitle, getFetched(interviewExperiencesyData)),
     );
 
+    // Update state.experiences which is the source of truth for all experiences
     data.interviewExperiencesResult.interviewExperiences.forEach(e => {
       dispatch(setExperience(e.id, getFetched(e)));
     });
@@ -398,6 +399,7 @@ export const queryJobTitleWorkExperiences = ({
 
     dispatch(setWorkExperiences(jobTitle, getFetched(workExperiencesData)));
 
+    // Update state.experiences which is the source of truth for all experiences
     data.workExperiencesResult.workExperiences.forEach(e => {
       dispatch(setExperience(e.id, getFetched(e)));
     });

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -24,6 +24,7 @@ import {
   getJobTitleWorkExperiences,
   queryJobTitlesApi,
 } from 'apis/jobTitle';
+import { setExperience } from './experience';
 
 export const SET_OVERVIEW = '@@JOB_TITLE/SET_OVERVIEW';
 export const SET_OVERVIEW_STATISTICS = '@@JOB_TITLE/SET_OVERVIEW_STATISTICS';
@@ -120,6 +121,14 @@ export const queryJobTitleOverview = (
     };
 
     dispatch(setOverview(jobTitle, getFetched(overviewData)));
+
+    data.interviewExperiencesResult.interviewExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
+
+    data.workExperiencesResult.workExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
   } catch (error) {
     if (isGraphqlError(error)) {
       dispatch(setOverview(jobTitle, getError(error)));
@@ -329,6 +338,10 @@ export const queryJobTitleInterviewExperiences = ({
     dispatch(
       setInterviewExperiences(jobTitle, getFetched(interviewExperiencesyData)),
     );
+
+    data.interviewExperiencesResult.interviewExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
   } catch (error) {
     dispatch(setInterviewExperiences(jobTitle, getError(error)));
   }
@@ -384,6 +397,10 @@ export const queryJobTitleWorkExperiences = ({
     };
 
     dispatch(setWorkExperiences(jobTitle, getFetched(workExperiencesData)));
+
+    data.workExperiencesResult.workExperiences.forEach(e => {
+      dispatch(setExperience(e.id, getFetched(e)));
+    });
   } catch (error) {
     dispatch(setWorkExperiences(jobTitle, getError(error)));
   }

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -121,14 +121,6 @@ export const queryJobTitleOverview = (
     };
 
     dispatch(setOverview(jobTitle, getFetched(overviewData)));
-
-    data.interviewExperiencesResult.interviewExperiences.forEach(e => {
-      dispatch(setExperience(e.id, getFetched(e)));
-    });
-
-    data.workExperiencesResult.workExperiences.forEach(e => {
-      dispatch(setExperience(e.id, getFetched(e)));
-    });
   } catch (error) {
     if (isGraphqlError(error)) {
       dispatch(setOverview(jobTitle, getError(error)));

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -29,11 +29,40 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year
@@ -59,11 +88,40 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year
@@ -281,11 +339,40 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year
@@ -319,11 +406,40 @@ export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -1,4 +1,8 @@
-import { experiencePartialGql } from './experience';
+import {
+  experiencePartialGql,
+  interviewExperiencePartialGql,
+  workExperiencesPartialGql,
+} from './experience';
 
 export const queryCompanyRatingStatisticsGql = /* GraphQL */ `
   query($companyName: String!) {
@@ -29,27 +33,14 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
         count
         interviewExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          averageSectionRating
+          ${interviewExperiencePartialGql()}
         }
       }
       workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
         count
         workExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          recommend_to_others
-          averageSectionRating
+          ${workExperiencesPartialGql()}
         }
       }
       salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {
@@ -247,13 +238,7 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
         count
         interviewExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          averageSectionRating
+          ${interviewExperiencePartialGql()}
         }
       }
     }
@@ -268,14 +253,7 @@ export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
         count
         workExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          recommend_to_others
-          averageSectionRating
+          ${workExperiencesPartialGql()}
         }
       }
     }

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -32,15 +32,62 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
       interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
         count
         interviewExperiences {
-          ${experiencePartialGql}
-          ${interviewExperiencePartialGql()}
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          averageSectionRating
         }
       }
       workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
         count
         workExperiences {
-          ${experiencePartialGql}
-          ${workExperiencesPartialGql()}
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          recommend_to_others
+          averageSectionRating
         }
       }
       salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -1,3 +1,5 @@
+import { experiencePartialGql } from './experience';
+
 export const queryCompanyRatingStatisticsGql = /* GraphQL */ `
   query($companyName: String!) {
     company(name: $companyName) {
@@ -26,57 +28,11 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
       interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
         count
         interviewExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           averageSectionRating
@@ -85,57 +41,11 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
       workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
         count
         workExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           recommend_to_others
@@ -336,57 +246,11 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
       ) {
         count
         interviewExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           averageSectionRating
@@ -403,57 +267,11 @@ export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
       workExperiencesResult(jobTitle: $jobTitle, start: $start, limit: $limit) {
         count
         workExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           recommend_to_others

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -1,53 +1,57 @@
+export const experiencePartialGql = /* GraphQL */ `
+  id
+  type
+  originalCompanyName
+  reportCount
+  reports {
+    id
+    reasonCategory
+    reason
+    createdAt
+  }
+  company {
+    name
+    salary_work_time_statistics {
+      job_average_salaries {
+        job_title {
+          name
+        }
+        average_salary {
+          type
+          amount
+        }
+        data_count
+      }
+    }
+  }
+  job_title {
+    name
+    salary_distribution {
+      bins {
+        data_count
+        range {
+          type
+          from
+          to
+        }
+      }
+    }
+  }
+  region
+  experience_in_year
+  education
+  salary {
+    type
+    amount
+  }
+  title
+  created_at
+`;
+
 export const queryExperienceGql = /* GraphQL */ `
   query($id: ID!) {
     experience(id: $id) {
-      id
-      type
-      originalCompanyName
-      reportCount
-      reports {
-        id
-        reasonCategory
-        reason
-        createdAt
-      }
-      company {
-        name
-        salary_work_time_statistics {
-          job_average_salaries {
-            job_title {
-              name
-            }
-            average_salary {
-              type
-              amount
-            }
-            data_count
-          }
-        }
-      }
-      job_title {
-        name
-        salary_distribution {
-          bins {
-            data_count
-            range {
-              type
-              from
-              to
-            }
-          }
-        }
-      }
-      region
-      experience_in_year
-      education
-      salary {
-        type
-        amount
-      }
-      title
-      created_at
+      ${experiencePartialGql}
 
       __typename
 

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -48,6 +48,45 @@ export const experiencePartialGql = /* GraphQL */ `
   created_at
 `;
 
+export const interviewExperiencePartialGql = ({
+  sectionTitleKey = 'subtitle',
+} = {}) => /* GraphQL */ `
+  sections {
+    ${sectionTitleKey}: subtitle
+    content
+    rating
+  }
+  interview_time {
+    year
+    month
+  }
+  interview_result
+  averageSectionRating
+  interview_qas {
+    question
+    answer
+  }
+  interview_sensitive_questions
+  reply_count
+  like_count
+`;
+
+export const workExperiencesPartialGql = ({
+  sectionTitleKey = 'subtitle',
+} = {}) => /* GraphQL */ `
+  sections {
+    ${sectionTitleKey}: subtitle
+    content
+    aspect
+    rating
+  }
+  week_work_time
+  recommend_to_others
+  averageSectionRating
+  reply_count
+  like_count
+`;
+
 export const queryExperienceGql = /* GraphQL */ `
   query($id: ID!) {
     experience(id: $id) {
@@ -56,34 +95,13 @@ export const queryExperienceGql = /* GraphQL */ `
       __typename
 
       ... on InterviewExperience {
-        sections {
-          interview_subtitle: subtitle
-          content
-          rating
-        }
-        interview_time {
-          year
-          month
-        }
-        interview_result
-        averageSectionRating
-        interview_qas {
-          question
-          answer
-        }
-        interview_sensitive_questions
+        ${interviewExperiencePartialGql({
+          sectionTitleKey: 'interview_subtitle',
+        })}
       }
 
       ... on WorkExperience {
-        sections {
-          work_subtitle: subtitle
-          content
-          aspect
-          rating
-        }
-        week_work_time
-        recommend_to_others
-        averageSectionRating
+        ${workExperiencesPartialGql({ sectionTitleKey: 'work_subtitle' })}
       }
     }
   }

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -1,3 +1,5 @@
+import { experiencePartialGql } from './experience';
+
 export const queryJobTitles = /* GraphQL */ `
   query($key: String!) {
     job_titles(query: $key, page: 0) {
@@ -18,57 +20,11 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
       interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
         count
         interviewExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           averageSectionRating
@@ -77,57 +33,11 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
       workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
         count
         workExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           recommend_to_others
@@ -285,57 +195,11 @@ export const getJobTitleInterviewExperiencesQuery = /* GraphQL */ `
       ) {
         count
         interviewExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           averageSectionRating
@@ -356,57 +220,11 @@ export const getJobTitleWorkExperiencesQuery = /* GraphQL */ `
       ) {
         count
         workExperiences {
-          id
-          type
-          originalCompanyName
-          reportCount
-          reports {
-            id
-            reasonCategory
-            reason
-            createdAt
-          }
-          company {
-            name
-            salary_work_time_statistics {
-              job_average_salaries {
-                job_title {
-                  name
-                }
-                average_salary {
-                  type
-                  amount
-                }
-                data_count
-              }
-            }
-          }
-          job_title {
-            name
-            salary_distribution {
-              bins {
-                data_count
-                range {
-                  type
-                  from
-                  to
-                }
-              }
-            }
-          }
-          region
-          experience_in_year
-          education
-          salary {
-            amount
-            type
-          }
-          title
+          ${experiencePartialGql}
           sections {
             subtitle
             content
           }
-          created_at
           reply_count
           like_count
           recommend_to_others

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -1,4 +1,8 @@
-import { experiencePartialGql } from './experience';
+import {
+  experiencePartialGql,
+  interviewExperiencePartialGql,
+  workExperiencesPartialGql,
+} from './experience';
 
 export const queryJobTitles = /* GraphQL */ `
   query($key: String!) {
@@ -21,27 +25,14 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
         count
         interviewExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          averageSectionRating
+          ${interviewExperiencePartialGql()}
         }
       }
       workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
         count
         workExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          recommend_to_others
-          averageSectionRating
+          ${workExperiencesPartialGql()}
         }
       }
       salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {
@@ -196,13 +187,7 @@ export const getJobTitleInterviewExperiencesQuery = /* GraphQL */ `
         count
         interviewExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          averageSectionRating
+          ${interviewExperiencePartialGql()}
         }
       }
     }
@@ -221,14 +206,7 @@ export const getJobTitleWorkExperiencesQuery = /* GraphQL */ `
         count
         workExperiences {
           ${experiencePartialGql}
-          sections {
-            subtitle
-            content
-          }
-          reply_count
-          like_count
-          recommend_to_others
-          averageSectionRating
+          ${workExperiencesPartialGql()}
         }
       }
     }

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -21,11 +21,40 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year
@@ -51,11 +80,40 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year
@@ -230,11 +288,40 @@ export const getJobTitleInterviewExperiencesQuery = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year
@@ -272,11 +359,40 @@ export const getJobTitleWorkExperiencesQuery = /* GraphQL */ `
           id
           type
           originalCompanyName
+          reportCount
+          reports {
+            id
+            reasonCategory
+            reason
+            createdAt
+          }
           company {
             name
+            salary_work_time_statistics {
+              job_average_salaries {
+                job_title {
+                  name
+                }
+                average_salary {
+                  type
+                  amount
+                }
+                data_count
+              }
+            }
           }
           job_title {
             name
+            salary_distribution {
+              bins {
+                data_count
+                range {
+                  type
+                  from
+                  to
+                }
+              }
+            }
           }
           region
           experience_in_year

--- a/src/graphql/jobTitle.js
+++ b/src/graphql/jobTitle.js
@@ -24,15 +24,62 @@ export const queryJobTitleOverviewGql = /* GraphQL */ `
       interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
         count
         interviewExperiences {
-          ${experiencePartialGql}
-          ${interviewExperiencePartialGql()}
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          averageSectionRating
         }
       }
       workExperiencesResult(start: 0, limit: $workExperiencesLimit) {
         count
         workExperiences {
-          ${experiencePartialGql}
-          ${workExperiencesPartialGql()}
+          id
+          type
+          originalCompanyName
+          company {
+            name
+          }
+          job_title {
+            name
+          }
+          region
+          experience_in_year
+          education
+          salary {
+            amount
+            type
+          }
+          title
+          sections {
+            subtitle
+            content
+          }
+          created_at
+          reply_count
+          like_count
+          recommend_to_others
+          averageSectionRating
         }
       }
       salaryWorkTimesResult(start: 0, limit: $salaryWorkTimesLimit) {

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -36,9 +36,8 @@ const useInterviewExperiencesBoxSelector = companyName => {
         state,
       );
       if (isFetched(box) && box.data) {
-        // Get full experience data from state.experiences if available
-        // This ensures we have the most up-to-date data, since state.experiences
-        // is the source of truth and may contain edits/updates made after the initial fetch
+        // Get experience data from state.experiences, which serves
+        // as the source of truth of experiences.
         const data = {
           ...box.data,
           interviewExperiences: box.data.interviewExperiences.map(

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -22,14 +22,28 @@ import {
   useSearchTextFromQuery,
 } from 'components/CompanyAndJobTitle/Searchbar';
 import { pageFromQuerySelector } from 'selectors/routing/page';
+import { isFetched, getFetched } from 'utils/fetchBox';
+import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
 
 const useInterviewExperiencesBoxSelector = companyName => {
   return useCallback(
     state => {
-      const company = companyInterviewExperiencesBoxSelectorByName(companyName)(
+      const box = companyInterviewExperiencesBoxSelectorByName(companyName)(
         state,
       );
-      return company;
+      if (isFetched(box) && box.data) {
+        // Get full experience data from state.experiences if available
+        // This ensures we have the most up-to-date data, since state.experiences
+        // is the source of truth and may contain edits/updates made after the initial fetch
+        const data = {
+          ...box.data,
+          interviewExperiences: box.data.interviewExperiences.map(
+            e => experienceBoxSelectorAtId(e.id)(state).data || e,
+          ),
+        };
+        return getFetched(data);
+      }
+      return box;
     },
     [companyName],
   );

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -20,12 +20,26 @@ import {
   searchTextFromQuerySelector,
   useSearchTextFromQuery,
 } from 'components/CompanyAndJobTitle/Searchbar';
+import { isFetched, getFetched } from 'utils/fetchBox';
+import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
 
 const useWorkExperiencesBoxSelector = pageName => {
   return useCallback(
     state => {
-      const company = workExperiencesBoxSelectorByName(pageName)(state);
-      return company;
+      const box = workExperiencesBoxSelectorByName(pageName)(state);
+      if (isFetched(box)) {
+        // Get full experience data from state.experiences if available
+        // This ensures we have the most up-to-date data, since state.experiences
+        // is the source of truth and may contain edits/updates made after the initial fetch
+        const data = {
+          ...box.data,
+          workExperiences: box.data.workExperiences.map(
+            e => experienceBoxSelectorAtId(e.id)(state).data || e,
+          ),
+        };
+        return getFetched(data);
+      }
+      return box;
     },
     [pageName],
   );

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -32,9 +32,8 @@ const useWorkExperiencesBoxSelector = pageName => {
     state => {
       const box = workExperiencesBoxSelectorByName(pageName)(state);
       if (isFetched(box)) {
-        // Get full experience data from state.experiences if available
-        // This ensures we have the most up-to-date data, since state.experiences
-        // is the source of truth and may contain edits/updates made after the initial fetch
+        // Get experience data from state.experiences, which serves
+        // as the source of truth of experiences.
         const data = {
           ...box.data,
           workExperiences: box.data.workExperiences.map(

--- a/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -31,9 +31,8 @@ const useInterviewExperiencesBoxSelector = jobTitle => {
         state,
       );
       if (isFetched(box)) {
-        // Get full experience data from state.experiences if available
-        // This ensures we have the most up-to-date data, since state.experiences
-        // is the source of truth and may contain edits/updates made after the initial fetch
+        // Get experience data from state.experiences, which serves
+        // as the source of truth of experiences.
         const data = {
           ...box.data,
           interviewExperiences: box.data.interviewExperiences.map(

--- a/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -17,14 +17,28 @@ import {
   searchTextFromQuerySelector,
   useSearchTextFromQuery,
 } from 'components/CompanyAndJobTitle/Searchbar';
+import { isFetched, getFetched } from 'utils/fetchBox';
+import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
 
 const useInterviewExperiencesBoxSelector = jobTitle => {
   return useCallback(
     state => {
-      const job = jobTitleInterviewExperiencesBoxSelectorByName(jobTitle)(
+      const box = jobTitleInterviewExperiencesBoxSelectorByName(jobTitle)(
         state,
       );
-      return job;
+      if (isFetched(box)) {
+        // Get full experience data from state.experiences if available
+        // This ensures we have the most up-to-date data, since state.experiences
+        // is the source of truth and may contain edits/updates made after the initial fetch
+        const data = {
+          ...box.data,
+          interviewExperiences: box.data.interviewExperiences.map(
+            e => experienceBoxSelectorAtId(e.id)(state).data || e,
+          ),
+        };
+        return getFetched(data);
+      }
+      return box;
     },
     [jobTitle],
   );

--- a/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
@@ -29,9 +29,8 @@ const useWorkExperiencesBoxSelector = pageName => {
     state => {
       const box = workExperiencesBoxSelectorByName(pageName)(state);
       if (isFetched(box)) {
-        // Get full experience data from state.experiences if available
-        // This ensures we have the most up-to-date data, since state.experiences
-        // is the source of truth and may contain edits/updates made after the initial fetch
+        // Get experience data from state.experiences, which serves
+        // as the source of truth of experiences.
         const data = {
           ...box.data,
           workExperiences: box.data.workExperiences.map(

--- a/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
@@ -17,12 +17,26 @@ import {
   searchTextFromQuerySelector,
   useSearchTextFromQuery,
 } from 'components/CompanyAndJobTitle/Searchbar';
+import { isFetched, getFetched } from 'utils/fetchBox';
+import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
 
 const useWorkExperiencesBoxSelector = pageName => {
   return useCallback(
     state => {
-      const jobTitle = workExperiencesBoxSelectorByName(pageName)(state);
-      return jobTitle;
+      const box = workExperiencesBoxSelectorByName(pageName)(state);
+      if (isFetched(box)) {
+        // Get full experience data from state.experiences if available
+        // This ensures we have the most up-to-date data, since state.experiences
+        // is the source of truth and may contain edits/updates made after the initial fetch
+        const data = {
+          ...box.data,
+          workExperiences: box.data.workExperiences.map(
+            e => experienceBoxSelectorAtId(e.id)(state).data || e,
+          ),
+        };
+        return getFetched(data);
+      }
+      return box;
     },
     [pageName],
   );


### PR DESCRIPTION
Close #1530 

## 這個 PR 是？
修復巢狀經驗的問題，統一經驗資料在 Redux store 中的位置。

- 將所有 GraphQL 的經驗資料存副本到 Redux store 中，避免資料重複獲取與不一致性。
- 使用 `setExperience` action 處理並統一存儲經驗資料。
- 修復公司頁面與職稱頁面之間不一致的 GraphQL query，統一資料結構。

## Screenshots

https://github.com/user-attachments/assets/6cbe70a9-289d-45e3-95e9-438e3f036d8f




## 我應該如何手動測試？
- 訪問公司頁面
  - [x] 確認經驗資料正確顯示 http://localhost:3000/companies/%E5%AE%9C%E5%AE%B6%E5%AE%B6%E5%B1%85%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/work-experiences
  - [x] 確認經驗資料的檢舉功能正常 http://localhost:3000/companies/%E5%AE%9C%E5%AE%B6%E5%AE%B6%E5%B1%85%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/work-experiences
  - [x] 確認面試資料正確顯示 http://localhost:3000/companies/%E5%AE%9C%E5%AE%B6%E5%AE%B6%E5%B1%85%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/interview-experiences
  - [x] 確認面試資料的檢舉功能正常 http://localhost:3000/companies/%E5%AE%9C%E5%AE%B6%E5%AE%B6%E5%B1%85%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/interview-experiences
- 訪問職位頁面
  - [x] 確認經驗資料正確顯示 http://localhost:3000/job-titles/%E8%A1%8C%E6%94%BF%E4%BA%BA%E5%93%A1/work-experiences
  - [x] 確認經驗資料的檢舉功能正常 http://localhost:3000/job-titles/%E8%A1%8C%E6%94%BF%E4%BA%BA%E5%93%A1/work-experiences
  - [x] 確認面試資料正確顯示 http://localhost:3000/job-titles/%E8%A1%8C%E6%94%BF%E4%BA%BA%E5%93%A1/interview-experiences
  - [x] 確認面試資料的檢舉功能正常 http://localhost:3000/job-titles/%E8%A1%8C%E6%94%BF%E4%BA%BA%E5%93%A1/interview-experiences
- 單篇經驗
  - [x] 確認單篇經驗正確顯示 http://localhost:3000/experiences/67a5bee99575a7d592773f4d
  - [x] 檢查單篇經驗的檢舉功能正常 http://localhost:3000/experiences/67a5bee99575a7d592773f4d
