### PR TITLE
[公司職稱頁面] 移除 Canonical url 的 page

### DIFF
--- a/src/components/CompanyAndJobTitle/InterviewExperiences/Helmet.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/Helmet.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { generatePath } from 'react-router';
-import qs from 'qs';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
 import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
@@ -32,9 +31,7 @@ const CompanyInterviewExperienceHelmet = ({
   const path = generatePath('/companies/:companyName/interview-experiences', {
     companyName,
   });
-  const search =
-    page > 1 ? qs.stringify({ p: page }, { addQueryPrefix: true }) : '';
-  const url = formatCanonicalPath(`${path}${search}`);
+  const url = formatCanonicalPath(path);
 
   return (
     <Helmet>
@@ -79,9 +76,7 @@ const JobTitleInterviewExperienceHelmet = ({ jobTitle, page, totalCount }) => {
   const path = generatePath('/job-titles/:jobTitle/interview-experiences', {
     jobTitle,
   });
-  const search =
-    page > 1 ? qs.stringify({ p: page }, { addQueryPrefix: true }) : '';
-  const url = formatCanonicalPath(`${path}${search}`);
+  const url = formatCanonicalPath(path);
 
   return (
     <Helmet>

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/Helmet.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/Helmet.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactHelmet from 'react-helmet';
 import { generatePath } from 'react-router';
-import qs from 'qs';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { IMG_HOST, SITE_NAME } from 'constants/helmetData';
 import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
@@ -32,9 +31,7 @@ const CompanySalaryWorkTimeHelmet = ({
   const path = generatePath('/companies/:companyName/salary-work-times', {
     companyName,
   });
-  const search =
-    page > 1 ? qs.stringify({ p: page }, { addQueryPrefix: true }) : '';
-  const url = formatCanonicalPath(`${path}${search}`);
+  const url = formatCanonicalPath(path);
 
   return (
     <ReactHelmet>
@@ -83,9 +80,7 @@ const JobTitleSalaryWorkTimeHelmet = ({ jobTitle, page, totalCount }) => {
   const path = generatePath('/job-titles/:jobTitle/salary-work-times', {
     jobTitle,
   });
-  const search =
-    page > 1 ? qs.stringify({ p: page }, { addQueryPrefix: true }) : '';
-  const url = formatCanonicalPath(`${path}${search}`);
+  const url = formatCanonicalPath(path);
 
   return (
     <ReactHelmet>

--- a/src/components/CompanyAndJobTitle/WorkExperiences/Helmet.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/Helmet.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { generatePath } from 'react-router';
-import qs from 'qs';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
 import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
@@ -22,9 +21,7 @@ const CompanyWorkExperienceHelmet = ({ companyName, page, totalCount }) => {
   const path = generatePath('/companies/:companyName/work-experiences', {
     companyName,
   });
-  const search =
-    page > 1 ? qs.stringify({ p: page }, { addQueryPrefix: true }) : '';
-  const url = formatCanonicalPath(`${path}${search}`);
+  const url = formatCanonicalPath(path);
 
   return (
     <Helmet>
@@ -64,9 +61,7 @@ const JobTitleWorkExperienceHelmet = ({ jobTitle, page, totalCount }) => {
   const path = generatePath('/job-titles/:jobTitle/work-experiences', {
     jobTitle,
   });
-  const search =
-    page > 1 ? qs.stringify({ p: page }, { addQueryPrefix: true }) : '';
-  const url = formatCanonicalPath(`${path}${search}`);
+  const url = formatCanonicalPath(path);
 
   return (
     <Helmet>


### PR DESCRIPTION
Close #1519

## 這個 PR 是？ <!-- 必填 -->

將公司職稱頁面的 canonical url 無視 page

## Screenshots  <!-- 選填，沒有就刪掉 -->

|Before|
|-|
|![截圖 2025-05-13 晚上11 52 28](https://github.com/user-attachments/assets/2fb603f3-a0dd-49fc-a62c-aba9bee98e83)|
|After|
|![截圖 2025-05-13 晚上11 52 07](https://github.com/user-attachments/assets/db676b53-b871-4f4a-85b2-db438421d2fd)|


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 檢查此 `p=3` 的頁面是否 canonical url 不包含 `?p=3` http://localhost:3000/companies/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8(%E5%8F%B0%E7%A9%8D%E9%9B%BB)%20TSMC/work-experiences?p=3