### PR TITLE
chore: add --ext .js,.ts,.tsx to eslint so TypeScript files are linted

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start:tsc": "tsc -b -w --preserveWatchOutput",
     "start": "npm run start:tsc & razzle start",
     "start-production": "NODE_ENV=production node build/server.js",
-    "lint": "eslint src/ razzle.config.js",
+    "lint": "eslint --ext .js,.ts,.tsx src/ razzle.config.js",
     "lint-staged": "lint-staged",
     "stylelint": "stylelint \"src/**/*.css\"",
     "testonly": "razzle test --env=jsdom",


### PR DESCRIPTION
## 這個 PR 是？

將 `package.json` 的 `lint` script 加上 `--ext .js,.ts,.tsx`，讓 ESLint 明確掃描 TypeScript 檔案（`.ts`、`.tsx`）。

過去 ESLint 預設只掃 `.js`，導致漸進式 TS 遷移後新增的 `.ts/.tsx` 檔案不會被 lint 到。

## 有哪些 dependency？

無。

## 我應該如何手動測試？

- [ ] `npm run test`（含 lint）應成功通過，且 TypeScript 檔案中的 lint 錯誤會被正確回報

## Questions

- 我需要更新 Packages 嗎？ No
- 有哪些文件需要被更新嗎？ No