### PR TITLE
fix(Modal): render via portal to document.body to fix shifted layout

### DIFF
--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 
@@ -52,28 +53,43 @@ const Modal = ({
   closableOnClickOutside,
   size,
   contentClassName,
-}) => (
-  <div
-    className={cn(styles.modal, {
-      [styles.isOpen]: isOpen,
-    })}
-    onClick={e => {
-      if (closableOnClickOutside) {
-        close();
-      }
-    }}
-  >
-    <div className={styles.inner}>
-      <InlineModal
-        children={children}
-        hasClose={hasClose}
-        close={close}
-        size={size}
-        contentClassName={contentClassName}
-      />
+}) => {
+  // Render via a portal to document.body so the fixed-position overlay is
+  // not contained by ancestors that establish a new containing block via
+  // transform/filter/perspective/will-change.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const node = (
+    <div
+      className={cn(styles.modal, {
+        [styles.isOpen]: isOpen,
+      })}
+      onClick={() => {
+        if (closableOnClickOutside) {
+          close();
+        }
+      }}
+    >
+      <div className={styles.inner}>
+        <InlineModal
+          children={children}
+          hasClose={hasClose}
+          close={close}
+          size={size}
+          contentClassName={contentClassName}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+
+  if (!mounted || typeof document === 'undefined') {
+    return null;
+  }
+  return ReactDOM.createPortal(node, document.body);
+};
 
 Modal.propTypes = {
   children: PropTypes.node,

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -54,15 +54,16 @@ const Modal = ({
   size,
   contentClassName,
 }) => {
-  // Render via a portal to document.body so the fixed-position overlay is
-  // not contained by ancestors that establish a new containing block via
-  // transform/filter/perspective/will-change.
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const node = (
+  if (!mounted || typeof document === 'undefined') {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
     <div
       className={cn(styles.modal, {
         [styles.isOpen]: isOpen,
@@ -82,13 +83,9 @@ const Modal = ({
           contentClassName={contentClassName}
         />
       </div>
-    </div>
+    </div>,
+    document.body,
   );
-
-  if (!mounted || typeof document === 'undefined') {
-    return null;
-  }
-  return ReactDOM.createPortal(node, document.body);
 };
 
 Modal.propTypes = {

--- a/src/components/common/Modal.js
+++ b/src/components/common/Modal.js
@@ -54,6 +54,9 @@ const Modal = ({
   size,
   contentClassName,
 }) => {
+  // Render via a portal to document.body so the fixed-position overlay is
+  // not contained by ancestors that establish a new containing block via
+  // transform/filter/perspective/will-change.
   const [mounted, setMounted] = useState(false);
   useEffect(() => {
     setMounted(true);


### PR DESCRIPTION
Close #1669  

## Summary

Fix a general bug in the shared `Modal` component where the popup layout is entirely shifted under certain ancestor CSS conditions.

Reproducible on `/companies/:companyName/salary-work-times`: filter salary by job title, then click the 回報 (report) button — the modal renders offset from the viewport instead of centered.

## Root cause

`Modal` (`src/components/common/Modal.js`) renders an overlay styled with `position: fixed; top/left/right/bottom: 0` (`Modal.module.css:5-12`), and is rendered **inline** as a descendant of whichever component invokes it (no portal).

Per the CSS spec, any ancestor with a non-`none` `transform`, `filter`, `perspective`, `will-change: transform`, or `contain: paint/layout/strict` establishes a **new containing block** for `position: fixed` descendants. When that happens, the modal is no longer fixed to the viewport — it is fixed to the transformed ancestor, so its `top/left/right/bottom: 0` anchor to the ancestor's box, and `.inner { height: 100vh }` centering drifts.

On the salary-work-times page this is triggered by `FadeInContent` inside `BoxRenderer` (`src/components/CompanyAndJobTitle/StatusRenderer.js:11-66`):

- Initial SSR-hydrated render: `wasFetchingRef` stays `false`; content rendered with no wrapper.
- User types in the searchbar → fetch triggers → `isFetching` flips `true` → `wasFetchingRef.current` latches to `true`.
- Fetch completes → `BoxRenderer` now wraps content in `<FadeInContent>`, which applies inline `transform: translateY(0)` permanently (not just during the 0.35s transition).
- `ReportZone` (`src/components/ExperienceDetail/ReportZone/index.js:73`) then renders `<Modal>` as a descendant of this transformed wrapper → `position: fixed` is resolved against `FadeInContent` / `Wrapper` instead of the viewport → visible layout shift.

This is a general `Modal` issue: any ancestor with the CSS properties listed above would break it the same way on any page.

## Solution

Render the `Modal` overlay through `ReactDOM.createPortal(node, document.body)` so it always mounts as a direct child of `<body>`, escaping any transformed ancestor's containing block.

- Guarded with a `mounted` flag + `typeof document === 'undefined'` check so SSR output is unchanged and there is no hydration mismatch (project uses `hydrate` in `src/client.js`).
- React tree semantics (context, event bubbling) are preserved by portals, so `ReportZone`'s state and handlers continue to work unchanged.

Alternative considered: removing the `transform` from `FadeInContent`. Rejected — it would fix only this page and leave the Modal fragile against any future transformed ancestor.

## Test plan

- [ ] Load `/companies/:companyName/salary-work-times`, click 回報 on a row — modal is centered on the viewport.
- [ ] On the same page, type into the job title filter, wait for results, then click 回報 — modal is still centered (previously shifted).
- [ ] Verify other callers of `Modal` still render correctly: `PermissionBlock/BasicPermissionSimpleBlock`, `FormBuilder/Modals/ConfirmModal`, `TimeAndSalary/InfoModal`, `Me/ShareBlockElement`.
- [ ] Reload the page with a modal-triggering route to confirm no hydration warnings in the console.
- [ ] Confirm click-outside-to-close, close button, and `closableOnClickOutside={false}` behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)