### PR TITLE
fix: prevent setState if unmounted

### DIFF
--- a/src/components/ExperienceDetail/hooks/useLoginFlow.js
+++ b/src/components/ExperienceDetail/hooks/useLoginFlow.js
@@ -4,7 +4,7 @@ import { useLogin } from 'hooks/login';
 import LoginModalContext from 'contexts/LoginModalContext';
 
 const useLoginFlow = callback => {
-  const isMounted = useMountedState();
+  const getIsMounted = useMountedState();
   const [state, setState] = useState('init');
   const [isLoggedIn] = useLogin();
   const { isLoginModalDisplayed, setLoginModalDisplayed } = useContext(
@@ -25,10 +25,10 @@ const useLoginFlow = callback => {
     if (state === 'submitting') {
       setState('submitting_check_api');
       callback().then(() => {
-        isMounted() && setState('init');
+        getIsMounted() && setState('init');
       });
     }
-  }, [callback, state, isMounted]);
+  }, [callback, state, getIsMounted]);
 
   useEffect(() => {
     if (state === 'submitting_open_modal' && !isLoginModalDisplayed) {

--- a/src/components/ExperienceDetail/hooks/useLoginFlow.js
+++ b/src/components/ExperienceDetail/hooks/useLoginFlow.js
@@ -1,8 +1,10 @@
 import { useState, useEffect, useCallback, useMemo, useContext } from 'react';
+import { useMountedState } from 'react-use';
 import { useLogin } from 'hooks/login';
 import LoginModalContext from 'contexts/LoginModalContext';
 
 const useLoginFlow = callback => {
+  const isMounted = useMountedState();
   const [state, setState] = useState('init');
   const [isLoggedIn] = useLogin();
   const { isLoginModalDisplayed, setLoginModalDisplayed } = useContext(
@@ -23,10 +25,10 @@ const useLoginFlow = callback => {
     if (state === 'submitting') {
       setState('submitting_check_api');
       callback().then(() => {
-        setState('init');
+        isMounted() && setState('init');
       });
     }
-  }, [callback, state]);
+  }, [callback, state, isMounted]);
 
   useEffect(() => {
     if (state === 'submitting_open_modal' && !isLoginModalDisplayed) {


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

這裡提到的
https://github.com/goodjoblife/GoodJobShare/pull/1542#issuecomment-2851343908

![image](https://github.com/user-attachments/assets/84232ace-87d8-42f8-b02c-51980f60a87d)

當按下 `SubscribeNotificationButton` 時，會有 callback (處理登入流程 與 call mutation api) 執行，

--> 當 callback 正在執行時，如果切換 tab (i.e. routing component change)，就會造成 `SubscribeNotificationButton` unmount

--> 當 unmount 時，callback 結束時，會嘗試 setState 來重設 LoginFlow 的流程

--> 但此時 LoginFlow 的 setState 已經失效，所以執行的話，會發生 memory leak

## 測試與修正

https://github.com/user-attachments/assets/436b14b6-0f9e-41be-aec8-9afd3a907184

修改一下 callback, 將 isMounted() 印出
(1) 按下 SubscribeNotificationButton，印出 true
(2) 按下 SubscribeNotificationButton，快速切換 tab，印出 false

(2) 就是 unmount 發生


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 將這個 PR patch 到 #1542，測試看看是否還會發生