### PR TITLE
refactor: 統一使用 keywordFromQuerySelector 取代 Searchbar 中的 searchTextFromQuerySelector

### DIFF
--- a/src/components/App/Header/Searchbar.js
+++ b/src/components/App/Header/Searchbar.js
@@ -4,14 +4,14 @@ import cn from 'classnames';
 import { useHistory } from 'react-router-dom';
 import SearchTextInput from 'common/form/TextInput/SearchTextInput';
 import Magnifiner from 'common/icons/Magnifiner';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
+import { queryFromQuerySelector } from 'selectors/routing';
 import { useQuery } from 'hooks/routing';
 import styles from './Searchbar.module.css';
 
 const Searchbar = ({ className, placeholder, inputRef }) => {
   const history = useHistory();
   const query = useQuery();
-  const [searchText, setSearchText] = useState(keywordFromQuerySelector(query));
+  const [searchText, setSearchText] = useState(queryFromQuerySelector(query));
   const [isActive, setActive] = useState(false);
 
   const handleFormFocus = useCallback(() => {

--- a/src/components/CompanyAndJobTitle/Searchbar.js
+++ b/src/components/CompanyAndJobTitle/Searchbar.js
@@ -16,12 +16,12 @@ import {
   tabTypeTranslation,
 } from 'constants/companyJobTitle';
 import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
+import { queryFromQuerySelector } from 'selectors/routing';
 
 export const useSearchTextFromQuery = () => {
   const history = useHistory();
   const query = useQuery();
-  const searchText = keywordFromQuerySelector(query);
+  const searchText = queryFromQuerySelector(query);
   const setSearchText = useCallback(
     nextSearchText => {
       if (searchText === nextSearchText) return;

--- a/src/components/CompanyAndJobTitle/Searchbar.js
+++ b/src/components/CompanyAndJobTitle/Searchbar.js
@@ -16,13 +16,12 @@ import {
   tabTypeTranslation,
 } from 'constants/companyJobTitle';
 import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
-
-export const searchTextFromQuerySelector = query => query.q || '';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 
 export const useSearchTextFromQuery = () => {
   const history = useHistory();
   const query = useQuery();
-  const searchText = searchTextFromQuerySelector(query);
+  const searchText = keywordFromQuerySelector(query);
   const setSearchText = useCallback(
     nextSearchText => {
       if (searchText === nextSearchText) return;

--- a/src/components/TimeAndSalary/SearchBar.js
+++ b/src/components/TimeAndSalary/SearchBar.js
@@ -5,12 +5,12 @@ import SearchTextInput from 'common/form/TextInput/SearchTextInput';
 import Magnifiner from 'common/icons/Magnifiner';
 import { useQuery } from 'hooks/routing';
 import styles from './SearchBar.module.css';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
+import { queryFromQuerySelector } from 'selectors/routing';
 
 const SearchBar = () => {
   const history = useHistory();
   const query = useQuery();
-  const [searchText, setSearchText] = useState(keywordFromQuerySelector(query));
+  const [searchText, setSearchText] = useState(queryFromQuerySelector(query));
 
   const gotoSearchResult = useCallback(
     searchText => {

--- a/src/hooks/routing/page.js
+++ b/src/hooks/routing/page.js
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import { pageFromQuerySelector } from 'selectors/routing';
 import { useQuery } from 'hooks/routing';
 
 export const usePage = () => {

--- a/src/pages/Company/CompanyIndexProvider.js
+++ b/src/pages/Company/CompanyIndexProvider.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { querySelector } from 'common/routing/selectors';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import { pageFromQuerySelector } from 'selectors/routing';
 import CompanyAndJobTitleIndexPage from 'components/CompanyAndJobTitle/IndexPage';
 import usePagination from 'components/CompanyAndJobTitle/IndexPage/usePagination';
 import { pageType as PAGE_TYPE, PAGE_SIZE } from 'constants/companyJobTitle';

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -17,10 +17,8 @@ import {
 import { companyInterviewExperiencesBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import useCompanyName, { companyNameSelector } from './useCompanyName';
 import { useTopNJobTitles } from './useTopNJobTitles';
-import {
-  searchTextFromQuerySelector,
-  useSearchTextFromQuery,
-} from 'components/CompanyAndJobTitle/Searchbar';
+import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -113,7 +111,7 @@ CompanyInterviewExperiencesProvider.fetchData = ({
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
   const sortBy = sortByFromQuerySelector(query);
-  const jobTitle = searchTextFromQuerySelector(query) || undefined;
+  const jobTitle = keywordFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return Promise.all([

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -18,12 +18,14 @@ import { companyInterviewExperiencesBoxSelectorByName } from 'selectors/companyA
 import useCompanyName, { companyNameSelector } from './useCompanyName';
 import { useTopNJobTitles } from './useTopNJobTitles';
 import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
+import {
+  queryFromQuerySelector,
+  pageFromQuerySelector,
+} from 'selectors/routing';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
 } from 'components/CompanyAndJobTitle/Sorter';
-import { pageFromQuerySelector } from 'selectors/routing/page';
 import { isFetched, getFetched } from 'utils/fetchBox';
 import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
 
@@ -111,7 +113,7 @@ CompanyInterviewExperiencesProvider.fetchData = ({
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
   const sortBy = sortByFromQuerySelector(query);
-  const jobTitle = keywordFromQuerySelector(query) || undefined;
+  const jobTitle = queryFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return Promise.all([

--- a/src/pages/Company/CompanyTimeAndSalaryProvider.js
+++ b/src/pages/Company/CompanyTimeAndSalaryProvider.js
@@ -27,10 +27,8 @@ import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useCompanyName, { companyNameSelector } from './useCompanyName';
 import { useTopNJobTitles } from './useTopNJobTitles';
 import { pageFromQuerySelector } from 'selectors/routing/page';
-import {
-  searchTextFromQuerySelector,
-  useSearchTextFromQuery,
-} from 'components/CompanyAndJobTitle/Searchbar';
+import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 
 const useOverviewStatisticsBox = pageName => {
   const selector = useMemo(
@@ -169,7 +167,7 @@ CompanyTimeAndSalaryProvider.fetchData = ({
   const companyName = companyNameSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const jobTitle = searchTextFromQuerySelector(query) || undefined;
+  const jobTitle = keywordFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   const dispatchOverviewStatistics = dispatch(

--- a/src/pages/Company/CompanyTimeAndSalaryProvider.js
+++ b/src/pages/Company/CompanyTimeAndSalaryProvider.js
@@ -26,9 +26,11 @@ import {
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useCompanyName, { companyNameSelector } from './useCompanyName';
 import { useTopNJobTitles } from './useTopNJobTitles';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  queryFromQuerySelector,
+  pageFromQuerySelector,
+} from 'selectors/routing';
 import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 
 const useOverviewStatisticsBox = pageName => {
   const selector = useMemo(
@@ -167,7 +169,7 @@ CompanyTimeAndSalaryProvider.fetchData = ({
   const companyName = companyNameSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const jobTitle = keywordFromQuerySelector(query) || undefined;
+  const jobTitle = queryFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   const dispatchOverviewStatistics = dispatch(

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -15,9 +15,11 @@ import {
 import { companyWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useCompanyName, { companyNameSelector } from './useCompanyName';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  queryFromQuerySelector,
+  pageFromQuerySelector,
+} from 'selectors/routing';
 import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -99,7 +101,7 @@ CompanyWorkExperiencesProvider.fetchData = ({
   const companyName = companyNameSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const jobTitle = keywordFromQuerySelector(query) || undefined;
+  const jobTitle = queryFromQuerySelector(query) || undefined;
   const sortBy = sortByFromQuerySelector(query);
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -16,10 +16,8 @@ import { companyWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorBy
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useCompanyName, { companyNameSelector } from './useCompanyName';
 import { pageFromQuerySelector } from 'selectors/routing/page';
-import {
-  searchTextFromQuerySelector,
-  useSearchTextFromQuery,
-} from 'components/CompanyAndJobTitle/Searchbar';
+import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -101,7 +99,7 @@ CompanyWorkExperiencesProvider.fetchData = ({
   const companyName = companyNameSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const jobTitle = searchTextFromQuerySelector(query) || undefined;
+  const jobTitle = keywordFromQuerySelector(query) || undefined;
   const sortBy = sortByFromQuerySelector(query);
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;

--- a/src/pages/JobTitle/JobTitleIndexProvider.js
+++ b/src/pages/JobTitle/JobTitleIndexProvider.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { querySelector } from 'common/routing/selectors';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import { pageFromQuerySelector } from 'selectors/routing';
 import CompanyAndJobTitleIndexPage from 'components/CompanyAndJobTitle/IndexPage';
 import usePagination from 'components/CompanyAndJobTitle/IndexPage/usePagination';
 import { pageType as PAGE_TYPE, PAGE_SIZE } from 'constants/companyJobTitle';

--- a/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -13,10 +13,8 @@ import { jobTitleInterviewExperiencesBoxSelectorByName } from 'selectors/company
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useJobTitle, { jobTitleSelector } from './useJobTitle';
 import { pageFromQuerySelector } from 'selectors/routing/page';
-import {
-  searchTextFromQuerySelector,
-  useSearchTextFromQuery,
-} from 'components/CompanyAndJobTitle/Searchbar';
+import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -97,7 +95,7 @@ JobTitleTimeAndSalaryProvider.fetchData = ({
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
   const sortBy = sortByFromQuerySelector(query);
-  const companyName = searchTextFromQuerySelector(query) || undefined;
+  const companyName = keywordFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return dispatch(

--- a/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -12,9 +12,11 @@ import { queryJobTitleInterviewExperiences } from 'actions/jobTitle';
 import { jobTitleInterviewExperiencesBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useJobTitle, { jobTitleSelector } from './useJobTitle';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  queryFromQuerySelector,
+  pageFromQuerySelector,
+} from 'selectors/routing';
 import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -95,7 +97,7 @@ JobTitleTimeAndSalaryProvider.fetchData = ({
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
   const sortBy = sortByFromQuerySelector(query);
-  const companyName = keywordFromQuerySelector(query) || undefined;
+  const companyName = queryFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return dispatch(

--- a/src/pages/JobTitle/JobTitleTimeAndSalaryProvider.js
+++ b/src/pages/JobTitle/JobTitleTimeAndSalaryProvider.js
@@ -22,10 +22,8 @@ import {
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useJobTitle, { jobTitleSelector } from './useJobTitle';
 import { pageFromQuerySelector } from 'selectors/routing/page';
-import {
-  searchTextFromQuerySelector,
-  useSearchTextFromQuery,
-} from 'components/CompanyAndJobTitle/Searchbar';
+import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 
 const useOverviewStatisticsBox = pageName => {
   const selector = useMemo(
@@ -134,7 +132,7 @@ JobTitleTimeAndSalaryProvider.fetchData = ({
   const jobTitle = jobTitleSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const companyName = searchTextFromQuerySelector(query) || undefined;
+  const companyName = keywordFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return Promise.all([

--- a/src/pages/JobTitle/JobTitleTimeAndSalaryProvider.js
+++ b/src/pages/JobTitle/JobTitleTimeAndSalaryProvider.js
@@ -21,9 +21,11 @@ import {
 } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useJobTitle, { jobTitleSelector } from './useJobTitle';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  queryFromQuerySelector,
+  pageFromQuerySelector,
+} from 'selectors/routing';
 import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 
 const useOverviewStatisticsBox = pageName => {
   const selector = useMemo(
@@ -132,7 +134,7 @@ JobTitleTimeAndSalaryProvider.fetchData = ({
   const jobTitle = jobTitleSelector(params);
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
-  const companyName = keywordFromQuerySelector(query) || undefined;
+  const companyName = queryFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return Promise.all([

--- a/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
@@ -13,10 +13,8 @@ import { jobTitleWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorB
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useJobTitle, { jobTitleSelector } from './useJobTitle';
 import { pageFromQuerySelector } from 'selectors/routing/page';
-import {
-  searchTextFromQuerySelector,
-  useSearchTextFromQuery,
-} from 'components/CompanyAndJobTitle/Searchbar';
+import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
+import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -95,7 +93,7 @@ JobTitleWorkExperiencesProvider.fetchData = ({
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
   const sortBy = sortByFromQuerySelector(query);
-  const companyName = searchTextFromQuerySelector(query) || undefined;
+  const companyName = keywordFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return dispatch(

--- a/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
@@ -12,9 +12,11 @@ import { queryJobTitleWorkExperiences } from 'actions/jobTitle';
 import { jobTitleWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import useJobTitle, { jobTitleSelector } from './useJobTitle';
-import { pageFromQuerySelector } from 'selectors/routing/page';
+import {
+  queryFromQuerySelector,
+  pageFromQuerySelector,
+} from 'selectors/routing';
 import { useSearchTextFromQuery } from 'components/CompanyAndJobTitle/Searchbar';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
 import {
   sortByFromQuerySelector,
   useSortByFromQuery,
@@ -93,7 +95,7 @@ JobTitleWorkExperiencesProvider.fetchData = ({
   const query = querySelector(props);
   const page = pageFromQuerySelector(query);
   const sortBy = sortByFromQuerySelector(query);
-  const companyName = keywordFromQuerySelector(query) || undefined;
+  const companyName = queryFromQuerySelector(query) || undefined;
   const start = (page - 1) * PAGE_SIZE;
   const limit = PAGE_SIZE;
   return dispatch(

--- a/src/pages/SearchPage/SearchPage.js
+++ b/src/pages/SearchPage/SearchPage.js
@@ -14,7 +14,7 @@ import { generatePageURL } from 'constants/companyJobTitle';
 import { useQuery } from 'hooks/routing';
 import { usePage } from 'hooks/routing/page';
 import { queryKeyword } from 'actions/search';
-import { keywordFromQuerySelector } from 'selectors/routing/keyword';
+import { queryFromQuerySelector } from 'selectors/routing';
 import { searchByKeywordSelector } from 'selectors/search';
 import CompanyJobTitleBlock from 'components/CompanyAndJobTitle/CompanyJobTitleBlock';
 import Helmet from './Helmet';
@@ -46,7 +46,7 @@ function getLinkForData(query, data) {
 const SearchPage = () => {
   const dispath = useDispatch();
   const query = useQuery();
-  const keyword = useMemo(() => keywordFromQuerySelector(query), [query]);
+  const keyword = useMemo(() => queryFromQuerySelector(query), [query]);
   const page = usePage();
   const box = useSelector(searchByKeywordSelector(keyword));
 
@@ -111,7 +111,7 @@ const SearchPage = () => {
 
 SearchPage.fetchData = ({ store: { dispatch }, ...props }) => {
   const query = querySelector(props);
-  const keyword = keywordFromQuerySelector(query);
+  const keyword = queryFromQuerySelector(query);
   return dispatch(queryKeyword({ keyword }));
 };
 

--- a/src/selectors/routing/index.ts
+++ b/src/selectors/routing/index.ts
@@ -1,0 +1,13 @@
+import { ParsedQs } from 'qs';
+
+// query from ?q=xxx
+export const queryFromQuerySelector = (query: ParsedQs): string => {
+  const keyword = query.q;
+  return typeof keyword === 'string' ? keyword : '';
+};
+
+// page from ?p=xxx
+export const pageFromQuerySelector = (query: ParsedQs): number => {
+  const p = parseInt(query.p as string, 10);
+  return Number.isNaN(p) ? 1 : p;
+};

--- a/src/selectors/routing/keyword.js
+++ b/src/selectors/routing/keyword.js
@@ -1,7 +1,0 @@
-import { compose, when, always } from 'ramda';
-
-// keyword from ?q=xxx
-export const keywordFromQuerySelector = compose(
-  when(keyword => typeof keyword !== 'string', always('')),
-  query => query.q,
-);

--- a/src/selectors/routing/page.js
+++ b/src/selectors/routing/page.js
@@ -1,8 +1,0 @@
-import { compose, when, always } from 'ramda';
-
-// page from ?p=xxx
-export const pageFromQuerySelector = compose(
-  when(Number.isNaN, always(1)),
-  p => parseInt(p, 10),
-  query => query.p,
-);


### PR DESCRIPTION
## 這個 PR 是？

Claude 在檢視 SearchBar 相關差異時，建議將 `Searchbar.js` 中自行定義的 `searchTextFromQuerySelector`（內容為 `query => query.q || ''`）移除，改為直接使用 `selectors/routing/keyword` 中已存在的 `keywordFromQuerySelector`，避免重複定義相同邏輯。

- 移除 `Searchbar.js` 中的 `searchTextFromQuerySelector`，改 import `keywordFromQuerySelector`
- 更新 6 個 Company / JobTitle provider，直接從 `selectors/routing/keyword` import `keywordFromQuerySelector`，不再透過 `Searchbar.js` 轉出

## Questions:

- 我需要更新 Packages 嗎？ No
- 有哪些文件需要被更新嗎？ No

## 我應該如何手動測試？

- [ ] 進入公司頁面（面試經驗、薪時、工作經驗），確認搜尋列仍可正確過濾結果
- [ ] 進入職稱頁面（面試經驗、薪時、工作經驗），確認搜尋列仍可正確過濾結果
- [ ] 確認 URL query param `?q=` 讀寫仍正確運作