### PR TITLE
fix: 新資料通知，手機版 style

### DIFF
--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.module.css
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.module.css
@@ -32,22 +32,22 @@
     }
   }
 
-  &.subscribed,
-  &:not(.subscribed):hover {
+  &.subscribed {
     background-color: #fceea7;
-
-    .bellWhite {
-      opacity: 0;
-    }
-
-    .bellBlack {
-      opacity: 1;
-    }
-
-    transform: scale(1.03);
+    transform: none;
   }
 
-  &.subscribed {
-    transform: none;
+  @media (hover: hover) and (pointer: fine) {
+    &:not(.subscribed):hover {
+      background-color: #fceea7;
+      transform: scale(1.03);
+
+      .bellWhite {
+        opacity: 0;
+      }
+      .bellBlack {
+        opacity: 1;
+      }
+    }
   }
 }

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.module.css
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.module.css
@@ -35,6 +35,13 @@
   &.subscribed {
     background-color: #fceea7;
     transform: none;
+
+    .bellWhite {
+      opacity: 0;
+    }
+    .bellBlack {
+      opacity: 1;
+    }
   }
 
   @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->
修正 chrome 瀏覽器上，手機版 hover style

## Screenshots  <!-- 選填，沒有就刪掉 -->
- 修正前 Chrome 手機版，取消訂閱後維持 hover 狀態時的 style
![2025-04-27 17 43 25](https://github.com/user-attachments/assets/dd74b77f-a48d-4cb2-b9f3-c3ef5c5c0c82)
- 修正後
![2025-05-13 22 26 18](https://github.com/user-attachments/assets/3489c236-a30d-460f-9afc-471b8118d89d)

## 我應該如何手動測試？ <!-- 必填 -->
用 chrome 手機版點選訂閱公司按鈕