### PR TITLE
fix(StatusRenderer): drop FadeInContent transform after fade-in ends

### DIFF
--- a/src/components/CompanyAndJobTitle/StatusRenderer.js
+++ b/src/components/CompanyAndJobTitle/StatusRenderer.js
@@ -1,29 +1,40 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
+import cn from 'classnames';
 import Redirect from 'common/routing/Redirect';
 import Loader from 'common/Loader';
 import NotFoundStatus from 'common/routing/NotFound';
 import { generateTabURL } from 'constants/companyJobTitle';
 import { isUnfetched, isFetching, isError } from 'utils/fetchBox';
 import EmptyView from './EmptyView';
+import styles from './StatusRenderer.module.css';
 
-const FadeInContent = ({ children }) => {
+const useFadeIn = () => {
   const [visible, setVisible] = useState(false);
-  const rafRef = useRef(null);
+  const [animating, setAnimating] = useState(true);
 
   useEffect(() => {
-    rafRef.current = requestAnimationFrame(() => setVisible(true));
-    return () => cancelAnimationFrame(rafRef.current);
+    const id = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(id);
   }, []);
 
+  const onTransitionEnd = e => {
+    if (e.propertyName === 'transform') setAnimating(false);
+  };
+
+  return { visible, animating, onTransitionEnd };
+};
+
+const FadeInContent = ({ children }) => {
+  const { visible, animating, onTransitionEnd } = useFadeIn();
   return (
     <div
-      style={{
-        opacity: visible ? 1 : 0,
-        transform: visible ? 'translateY(0)' : 'translateY(12px)',
-        transition: 'opacity 0.35s ease, transform 0.35s ease',
-      }}
+      className={cn({
+        [styles['fade-in']]: animating,
+        [styles['fade-in--visible']]: animating && visible,
+      })}
+      onTransitionEnd={onTransitionEnd}
     >
       {children}
     </div>

--- a/src/components/CompanyAndJobTitle/StatusRenderer.module.css
+++ b/src/components/CompanyAndJobTitle/StatusRenderer.module.css
@@ -1,0 +1,10 @@
+.fade-in {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+
+  &--visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
Close #1669  

## 這個 PR 是？ <!-- 必填 -->

修正 Modal 跑版 ，昨晚看完 AI 的 PR #1670  後，有點好奇那解法是否為 root case 解法所以又查找一下，查完之後認為該 PR 是更好的解法

原因是：
1. 修在正確的層級：bug 的觸發點就是 FadeInContent 的永久 transform，之前因動畫結束後沒有清 class 導致跑版：
    `FadeInContent`（`src/components/CompanyAndJobTitle/StatusRenderer.js`）在 0.35s 淡入動畫**結束後仍保留**
`transform: translateY(0)` 在 wrapper `<div>` 上。
2. AI 的 PR #1670 是修改成 Modal portal，無法修正這個 bug 的 root case — 它修的是 position: fixed 與 z-index 容易被祖先 CSS 改寫的議題，跟 #1669 的 root cause 不同。

## Screenshot

**修正前**
1. 點回報按鈕
<img width="1281" height="836" alt="Image" src="https://github.com/user-attachments/assets/778b0c43-6013-40b7-9aa0-fce3405da91c" />

2. 點登入按鈕
<img width="1164" height="842" alt="Image" src="https://github.com/user-attachments/assets/2e60180f-e1f6-44e6-9fb9-059727c3cb26" />


**修正後**

https://github.com/user-attachments/assets/a08bf70e-260c-47bc-a167-a34a6b0b452e

**觸發路徑**
1. 初次 SSR + hydration：`wasFetchingRef.current` 為 `false`，內容**不**經過 `FadeInContent` 包裹 → Modal 正常。
2. 使用者輸入搜尋字 → 觸發 refetch → 進入 fetching 狀態 → `wasFetchingRef.current` 鎖死為 `true`。
4. fetch 完成 → 內容**永久**被 `FadeInContent` 包裹 → 永久 `transform` 殘留 → Modal 跑版。

## 改動
- 抽出 `useFadeIn` hook 集中管理 `visible` / `animating` / `onTransitionEnd` 狀態。
- 監聽 `transform` 屬性的 `transitionend`，動畫一結束就把 fade-in class 拿掉，整個 wrapper 不再帶任何 inline style 與 
class，自然就不再構成 containing block。             
- inline style 改為 CSS Module（`StatusRenderer.module.css`），採用 BEM 命名（`.fade-in` / `.fade-in--visible`）。 
   
## 我應該如何手動測試？        
  - [x] `/companies/:companyName/salary-work-times`：先職稱搜尋過濾，再點「回報」→ Modal 置中於 viewport。
  - [x] 同頁面，過濾後點表頭「估計時薪」「參考時間」→  Modal 置中。                                         
  - [x] 同頁面未登入時點「我要回報」→ 登入 Modal 置中。                                
  - [x] 首次載入後（fetch 完成那一刻）淡入動畫仍正常播放（0.35s opacity + 12px  上滑）。
  - [x] DevTools Elements 觀察：動畫結束後 `FadeInContent` 的 `<div>` 不再帶任何 inline style 或 class。