### PR TITLE
Draft PR，討論新資料通知 isSubscribed 為 false

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -152,9 +152,6 @@ export const queryCompanyOverview = (
       salaryWorkTimesLimit: SALARY_WORK_TIMES_LIMIT,
     });
 
-    console.log('API response data', data);
-    console.log('API isSubscribed', data?.isSubscribed);
-
     // Not found case
     if (data == null) {
       return dispatch(setOverview(companyName, getFetched(data)));
@@ -172,9 +169,6 @@ export const queryCompanyOverview = (
       isSubscribed: data.isSubscribed,
       id: data.id,
     };
-
-    console.log('overviewData', overviewData);
-    console.log('overviewData isSubscribed', overviewData.isSubscribed);
 
     dispatch(setOverview(companyName, getFetched(overviewData)));
   } catch (error) {

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -29,7 +29,9 @@ import {
   getCompanyTopNJobTitles,
   getCompanyEsgSalaryData,
   queryCompanyOverviewStatistics as queryCompanyOverviewStatisticsApi,
+  createCompanySubscriptionApi,
 } from 'apis/company';
+import { tokenSelector } from 'selectors/authSelector';
 
 export const SET_RATING_STATISTICS = '@@COMPANY/SET_RATING_STATISTICS';
 export const SET_OVERVIEW = '@@COMPANY/SET_OVERVIEW';
@@ -149,6 +151,9 @@ export const queryCompanyOverview = (
       salaryWorkTimesLimit: SALARY_WORK_TIMES_LIMIT,
     });
 
+    console.log('API response data', data);
+    console.log('API isSubscribed', data?.isSubscribed);
+
     // Not found case
     if (data == null) {
       return dispatch(setOverview(companyName, getFetched(data)));
@@ -163,7 +168,12 @@ export const queryCompanyOverview = (
       interviewExperiencesCount: data.interviewExperiencesResult.count,
       workExperiences: data.workExperiencesResult.workExperiences,
       workExperiencesCount: data.workExperiencesResult.count,
+      isSubscribed: data.isSubscribed,
+      id: data.id,
     };
+
+    console.log('overviewData', overviewData);
+    console.log('overviewData isSubscribed', overviewData.isSubscribed);
 
     dispatch(setOverview(companyName, getFetched(overviewData)));
   } catch (error) {
@@ -514,4 +524,14 @@ export const queryCompanyWorkExperiences = ({
   } catch (error) {
     dispatch(setWorkExperiences(companyName, getError(error)));
   }
+};
+
+export const createCompanySubscription = ({ companyId }) => (_, getState) => {
+  const state = getState();
+  const token = tokenSelector(state);
+
+  return createCompanySubscriptionApi({ companyId, token }).catch(error => {
+    console.error(error);
+    throw error;
+  });
 };

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -166,7 +166,6 @@ export const queryCompanyOverview = (
       interviewExperiencesCount: data.interviewExperiencesResult.count,
       workExperiences: data.workExperiencesResult.workExperiences,
       workExperiencesCount: data.workExperiencesResult.count,
-      isSubscribed: data.isSubscribed,
       id: data.id,
     };
 

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -281,6 +281,7 @@ export const queryCompanyTimeAndSalary = (
 
     const timeAndSalaryData = {
       name: data.name,
+      id: data.id,
       jobTitle,
       start,
       limit,
@@ -452,6 +453,7 @@ export const queryCompanyInterviewExperiences = ({
 
     const interviewExperiencesData = {
       name: data.name,
+      id: data.id,
       jobTitle,
       start,
       limit,
@@ -514,6 +516,7 @@ export const queryCompanyWorkExperiences = ({
 
     const workExperiencesData = {
       name: data.name,
+      id: data.id,
       jobTitle,
       start,
       limit,

--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -29,7 +29,8 @@ import {
   getCompanyTopNJobTitles,
   getCompanyEsgSalaryData,
   queryCompanyOverviewStatistics as queryCompanyOverviewStatisticsApi,
-  createCompanySubscriptionApi,
+  subscribeCompanyApi,
+  unsubscribeCompanyApi,
 } from 'apis/company';
 import { tokenSelector } from 'selectors/authSelector';
 
@@ -526,11 +527,21 @@ export const queryCompanyWorkExperiences = ({
   }
 };
 
-export const createCompanySubscription = ({ companyId }) => (_, getState) => {
+export const subscribeCompany = ({ companyId }) => (_, getState) => {
   const state = getState();
   const token = tokenSelector(state);
 
-  return createCompanySubscriptionApi({ companyId, token }).catch(error => {
+  return subscribeCompanyApi({ companyId, token }).catch(error => {
+    console.error(error);
+    throw error;
+  });
+};
+
+export const unsubscribeCompany = ({ companyId }) => (_, getState) => {
+  const state = getState();
+  const token = tokenSelector(state);
+
+  return unsubscribeCompanyApi({ companyId, token }).catch(error => {
     console.error(error);
     throw error;
   });

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -11,6 +11,7 @@ import {
   getCompanyTopNJobTitlesQuery,
   getCompanyEsgSalaryDataQuery,
   queryCompanyOverviewStatisticsQuery,
+  createCompanySubscriptionGql,
 } from 'graphql/company';
 
 export const queryCompanyRatingStatisticsApi = ({ companyName }) =>
@@ -98,4 +99,11 @@ export const queryCompaniesApi = ({ start, limit }) =>
   graphqlClient({
     query: queryCompaniesHavingDataGql,
     variables: { start, limit },
+  });
+
+export const createCompanySubscriptionApi = ({ companyId, token }) =>
+  graphqlClient({
+    query: createCompanySubscriptionGql,
+    token,
+    variables: { input: { companyId } },
   });

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -11,7 +11,9 @@ import {
   getCompanyTopNJobTitlesQuery,
   getCompanyEsgSalaryDataQuery,
   queryCompanyOverviewStatisticsQuery,
-  createCompanySubscriptionGql,
+  queryCompanyIsSubscribedGql,
+  subscribeCompanyGql,
+  unsubscribeCompanyGql,
 } from 'graphql/company';
 
 export const queryCompanyRatingStatisticsApi = ({ companyName }) =>
@@ -101,9 +103,26 @@ export const queryCompaniesApi = ({ start, limit }) =>
     variables: { start, limit },
   });
 
-export const createCompanySubscriptionApi = ({ companyId, token }) =>
+export const queryCompanySubscription = async ({ companyName, token }) => {
+  const data = await graphqlClient({
+    query: queryCompanyIsSubscribedGql,
+    token,
+    variables: { companyName },
+  });
+
+  return data.company.isSubscribed;
+};
+
+export const subscribeCompanyApi = ({ companyId, token }) =>
   graphqlClient({
-    query: createCompanySubscriptionGql,
+    query: subscribeCompanyGql,
+    token,
+    variables: { input: { companyId } },
+  });
+
+export const unsubscribeCompanyApi = ({ companyId, token }) =>
+  graphqlClient({
+    query: unsubscribeCompanyGql,
     token,
     variables: { input: { companyId } },
   });

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -103,7 +103,7 @@ export const queryCompaniesApi = ({ start, limit }) =>
     variables: { start, limit },
   });
 
-export const queryCompanySubscription = async ({ companyName, token }) => {
+export const queryCompanyIsSubscribed = async ({ companyName, token }) => {
   const data = await graphqlClient({
     query: queryCompanyIsSubscribedGql,
     token,

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { toPairs, compose, map } from 'ramda';
 import Heading from 'common/base/Heading';
@@ -16,6 +17,7 @@ const CompanyAndJobTitleWrapper = ({
   pageType,
   pageName,
   tabType,
+  boxSelector,
 }) => {
   const tabLinkOptions = useMemo(
     () =>
@@ -33,6 +35,11 @@ const CompanyAndJobTitleWrapper = ({
     [pageType, pageName],
   );
 
+  const box = useSelector(boxSelector || (state => null));
+  console.log('box isSubscribed', box?.data?.isSubscribed);
+  console.log('box data', box?.data);
+  console.log('box selector', boxSelector);
+
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -43,7 +50,10 @@ const CompanyAndJobTitleWrapper = ({
       <div>
         <div className={styles.titleContainer}>
           <Heading className={styles.title}>{pageName}</Heading>
-          <SubscribeNotificationButton />
+          <SubscribeNotificationButton
+            hasSubscribed={box?.data?.isSubscribed}
+            companyId={box?.data?.id}
+          />
         </div>
         <StatisticsCard pageType={pageType} pageName={pageName} />
       </div>
@@ -60,6 +70,7 @@ const CompanyAndJobTitleWrapper = ({
 };
 
 CompanyAndJobTitleWrapper.propTypes = {
+  boxSelector: PropTypes.func,
   children: PropTypes.node,
   pageName: PropTypes.string.isRequired,
   pageType: PropTypes.string.isRequired,

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -11,6 +11,7 @@ import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
 import SubscribeNotificationButton from 'components/CompanyAndJobTitle/SubscribeNotificationButton';
 import StatisticsCard from 'components/CompanyAndJobTitle/StatisticsCard';
+import { isFetched } from 'utils/fetchBox';
 
 const CompanyAndJobTitleWrapper = ({
   children,
@@ -19,6 +20,8 @@ const CompanyAndJobTitleWrapper = ({
   tabType,
   boxSelector,
 }) => {
+  const box = useSelector(boxSelector);
+  const { id: companyId, name: companyName } = box.data || {};
   const tabLinkOptions = useMemo(
     () =>
       compose(
@@ -35,11 +38,6 @@ const CompanyAndJobTitleWrapper = ({
     [pageType, pageName],
   );
 
-  const box = useSelector(boxSelector || (state => null));
-  console.log('box isSubscribed', box?.data?.isSubscribed);
-  console.log('box data', box?.data);
-  console.log('box selector', boxSelector);
-
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -51,8 +49,9 @@ const CompanyAndJobTitleWrapper = ({
         <div className={styles.titleContainer}>
           <Heading className={styles.title}>{pageName}</Heading>
           <SubscribeNotificationButton
-            hasSubscribed={box?.data?.isSubscribed}
-            companyId={box?.data?.id}
+            companyName={companyName}
+            companyId={companyId}
+            isFetched={isFetched(box)}
           />
         </div>
         <StatisticsCard pageType={pageType} pageName={pageName} />

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
@@ -19,6 +19,7 @@ const InterviewExperiences = ({
     pageType={pageType}
     pageName={pageName}
     tabType={tabType}
+    boxSelector={boxSelector}
   >
     <Searchbar pageType={pageType} tabType={tabType} />
     <PageBoxRenderer

--- a/src/components/CompanyAndJobTitle/Overview/index.js
+++ b/src/components/CompanyAndJobTitle/Overview/index.js
@@ -19,6 +19,7 @@ const Overview = ({
     pageType={pageType}
     pageName={pageName}
     tabType={tabType}
+    boxSelector={boxSelector}
   >
     <PageBoxRenderer
       pageType={pageType}

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.js
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.js
@@ -1,25 +1,60 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import BellWhiteImage from 'common/icons/bellWhite.svg';
 import BellBlackImage from 'common/icons/bellBlack.svg';
 import PropTypes from 'prop-types';
 import styles from './SubscribeNotificationButton.module.css';
 import cn from 'classnames';
 import { useDispatch } from 'react-redux';
-import { createCompanySubscription } from 'actions/company';
+import { subscribeCompany, unsubscribeCompany } from 'actions/company';
+import useQueryCompanyIsSubscribed from 'components/ExperienceDetail/hooks/useQueryCompanyIsSubscribed';
+import Skeleton from 'react-loading-skeleton';
 
-const SubscribeNotificationButton = ({ hasSubscribed = false, companyId }) => {
+const SubscribeNotificationButton = ({ isFetched, companyName, companyId }) => {
   const dispatch = useDispatch();
+  const [
+    { loading, value },
+    queryCompanyIsSubscribed,
+  ] = useQueryCompanyIsSubscribed(companyName);
+  const [isSubscribed, setIsSubscribed] = useState(false);
 
-  console.log('companyId', companyId);
+  useEffect(() => {
+    if (!loading) {
+      setIsSubscribed(value);
+    }
+  }, [loading, value]);
+
+  const handleSubscribeCompany = useCallback(async () => {
+    setIsSubscribed(true);
+    await dispatch(subscribeCompany({ companyId }));
+  }, [dispatch, companyId]);
+
+  const handleUnsubscribeCompany = useCallback(async () => {
+    setIsSubscribed(false);
+    await dispatch(unsubscribeCompany({ companyId }));
+  }, [dispatch, companyId]);
+
+  const handleToggleSubscribeCompany = useCallback(async () => {
+    if (isSubscribed) {
+      await handleUnsubscribeCompany();
+    } else {
+      await handleSubscribeCompany();
+    }
+  }, [isSubscribed, handleSubscribeCompany, handleUnsubscribeCompany]);
+
+  useEffect(() => {
+    queryCompanyIsSubscribed();
+  }, [queryCompanyIsSubscribed]);
+
+  if (!isFetched || loading) {
+    return <Skeleton width={144} height={30} borderRadius={5} />;
+  }
 
   return (
     <button
       className={cn(styles.buttonContainer, {
-        [styles.subscribed]: hasSubscribed,
+        [styles.subscribed]: isSubscribed,
       })}
-      onClick={() => {
-        dispatch(createCompanySubscription({ companyId }));
-      }}
+      onClick={handleToggleSubscribeCompany}
     >
       <div className={styles.bellContainer}>
         <img
@@ -33,14 +68,15 @@ const SubscribeNotificationButton = ({ hasSubscribed = false, companyId }) => {
           alt="notificationBlackBell"
         />
       </div>
-      <div>{hasSubscribed ? '已訂閱新資料通知' : '有新資料時通知我'}</div>
+      <div>{isSubscribed ? '已訂閱新資料通知' : '有新資料時通知我'}</div>
     </button>
   );
 };
 
 SubscribeNotificationButton.propTypes = {
   companyId: PropTypes.string.isRequired,
-  hasSubscribed: PropTypes.bool,
+  companyName: PropTypes.string.isRequired,
+  isFetched: PropTypes.bool.isRequired,
 };
 
 export default SubscribeNotificationButton;

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.js
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.js
@@ -4,13 +4,22 @@ import BellBlackImage from 'common/icons/bellBlack.svg';
 import PropTypes from 'prop-types';
 import styles from './SubscribeNotificationButton.module.css';
 import cn from 'classnames';
+import { useDispatch } from 'react-redux';
+import { createCompanySubscription } from 'actions/company';
 
-const SubscribeNotificationButton = ({ hasSubscribed = false } = {}) => {
+const SubscribeNotificationButton = ({ hasSubscribed = false, companyId }) => {
+  const dispatch = useDispatch();
+
+  console.log('companyId', companyId);
+
   return (
     <button
       className={cn(styles.buttonContainer, {
         [styles.subscribed]: hasSubscribed,
       })}
+      onClick={() => {
+        dispatch(createCompanySubscription({ companyId }));
+      }}
     >
       <div className={styles.bellContainer}>
         <img
@@ -30,6 +39,7 @@ const SubscribeNotificationButton = ({ hasSubscribed = false } = {}) => {
 };
 
 SubscribeNotificationButton.propTypes = {
+  companyId: PropTypes.string.isRequired,
   hasSubscribed: PropTypes.bool,
 };
 

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.js
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.js
@@ -74,8 +74,8 @@ const SubscribeNotificationButton = ({ isFetched, companyName, companyId }) => {
 };
 
 SubscribeNotificationButton.propTypes = {
-  companyId: PropTypes.string.isRequired,
-  companyName: PropTypes.string.isRequired,
+  companyId: PropTypes.string,
+  companyName: PropTypes.string,
   isFetched: PropTypes.bool.isRequired,
 };
 

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/index.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/index.js
@@ -29,6 +29,7 @@ const TimeAndSalary = ({
     pageType={pageType}
     pageName={pageName}
     tabType={tabType}
+    boxSelector={boxSelector}
   >
     {pageType === PAGE_TYPE.COMPANY && (
       <BoxRenderer

--- a/src/components/CompanyAndJobTitle/WorkExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/index.js
@@ -18,6 +18,7 @@ const WorkExperiences = ({
     pageType={pageType}
     pageName={pageName}
     tabType={tabType}
+    boxSelector={boxSelector}
   >
     <Searchbar pageType={pageType} tabType={tabType} />
     <PageBoxRenderer

--- a/src/components/ExperienceDetail/hooks/useQueryCompanyIsSubscribed.js
+++ b/src/components/ExperienceDetail/hooks/useQueryCompanyIsSubscribed.js
@@ -1,0 +1,13 @@
+import { useAsyncFn } from 'react-use';
+import { useToken } from 'hooks/auth';
+import { queryCompanyIsSubscribed } from 'apis/company';
+
+const useQueryCompanyIsSubscribed = companyName => {
+  const token = useToken();
+  return useAsyncFn(() => queryCompanyIsSubscribed({ companyName, token }), [
+    companyName,
+    token,
+  ]);
+};
+
+export default useQueryCompanyIsSubscribed;

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -367,9 +367,25 @@ export const queryCompaniesHavingDataGql = /* GraphQL */ `
   }
 `;
 
-export const createCompanySubscriptionGql = /* GraphQL */ `
+export const queryCompanyIsSubscribedGql = /* GraphQL */ `
+  query($companyName: String!) {
+    company(name: $companyName) {
+      isSubscribed
+    }
+  }
+`;
+
+export const subscribeCompanyGql = /* GraphQL */ `
   mutation SubscribeCompany($input: SubscribeCompanyInput!) {
     subscribeCompany(input: $input) {
+      success
+    }
+  }
+`;
+
+export const unsubscribeCompanyGql = /* GraphQL */ `
+  mutation UnsubscribeCompany($input: UnsubscribeCompanyInput!) {
+    unsubscribeCompany(input: $input) {
       success
     }
   }

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -22,7 +22,6 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
     $salaryWorkTimesLimit: Int!
   ) {
     company(name: $companyName) {
-      isSubscribed
       id
       name
       interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
@@ -154,7 +153,6 @@ export const queryCompanyOverviewStatisticsQuery = /* GraphQL */ `
 export const getCompanyTimeAndSalaryQuery = /* GraphQL */ `
   query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
     company(name: $companyName) {
-      isSubscribed
       id
       name
       salaryWorkTimesResult(jobTitle: $jobTitle, start: $start, limit: $limit) {
@@ -274,7 +272,6 @@ export const getCompanyEsgSalaryDataQuery = /* GraphQL */ `
 export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
   query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
     company(name: $companyName) {
-      isSubscribed
       id
       name
       interviewExperiencesResult(
@@ -318,7 +315,6 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
 export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
   query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
     company(name: $companyName) {
-      isSubscribed
       id
       name
       workExperiencesResult(jobTitle: $jobTitle, start: $start, limit: $limit) {

--- a/src/graphql/company.js
+++ b/src/graphql/company.js
@@ -22,6 +22,8 @@ export const queryCompanyOverviewGql = /* GraphQL */ `
     $salaryWorkTimesLimit: Int!
   ) {
     company(name: $companyName) {
+      isSubscribed
+      id
       name
       interviewExperiencesResult(start: 0, limit: $interviewExperiencesLimit) {
         count
@@ -152,6 +154,8 @@ export const queryCompanyOverviewStatisticsQuery = /* GraphQL */ `
 export const getCompanyTimeAndSalaryQuery = /* GraphQL */ `
   query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
     company(name: $companyName) {
+      isSubscribed
+      id
       name
       salaryWorkTimesResult(jobTitle: $jobTitle, start: $start, limit: $limit) {
         count
@@ -270,6 +274,8 @@ export const getCompanyEsgSalaryDataQuery = /* GraphQL */ `
 export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
   query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
     company(name: $companyName) {
+      isSubscribed
+      id
       name
       interviewExperiencesResult(
         jobTitle: $jobTitle
@@ -312,6 +318,8 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
 export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
   query($companyName: String!, $jobTitle: String, $start: Int!, $limit: Int!) {
     company(name: $companyName) {
+      isSubscribed
+      id
       name
       workExperiencesResult(jobTitle: $jobTitle, start: $start, limit: $limit) {
         count
@@ -356,5 +364,13 @@ export const queryCompaniesHavingDataGql = /* GraphQL */ `
       dataCount
     }
     companiesHavingDataCount
+  }
+`;
+
+export const createCompanySubscriptionGql = /* GraphQL */ `
+  mutation SubscribeCompany($input: SubscribeCompanyInput!) {
+    subscribeCompany(input: $input) {
+      success
+    }
   }
 `;


### PR DESCRIPTION
Close #1522 

## 這個 PR 是？
先開 draft PR 做討論，解決完問題後，補上 PR description，想討論的是：

用 graphQL playground 訂閱成功後，再 query company 資料 `isSubscribed: true`
但專案中 subscribeCompany 訂閱成功了，但專案中撈 company 資料 `isSubscribed: false`，也重新 `npm run start`、重整多次。

不確定是我程式面哪邊沒寫好？

## Screenshots  <!-- 選填，沒有就刪掉 -->
- 專案中 subscribeCompany 的 payload: `66418025d166e4b97c1e1ff0` (精誠資訊)
![image](https://github.com/user-attachments/assets/45e29b87-734c-4e07-b693-15355f293d04)
- 專案中 subscribeCompany 的 response 顯示 `success: true`，訂閱成功
![image](https://github.com/user-attachments/assets/de7659e9-b888-466a-a8c1-b3e04587cd4a)
- 專案中訂閱成功後，query company 的資料，`isSubscribed: false`，也重新 `npm run start`、重整多次
![image](https://github.com/user-attachments/assets/2af4bfe3-ae47-48f2-a7bb-a3a9f7900fe3)
- GraphQL playground，訂閱成功且有回傳 `isSubscribed: true`
![image](https://github.com/user-attachments/assets/c24834d7-6708-4956-99c7-ee85cfad7f4d)