### PR TITLE
修正 Firefox 給我們回饋

### DIFF
--- a/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
+++ b/src/components/common/Questionnaire/CollapsedDrawer/CollapsedDrawer.module.css
@@ -29,9 +29,3 @@
   box-shadow: 0px 0px 7px 0px main-black;
   transform: translateX(0px);
 }
-
-@-moz-document url-prefix() {
-  .container {
-    transform: translateX(-100%) translateY(-50%);
-  }
-}


### PR DESCRIPTION
## 這個 PR 是？ <!-- 必填 -->

移除 `CollapsedDrawer.module.css` 中針對 Firefox 的 `@-moz-document` 特定樣式。
`.container` 本身已有正確的樣式設定，這個 Firefox 專用的額外 `translateX(-100%)` transform 反而造成顯示問題。

## Screeenshots

|Before|After|
|-|-|
|<img width="750" height="1334" alt="畫面擷取於 2025-10-09 00 19 14" src="https://github.com/user-attachments/assets/6b58142a-072b-43a6-bf6f-47b5f5b1c291" />|<img width="750" height="1334" alt="畫面擷取於 2025-10-09 00 19 44" src="https://github.com/user-attachments/assets/b7360c54-cfcf-4874-9319-26a0b754d552" />|


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] 在 Firefox 瀏覽器中開啟 http://localhost:3000 檢查 CollapsedDrawer 顯示是否正常