### PR TITLE
[分享經驗] 更新評分標籤為滿意度用語

### DIFF
--- a/src/components/ShareExperience/constants.js
+++ b/src/components/ShareExperience/constants.js
@@ -50,7 +50,13 @@ export const RESULT_OPTIONS = ['錄取', '未錄取', '沒通知', '其他'];
 
 export const UNRATABLE_SUBJECTS = ['面試問題', '如何準備面試', '工作內容'];
 
-export const RATING_LABELS = ['差', '普通', '不錯啦～', '很好！', '大推！'];
+export const RATING_LABELS = [
+  '非常不滿意',
+  '不滿意',
+  '普通',
+  '滿意',
+  '非常滿意',
+];
 
 export const RATING_COURSE_LABELS = [
   '非常混亂',


### PR DESCRIPTION
Close #1618 

## 這個 PR 是？

將分享經驗頁面的評分標籤從口語化用詞（'差'、'普通'、'不錯啦～'、'很好！'、'大推！'）更新為標準化的滿意度量表（'非常不滿意'、'不滿意'、'普通'、'滿意'、'非常滿意'），提升使用者介面的專業度與一致性。

## Screenshots

|Before|After|
|-|-|
|<img width="1125" height="2436" alt="畫面擷取於 2026-02-04 23 12 37" src="https://github.com/user-attachments/assets/5484018a-e011-4454-95a4-0d45990973b9" />|<img width="1125" height="2436" alt="畫面擷取於 2026-02-04 23 09 07" src="https://github.com/user-attachments/assets/bc14a866-2c10-4572-bbbf-12d9895b36d4" />|


## 我應該如何手動測試？

- [ ] 前往分享經驗頁面 http://localhost:3000/share
- [ ] 確認評分區塊顯示的標籤文字已更新為新的滿意度用語
