### PR TITLE
[首頁] 修復 wrapper 寬度

### DIFF
--- a/src/components/common/variables.module.css
+++ b/src/components/common/variables.module.css
@@ -3,7 +3,7 @@
 /* ------------------------------------
  *  Width and Height
  * ------------------------------------ */
-@value inner-wrap-l: 1360px;
+@value inner-wrap-l: 1264px;
 @value inner-wrap-m: 964px;
 @value inner-wrap-s: 764px;
 


### PR DESCRIPTION
Close #1584  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？ <!-- 必填 -->

修復 #1584 的錯誤更動

## Screenshots  <!-- 選填，沒有就刪掉 -->

### BEFORE
<img width="3840" height="2160" alt="截圖 2025-10-30 晚上10 15 32（2）" src="https://github.com/user-attachments/assets/65d6f827-c809-4462-ac4e-56291fe76142" />
### AFTER
<img width="3840" height="2160" alt="截圖 2025-10-30 晚上10 15 54（2）" src="https://github.com/user-attachments/assets/943fc00f-4c2a-4f1b-895a-9c2168c1e652" />


## 我應該如何手動測試？ <!-- 必填 -->

- [ ] http://localhost:3000/ 觀察nav和下方卡片的相對位置