### PR TITLE
refactor: SearchScreen move

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ npm run testonly    # unit tests only
 
 ## Convention
 
-### API Layer
+### Directory Structure
 
+- **`src/pages/`** — route-level (page) components. If a component is directly mounted by a route in `src/routes.js`, it belongs here, not inside `src/components/`.
+- **`src/components/`** — reusable UI components, organized by domain (e.g. `CompanyAndJobTitle/`, `SalaryWorkTime/`). A component's location and name should reflect its actual domain, not where it was first created. Rename and move when reuse expands beyond the original context.
 `src/apis/` contains all API calls to the backend. When writing or modifying API-related code, follow the TypeScript typing guidelines in [src/apis/README.md](src/apis/README.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/src/components/CompanyAndJobTitle/CompanyJobTitleBlock.js
+++ b/src/components/CompanyAndJobTitle/CompanyJobTitleBlock.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { Heading } from 'common/base';
 import { Link } from 'react-router-dom';
 
-import styles from './WorkingHourBlock.module.css';
+import styles from './CompanyJobTitleBlock.module.css';
 import { pageTypeTranslation } from 'constants/companyJobTitle';
 
-const WorkingHourBlock = ({
+const CompanyJobTitleBlock = ({
   pageType,
   name,
   businessNumber,
@@ -39,7 +39,7 @@ const WorkingHourBlock = ({
   </section>
 );
 
-WorkingHourBlock.propTypes = {
+CompanyJobTitleBlock.propTypes = {
   businessNumber: PropTypes.string,
   dataCount: PropTypes.number,
   name: PropTypes.string.isRequired,
@@ -47,4 +47,4 @@ WorkingHourBlock.propTypes = {
   to: PropTypes.string.isRequired,
 };
 
-export default WorkingHourBlock;
+export default CompanyJobTitleBlock;

--- a/src/components/CompanyAndJobTitle/CompanyJobTitleBlock.module.css
+++ b/src/components/CompanyAndJobTitle/CompanyJobTitleBlock.module.css
@@ -1,4 +1,4 @@
-@value yellow-bar, main-yellow, border-gray, main-gray, text-gray, gray-dark, gray-light, link-blue, page-gutter-s from "../../common/variables.module.css";
+@value yellow-bar, main-yellow, border-gray, main-gray, text-gray, gray-dark, gray-light, link-blue, page-gutter-s from "../common/variables.module.css";
 
 .container {
   display: block;

--- a/src/components/CompanyAndJobTitle/IndexPage/index.js
+++ b/src/components/CompanyAndJobTitle/IndexPage/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import qs from 'qs';
 import Pagination from 'common/Pagination';
 import Loader from 'common/Loader';
-import WorkingHourBlock from '../../TimeAndSalary/SearchScreen/WorkingHourBlock';
+import CompanyJobTitleBlock from '../CompanyJobTitleBlock';
 import {
   pageTypeTranslation,
   generatePageURL,
@@ -62,7 +62,7 @@ const CompanyAndJobTitleIndex = ({
         </div>
         <div className={styles.index}>
           {indexesBox.data.map((pageIndex, i) => (
-            <WorkingHourBlock
+            <CompanyJobTitleBlock
               key={i}
               pageType={pageType}
               name={pageIndex.name}

--- a/src/components/TimeAndSalary/SearchScreen/index.js
+++ b/src/components/TimeAndSalary/SearchScreen/index.js
@@ -1,3 +1,0 @@
-import SearchScreen from './SearchScreen';
-
-export default SearchScreen;

--- a/src/pages/SearchPage/Helmet.js
+++ b/src/pages/SearchPage/Helmet.js
@@ -6,7 +6,7 @@ import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
 import SalaryWorkTimeOgImage from 'images/og/salary-work-time.jpg';
 
-const SearchScreenHelmet = ({ keyword, page }) => {
+const SearchPageHelmet = ({ keyword, page }) => {
   const title = `查詢${keyword}的結果 - 第${page}頁`;
   const description = `查詢${keyword}的薪水、加班狀況、面試心得、評價資料的結果`;
 
@@ -30,9 +30,9 @@ const SearchScreenHelmet = ({ keyword, page }) => {
   );
 };
 
-SearchScreenHelmet.propTypes = {
+SearchPageHelmet.propTypes = {
   keyword: PropTypes.string.isRequired,
   page: PropTypes.number.isRequired,
 };
 
-export default SearchScreenHelmet;
+export default SearchPageHelmet;

--- a/src/pages/SearchPage/SearchPage.js
+++ b/src/pages/SearchPage/SearchPage.js
@@ -16,9 +16,9 @@ import { usePage } from 'hooks/routing/page';
 import { queryKeyword } from 'actions/search';
 import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import { searchByKeywordSelector } from 'selectors/search';
-import WorkingHourBlock from './WorkingHourBlock';
+import CompanyJobTitleBlock from 'components/CompanyAndJobTitle/CompanyJobTitleBlock';
 import Helmet from './Helmet';
-import styles from './SearchScreen.module.css';
+import styles from './SearchPage.module.css';
 
 const keywordMinLength = 2;
 
@@ -43,7 +43,7 @@ function getLinkForData(query, data) {
   return `${path}${search}`;
 }
 
-const SearchScreen = () => {
+const SearchPage = () => {
   const dispath = useDispatch();
   const query = useQuery();
   const keyword = useMemo(() => keywordFromQuerySelector(query), [query]);
@@ -83,7 +83,7 @@ const SearchScreen = () => {
           <>
             {slice((page - 1) * pageSize, page * pageSize)(box.data).map(
               (o, i) => (
-                <WorkingHourBlock
+                <CompanyJobTitleBlock
                   key={i}
                   pageType={o.pageType}
                   name={o.name}
@@ -109,10 +109,10 @@ const SearchScreen = () => {
   );
 };
 
-SearchScreen.fetchData = ({ store: { dispatch }, ...props }) => {
+SearchPage.fetchData = ({ store: { dispatch }, ...props }) => {
   const query = querySelector(props);
   const keyword = keywordFromQuerySelector(query);
   return dispatch(queryKeyword({ keyword }));
 };
 
-export default SearchScreen;
+export default SearchPage;

--- a/src/pages/SearchPage/SearchPage.module.css
+++ b/src/pages/SearchPage/SearchPage.module.css
@@ -1,4 +1,4 @@
-@value yellow-bar, gray-dark, main-gray, main-yellow, warning-red, above-mobile from "../../common/variables.module.css";
+@value yellow-bar, gray-dark, main-gray, main-yellow, warning-red, above-mobile from "../../components/common/variables.module.css";
 $below-mobile: 550px;
 $below-small: 850px;
 $above-desktop: 1025px;

--- a/src/pages/SearchPage/index.js
+++ b/src/pages/SearchPage/index.js
@@ -1,0 +1,3 @@
+import SearchPage from './SearchPage';
+
+export default SearchPage;

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import { generatePath } from 'react-router';
 import LandingPage from './components/LandingPage';
 import LaborRightsMenu from './components/LaborRightsMenu';
 import LaborRightsSingle from './components/LaborRightsSingle';
-import SearchScreen from './components/TimeAndSalary/SearchScreen';
+import SearchPage from './pages/SearchPage';
 import ExperienceDetail from './components/ExperienceDetail';
 import NotFound from './components/common/NotFound';
 import ShareExperience from './components/ShareExperience';
@@ -107,7 +107,7 @@ const routes = [
   {
     path: '/search',
     exact: true,
-    component: SearchScreen,
+    component: SearchPage,
   },
   {
     path: '/companies',

--- a/src/routes.js
+++ b/src/routes.js
@@ -3,7 +3,7 @@ import { generatePath } from 'react-router';
 import LandingPage from './components/LandingPage';
 import LaborRightsMenu from './components/LaborRightsMenu';
 import LaborRightsSingle from './components/LaborRightsSingle';
-import SearchPage from './pages/SearchPage';
+import SearchPage from 'pages/SearchPage';
 import ExperienceDetail from './components/ExperienceDetail';
 import NotFound from './components/common/NotFound';
 import ShareExperience from './components/ShareExperience';


### PR DESCRIPTION
## 這個 PR 是？

純 refactor，調整兩個元件的命名與位置，讓目錄結構更符合實際用途：

1. **SearchScreen → SearchPage** (由 Claude 建議命名)
   - 從 `components/TimeAndSalary/SearchScreen/` 移至 `pages/SearchPage/`
   - 元件重新命名為 `SearchPage`（page-level component 應放在 `pages/`）
   - `SearchScreenHelmet` 同步改名為 `SearchPageHelmet`

2. **WorkingHourBlock → CompanyJobTitleBlock** (由 Claude 建議命名)
   - 從 `components/TimeAndSalary/SearchScreen/` 移至 `components/CompanyAndJobTitle/`
   - 元件重新命名為 `CompanyJobTitleBlock`（原名稱僅反映薪水/工時，實際上也用於職稱頁）

---

## Questions:

- 我需要更新 Packages 嗎？ No
- 有哪些文件需要被更新嗎？ No

## 我應該如何手動測試？

- [ ] 前往 `/search?q=<keyword>` 確認搜尋頁正常顯示
- [ ] 確認公司/職稱索引頁（`CompanyAndJobTitle/IndexPage`）的區塊元件正常渲染