### PR TITLE
Fix: salary format number parsing issue

### DIFF
--- a/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
+++ b/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
@@ -100,7 +100,8 @@ const bodyFromDraft = evolve({
   gender: draft => draft[DATA_KEY_GENDER],
   email: '',
   salaryType: draft => draft[DATA_KEY_SALARY][0],
-  salaryAmount: draft => parseSalaryAmount(draft[DATA_KEY_SALARY][1]),
+  salaryAmount: draft =>
+    parseSalaryAmount(draft[DATA_KEY_SALARY][1]).toString(),
   experienceInYear: draft => draft[DATA_KEY_EXPERIENCE_IN_YEAR].toString(),
   dayPromisedWorkTime: draft => draft[DATA_KEY_DAY_PROMISED_WORK_TIME],
   dayRealWorkTime: draft => draft[DATA_KEY_DAY_REAL_WORK_TIME],


### PR DESCRIPTION
Close #1405 

## 這個 PR 是？
修正工時薪資表單：薪資欄位若包含千分位符號（如 `,`），會觸發「薪資過低」驗證錯誤的問題。

## Screenshots  <!-- 選填，沒有就刪掉 -->
修正前
<img width="1297" height="825" alt="image" src="https://github.com/user-attachments/assets/2ef10af6-563c-48ee-a4f6-c907c3d6fb53" />

## 我應該如何手動測試？ <!-- 必填 -->
1. 填寫薪資工時表單時，薪資加上千分位符號，填寫其他資料後送出
2. workings API 不會回傳錯誤
<img width="316" height="109" alt="image" src="https://github.com/user-attachments/assets/43edb074-0fa1-480d-b9ce-8c5a6b77a08b" />