### PR TITLE
feat: 公司/職稱的 面試/評價列表頁面 h1, h2, h3 調整

### DIFF
--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -10,7 +10,11 @@ import TabLinkGroup from 'common/TabLinkGroup';
 import styles from './CompanyAndJobTitleWrapper.module.css';
 import SubscribeNotificationButton from 'components/CompanyAndJobTitle/SubscribeNotificationButton';
 import StatisticsCard from 'components/CompanyAndJobTitle/StatisticsCard';
-import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import {
+  pageType as PAGE_TYPE,
+  tabType as TAB_TYPE,
+  tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
+} from 'constants/companyJobTitle';
 
 const CompanyAndJobTitleWrapper = ({
   children,
@@ -34,6 +38,17 @@ const CompanyAndJobTitleWrapper = ({
     [pageType, pageName],
   );
 
+  const pageH1 = useMemo(() => {
+    switch (tabType) {
+      case TAB_TYPE.WORK_EXPERIENCE:
+      case TAB_TYPE.INTERVIEW_EXPERIENCE:
+      case TAB_TYPE.TIME_AND_SALARY:
+        return `${pageName} ${TAB_TYPE_DETAIL_TRANSLATION[tabType]}`;
+      default:
+        return pageName;
+    }
+  }, [pageName, tabType]);
+
   return (
     <div>
       <div style={{ marginBottom: '20px' }}>
@@ -43,7 +58,7 @@ const CompanyAndJobTitleWrapper = ({
       </div>
       <div>
         <div className={styles.titleContainer}>
-          <Heading className={styles.title}>{pageName}</Heading>
+          <Heading className={styles.title}>{pageH1}</Heading>
           {pageType === PAGE_TYPE.COMPANY && (
             <SubscribeNotificationButton companyName={pageName} />
           )}

--- a/src/components/CompanyAndJobTitle/Experience.js
+++ b/src/components/CompanyAndJobTitle/Experience.js
@@ -37,20 +37,15 @@ const useTracePreviewRef = ({ experience }) => {
   return ref;
 };
 
-const Experience = ({ experience, pageType, tabType, subTitleTag }) => {
-  const [, , canViewPublishId] = usePermission();
-  const [messageExpanded, setMessageExpanded] = useState(false);
-  const ref = useTracePreviewRef({ experience });
-
-  /**
-   * If in company's work/interview experience listing page, only show "${job title} ${data type}"
-   *  - For example, under 台積電 面試經驗列表，title 僅會顯示 "軟體工程師 面試經驗"
-   *
-   * If in job title's work/interview experience listing page, only show "${company name} ${data type}"
-   *  - For example, under 軟體工程師 面試經驗列表，title 僅會顯示 "台積電 面試經驗"
-   */
-  const title = useMemo(() => {
-    console.log({ experience, pageType, tabType });
+/**
+ * If in company's work/interview experience listing page, only show "${job title} ${data type}"
+ *  - For example, under 台積電 面試經驗列表，title 僅會顯示 "軟體工程師 面試經驗"
+ *
+ * If in job title's work/interview experience listing page, only show "${company name} ${data type}"
+ *  - For example, under 軟體工程師 面試經驗列表，title 僅會顯示 "台積電 面試經驗"
+ */
+const useExperienceTitle = ({ experience, pageType, tabType }) =>
+  useMemo(() => {
     let str;
     if (
       pageType === PAGE_TYPE.COMPANY &&
@@ -77,6 +72,13 @@ const Experience = ({ experience, pageType, tabType, subTitleTag }) => {
         return str;
     }
   }, [experience, pageType, tabType]);
+
+const Experience = ({ experience, pageType, tabType, subTitleTag }) => {
+  const [, , canViewPublishId] = usePermission();
+  const [messageExpanded, setMessageExpanded] = useState(false);
+  const ref = useTracePreviewRef({ experience });
+
+  const title = useExperienceTitle({ experience, pageType, tabType });
 
   return (
     <div ref={ref}>

--- a/src/components/CompanyAndJobTitle/Experience.js
+++ b/src/components/CompanyAndJobTitle/Experience.js
@@ -42,6 +42,13 @@ const Experience = ({ experience, pageType, tabType }) => {
   const [messageExpanded, setMessageExpanded] = useState(false);
   const ref = useTracePreviewRef({ experience });
 
+  /**
+   * If in company's work/interview experience listing page, only show "${job title} ${data type}"
+   *  - For example, under 台積電 面試經驗列表，title 僅會顯示 "軟體工程師 面試經驗"
+   *
+   * If in job title's work/interview experience listing page, only show "${company name} ${data type}"
+   *  - For example, under 軟體工程師 面試經驗列表，title 僅會顯示 "台積電 面試經驗"
+   */
   const title = useMemo(() => {
     let str;
     if (

--- a/src/components/CompanyAndJobTitle/Experience.js
+++ b/src/components/CompanyAndJobTitle/Experience.js
@@ -37,7 +37,7 @@ const useTracePreviewRef = ({ experience }) => {
   return ref;
 };
 
-const Experience = ({ experience, pageType, tabType }) => {
+const Experience = ({ experience, pageType, tabType, subTitleTag }) => {
   const [, , canViewPublishId] = usePermission();
   const [messageExpanded, setMessageExpanded] = useState(false);
   const ref = useTracePreviewRef({ experience });
@@ -50,6 +50,7 @@ const Experience = ({ experience, pageType, tabType }) => {
    *  - For example, under 軟體工程師 面試經驗列表，title 僅會顯示 "台積電 面試經驗"
    */
   const title = useMemo(() => {
+    console.log({ experience, pageType, tabType });
     let str;
     if (
       pageType === PAGE_TYPE.COMPANY &&
@@ -94,6 +95,7 @@ const Experience = ({ experience, pageType, tabType }) => {
         }
         onClickMsgButton={() => setMessageExpanded(expended => !expended)}
         originalLink={`/experiences/${experience.id}`}
+        subTitleTag={subTitleTag}
       />
       {messageExpanded && (
         <Wrapper size="s">
@@ -107,6 +109,7 @@ const Experience = ({ experience, pageType, tabType }) => {
 Experience.propTypes = {
   experience: PropTypes.object.isRequired,
   pageType: PropTypes.string.isRequired,
+  subTitleTag: PropTypes.string,
   tabType: PropTypes.string.isRequired,
 };
 

--- a/src/components/CompanyAndJobTitle/Experience.js
+++ b/src/components/CompanyAndJobTitle/Experience.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
 import { useWindowScroll, useWindowSize } from 'react-use';
 import PropTypes from 'prop-types';
 import usePermission from 'hooks/usePermission';
@@ -10,6 +10,11 @@ import * as VISIBILITY from 'components/ExperienceDetail/Article/visibility';
 import styles from './Experience.module.css';
 import { formatSimpleDate } from 'utils/dateUtil';
 import { CONTENT_TYPE, ACTION } from 'constants/viewLog';
+import {
+  pageType as PAGE_TYPE,
+  tabType as TAB_TYPE,
+  tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
+} from 'constants/companyJobTitle';
 
 const useTracePreviewRef = ({ experience }) => {
   const { height: windowHeight } = useWindowSize();
@@ -32,15 +37,43 @@ const useTracePreviewRef = ({ experience }) => {
   return ref;
 };
 
-const Experience = ({ experience }) => {
+const Experience = ({ experience, pageType, tabType }) => {
   const [, , canViewPublishId] = usePermission();
   const [messageExpanded, setMessageExpanded] = useState(false);
   const ref = useTracePreviewRef({ experience });
 
+  const title = useMemo(() => {
+    let str;
+    if (
+      pageType === PAGE_TYPE.COMPANY &&
+      experience &&
+      experience.job_title &&
+      experience.job_title.name
+    ) {
+      str = experience.job_title.name;
+    } else if (
+      pageType === PAGE_TYPE.JOB_TITLE &&
+      experience &&
+      experience.company &&
+      experience.company.name
+    ) {
+      str = experience.company.name;
+    } else {
+      str = experience.title;
+    }
+    switch (tabType) {
+      case TAB_TYPE.INTERVIEW_EXPERIENCE:
+      case TAB_TYPE.WORK_EXPERIENCE:
+        return `${str} ${TAB_TYPE_DETAIL_TRANSLATION[tabType]}`;
+      default:
+        return str;
+    }
+  }, [experience, pageType, tabType]);
+
   return (
     <div ref={ref}>
       <Heading size="m" Tag="h2" bold className={styles.title}>
-        {experience.title}{' '}
+        {title}{' '}
         <span className={styles.timestamp}>
           {formatSimpleDate(new Date(experience.created_at))}
         </span>
@@ -66,6 +99,8 @@ const Experience = ({ experience }) => {
 
 Experience.propTypes = {
   experience: PropTypes.object.isRequired,
+  pageType: PropTypes.string.isRequired,
+  tabType: PropTypes.string.isRequired,
 };
 
 export default Experience;

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
@@ -36,7 +36,12 @@ const InterviewExperiences = ({
     <Section Tag="main" paddingBottom>
       {data.map(d => (
         <div key={d.id} className={styles.experience}>
-          <Experience experience={d} pageType={pageType} tabType={tabType} />
+          <Experience
+            experience={d}
+            pageType={pageType}
+            tabType={tabType}
+            subTitleTag={'h3'}
+          />
         </div>
       ))}
       <Pagination

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/InterviewExperiences.js
@@ -36,7 +36,7 @@ const InterviewExperiences = ({
     <Section Tag="main" paddingBottom>
       {data.map(d => (
         <div key={d.id} className={styles.experience}>
-          <Experience experience={d} />
+          <Experience experience={d} pageType={pageType} tabType={tabType} />
         </div>
       ))}
       <Pagination

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -7,7 +7,11 @@ import SnippetBlock from './SnippetBlock';
 import WorkingHourTable from '../TimeAndSalary/WorkingHourTable';
 import WorkExperienceEntry from '../WorkExperiences/ExperienceEntry';
 import InterviewExperienceEntry from '../InterviewExperiences/ExperienceEntry';
-import { tabType as TAB_TYPE, generateTabURL } from 'constants/companyJobTitle';
+import {
+  tabType as TAB_TYPE,
+  tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
+  generateTabURL,
+} from 'constants/companyJobTitle';
 import SummaryBlock from './SummaryBlock';
 import usePermission from 'hooks/usePermission';
 import BoxRenderer from '../StatusRenderer';
@@ -30,7 +34,7 @@ const Overview = ({
   return (
     <Section Tag="main" paddingBottom>
       <SnippetBlock
-        title="薪水&加班狀況"
+        title={TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]}
         linkText={`查看 ${salaryWorkTimesCount} 筆完整的薪水、加班數據資料 >>`}
         linkTo={generateTabURL({
           pageType,
@@ -65,8 +69,10 @@ const Overview = ({
         />
       </SnippetBlock>
       <SnippetBlock
-        title="評價"
-        linkText={`查看 ${workExperiencesCount} 篇完整的評價 >>`}
+        title={TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.WORK_EXPERIENCE]}
+        linkText={`查看 ${workExperiencesCount} 篇完整的 ${
+          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.WORK_EXPERIENCE]
+        } >>`}
         linkTo={generateTabURL({
           pageType,
           pageName,
@@ -87,8 +93,10 @@ const Overview = ({
         ))}
       </SnippetBlock>
       <SnippetBlock
-        title="面試心得"
-        linkText={`查看 ${interviewExperiencesCount} 篇完整的面試心得 >>`}
+        title={TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.INTERVIEW_EXPERIENCE]}
+        linkText={`查看 ${interviewExperiencesCount} 篇完整的${
+          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.INTERVIEW_EXPERIENCE]
+        } >>`}
         linkTo={generateTabURL({
           pageType,
           pageName,

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/Helmet.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/Helmet.js
@@ -4,7 +4,11 @@ import ReactHelmet from 'react-helmet';
 import { generatePath } from 'react-router';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { IMG_HOST, SITE_NAME } from 'constants/helmetData';
-import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import {
+  pageType as PAGE_TYPE,
+  tabType as TAB_TYPE,
+  tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
+} from 'constants/companyJobTitle';
 
 const CompanySalaryWorkTimeHelmet = ({
   companyName,
@@ -15,8 +19,12 @@ const CompanySalaryWorkTimeHelmet = ({
   // title
   const title =
     page === 1
-      ? `${companyName} 薪水&加班狀況`
-      : `${companyName} 薪水&加班狀況 - 第${page}頁`;
+      ? `${companyName} ${
+          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]
+        }`
+      : `${companyName} ${
+          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]
+        } - 第${page}頁`;
 
   // description
   let description = `目前還沒有${companyName}的薪水、加班狀況資料。分享你的薪水、加班狀況，一起讓職場更透明。`;
@@ -68,7 +76,9 @@ CompanySalaryWorkTimeHelmet.propTypes = {
 
 const JobTitleSalaryWorkTimeHelmet = ({ jobTitle, page, totalCount }) => {
   // title
-  const title = `${jobTitle} 薪水&加班狀況 - 第${page}頁`;
+  const title = `${jobTitle} ${
+    TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]
+  } - 第${page}頁`;
 
   // description
   let description = `目前還沒有${jobTitle}的薪水、加班狀況資料。分享你的薪水、加班狀況，一起讓職場更透明。`;

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
@@ -34,7 +34,7 @@ const WorkExperiences = ({
     <Section Tag="main" paddingBottom>
       {data.map(d => (
         <div key={d.id} className={styles.experience}>
-          <Experience experience={d} />
+          <Experience experience={d} pageType={pageType} tabType={tabType} />
         </div>
       ))}
       <Pagination

--- a/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/WorkExperiences.js
@@ -34,7 +34,12 @@ const WorkExperiences = ({
     <Section Tag="main" paddingBottom>
       {data.map(d => (
         <div key={d.id} className={styles.experience}>
-          <Experience experience={d} pageType={pageType} tabType={tabType} />
+          <Experience
+            experience={d}
+            pageType={pageType}
+            tabType={tabType}
+            subTitleTag={'h3'}
+          />
         </div>
       ))}
       <Pagination

--- a/src/components/ExperienceDetail/Article/SectionBlock.js
+++ b/src/components/ExperienceDetail/Article/SectionBlock.js
@@ -4,10 +4,10 @@ import { Heading, P } from 'common/base';
 import styles from './SectionBlock.module.css';
 import OverallRating from 'common/OverallRating';
 
-const SectionBlock = ({ subtitle, content, rating }) => (
+const SectionBlock = ({ subtitle, content, rating, subTitleTag = 'h2' }) => (
   <section>
     {subtitle && (
-      <Heading size="sm" bold Tag="h2" className={styles.heading}>
+      <Heading size="sm" bold Tag={subTitleTag} className={styles.heading}>
         {subtitle}
         {rating ? <OverallRating rating={rating} /> : null}
       </Heading>
@@ -21,6 +21,7 @@ const SectionBlock = ({ subtitle, content, rating }) => (
 SectionBlock.propTypes = {
   content: PropTypes.string.isRequired,
   rating: PropTypes.number,
+  subTitleTag: PropTypes.string,
   subtitle: PropTypes.string,
 };
 

--- a/src/components/ExperienceDetail/Article/index.js
+++ b/src/components/ExperienceDetail/Article/index.js
@@ -55,7 +55,7 @@ ChildrenOnMaskBottom.propTypes = {
   visibility: PropTypes.string.isRequired,
 };
 
-const Sections = ({ experience, visibility, onExpand }) => {
+const Sections = ({ experience, visibility, onExpand, subTitleTag }) => {
   let toHide = false;
   let currentTotalWords = 0;
   const totalWords = countSectionWords(experience.sections);
@@ -90,12 +90,21 @@ const Sections = ({ experience, visibility, onExpand }) => {
                     />
                   }
                 >
-                  <SectionBlock subtitle={subtitle} content={newContent} />
+                  <SectionBlock
+                    subtitle={subtitle}
+                    content={newContent}
+                    subTitleTag={subTitleTag}
+                  />
                 </GradientMask>
               );
             }
             return (
-              <SectionBlock key={idx} subtitle={subtitle} content={content} />
+              <SectionBlock
+                key={idx}
+                subtitle={subtitle}
+                content={content}
+                subTitleTag={subTitleTag}
+              />
             );
           })}
       </div>
@@ -110,6 +119,7 @@ const Sections = ({ experience, visibility, onExpand }) => {
             subtitle={subtitle}
             content={content}
             rating={rating}
+            subTitleTag={subTitleTag}
           />
         ))}
     </div>
@@ -119,6 +129,7 @@ const Sections = ({ experience, visibility, onExpand }) => {
 Sections.propTypes = {
   experience: PropTypes.object.isRequired,
   onExpand: PropTypes.func.isRequired,
+  subTitleTag: PropTypes.string,
   visibility: PropTypes.string.isRequired,
 };
 
@@ -127,6 +138,7 @@ const Article = ({
   visibility,
   onClickMsgButton,
   originalLink,
+  subTitleTag,
 }) => {
   // Get share link object according to Google Optimize parameters
   const shareLink = useShareLink();
@@ -150,6 +162,7 @@ const Article = ({
               experience={experience}
               visibility={visibility}
               onExpand={handleExpand}
+              subTitleTag={subTitleTag}
             />
           </div>
           <div>
@@ -190,6 +203,7 @@ Article.propTypes = {
   experience: PropTypes.object.isRequired,
   onClickMsgButton: PropTypes.func.isRequired,
   originalLink: PropTypes.string,
+  subTitleTag: PropTypes.string,
   visibility: PropTypes.string.isRequired,
 };
 

--- a/src/constants/companyJobTitle.js
+++ b/src/constants/companyJobTitle.js
@@ -33,6 +33,13 @@ export const tabTypeTranslation = {
   [INTERVIEW_EXPERIENCE]: '面試',
 };
 
+export const tabTypeDetailTranslation = {
+  [OVERVIEW]: '總覽',
+  [TIME_AND_SALARY]: '薪水&加班狀況',
+  [WORK_EXPERIENCE]: '評價',
+  [INTERVIEW_EXPERIENCE]: '面試經驗',
+};
+
 const tabTypeURLMap = {
   [OVERVIEW]: 'overview',
   [TIME_AND_SALARY]: 'salary-work-times',


### PR DESCRIPTION
Close #1553  #1554 

## 這個 PR 是？ <!-- 必填 -->
基於 SEO 、使用者體驗考量，修改：

| 頁面 | 類別 | 原本 | 修改後  |
|------|---|---|---|
| 公司 面試經驗列表  |  h1  | OOO公司 | OOO公司 面試經驗  |
| 公司 面試經驗列表  |  h2  | OOO公司XXX職稱  | XXX職稱 面試經驗 | 
| 公司 面試經驗列表  |  h3  | 原本的面向是h2  | 改成 h3  | 
| 公司 評價列表  |  h1  | OOO公司 | OOO公司 評價  |
| 公司 評價列表  |  h2  | OOO公司XXX職稱  | XXX職稱 評價 | 
| 公司 評價列表  |  h3  | 原本的面向是h2  | 改成 h3  | 
| 職稱 面試經驗列表  |  h1  | XXX職稱 | XXX職稱 面試經驗  |
| 職稱 面試經驗列表  |  h2  | OOO公司XXX職稱 | OOO公司 面試經驗  | 
| 職稱 面試經驗列表  |  h3  | 原本的面向是h2  | 改成 h3  | 
| 職稱 評價列表  |  h1  | XXX職稱 | XXX職稱 評價  |
| 職稱 評價列表  |  h2  | OOO公司XXX職稱 | OOO公司 評價  | 
| 職稱 評價列表  |  h3  | 原本的面向是h2  | 改成 h3  | 

面向指的是單篇的不同 subtitle (e.g. 薪資福利、工作內容）

## Screenshots  <!-- 選填，沒有就刪掉 -->

| 原本 |  修改後  |
|------|-------|
| ![Screenshot 2025-05-24 at 10 07 51 PM](https://github.com/user-attachments/assets/e6e29ef8-699a-4cc7-89ef-3d179c8d9737) | ![Screenshot 2025-05-24 at 10 07 22 PM](https://github.com/user-attachments/assets/1691bae1-b15a-4808-9452-21defe53d8c6) |


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 本地端跑起來，確保上述提到的頁面正常 render ，h1, h2, h3 如上表
- [ ] 確保單篇頁面的 h1 (單篇的標題), h2 (面向) 沒有被動到
- [ ] <!-- 提供一個 Demo URL Link -->
- [ ] <!-- 列出給 Reviewer 的 Step By Step Checklist -->