### PR TITLE
fix: 修正鎖定體驗時文章資訊未隱藏的問題

### DIFF
--- a/src/components/CompanyAndJobTitle/Experience.js
+++ b/src/components/CompanyAndJobTitle/Experience.js
@@ -6,7 +6,7 @@ import { useTrackEvent } from 'hooks/viewLog';
 import Article from 'components/ExperienceDetail/Article';
 import { Heading, Wrapper } from 'common/base';
 import MessageBoard from '../ExperienceDetail/MessageBoard';
-import * as VISIBILITY from 'components/ExperienceDetail/Article/visibility';
+import VISIBILITY from 'components/ExperienceDetail/Article/visibility';
 import styles from './Experience.module.css';
 import { formatSimpleDate } from 'utils/dateUtil';
 import { CONTENT_TYPE, ACTION } from 'constants/viewLog';

--- a/src/components/ExperienceDetail/Article/ArticleInfo.js
+++ b/src/components/ExperienceDetail/Article/ArticleInfo.js
@@ -141,7 +141,7 @@ InterviewInfoBlocks.propTypes = {
       type: PropTypes.string,
     }),
   }).isRequired,
-  hideContent: PropTypes.bool,
+  hideContent: PropTypes.bool.isRequired,
 };
 
 const WorkInfoBlocks = ({ experience, hideContent }) => {
@@ -205,7 +205,7 @@ WorkInfoBlocks.propTypes = {
     }),
     week_work_time: PropTypes.number,
   }).isRequired,
-  hideContent: PropTypes.bool,
+  hideContent: PropTypes.bool.isRequired,
 };
 
 const InfoCorner = ({ experience, originalLink }) => {
@@ -272,7 +272,7 @@ Aside.propTypes = {
   experience: PropTypes.shape({
     type: PropTypes.string.isRequired,
   }).isRequired,
-  hideContent: PropTypes.bool,
+  hideContent: PropTypes.bool.isRequired,
   originalLink: PropTypes.string,
 };
 

--- a/src/components/ExperienceDetail/Article/index.js
+++ b/src/components/ExperienceDetail/Article/index.js
@@ -15,7 +15,7 @@ import ReactionZone from './ReactionZone';
 import { BasicPermissionBlock } from 'common/PermissionBlock';
 import { MAX_WORDS_IF_HIDDEN } from 'constants/hideContent';
 import { CONTENT_TYPE, ACTION } from 'constants/viewLog';
-import * as VISIBILITY from './visibility';
+import VISIBILITY, { VisibilityPropTypes } from './visibility';
 import Button from 'common/button/Button';
 import Card from 'common/Card';
 import InfoBlock from './InfoBlock';
@@ -53,7 +53,7 @@ const ChildrenOnMaskBottom = ({ visibility, totalWords, onExpand }) => {
 ChildrenOnMaskBottom.propTypes = {
   onExpand: PropTypes.func.isRequired,
   totalWords: PropTypes.number.isRequired,
-  visibility: PropTypes.string.isRequired,
+  visibility: VisibilityPropTypes.isRequired,
 };
 
 const Sections = ({ experience, visibility, onExpand, subTitleTag }) => {
@@ -150,7 +150,7 @@ Sections.propTypes = {
   }).isRequired,
   onExpand: PropTypes.func.isRequired,
   subTitleTag: PropTypes.string,
-  visibility: PropTypes.string.isRequired,
+  visibility: VisibilityPropTypes.isRequired,
 };
 
 const Article = ({
@@ -175,6 +175,7 @@ const Article = ({
           experience={experience}
           visibility={visibility}
           originalLink={originalLink}
+          hideContent={visibility === VISIBILITY.LOCKED}
         />
         <section className={styles.main}>
           <div className={styles.article}>
@@ -224,7 +225,7 @@ Article.propTypes = {
   onClickMsgButton: PropTypes.func.isRequired,
   originalLink: PropTypes.string,
   subTitleTag: PropTypes.string,
-  visibility: PropTypes.string.isRequired,
+  visibility: VisibilityPropTypes.isRequired,
 };
 
 export default Article;

--- a/src/components/ExperienceDetail/Article/visibility.js
+++ b/src/components/ExperienceDetail/Article/visibility.js
@@ -1,3 +1,15 @@
-export const VISIBLE = 'VISIBLE';
-export const COLLAPSED = 'COLLAPSED';
-export const LOCKED = 'LOCKED';
+import PropTypes from 'prop-types';
+
+const VISIBLE = 'VISIBLE';
+const COLLAPSED = 'COLLAPSED';
+const LOCKED = 'LOCKED';
+
+const VISIBILITY = {
+  VISIBLE,
+  COLLAPSED,
+  LOCKED,
+};
+
+export default VISIBILITY;
+
+export const VisibilityPropTypes = PropTypes.oneOf(Object.values(VISIBILITY));

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -32,7 +32,7 @@ import {
 import { generateBreadCrumbData } from '../CompanyAndJobTitle/utils';
 import styles from './ExperienceDetail.module.css';
 import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
-import * as VISIBILITY from './Article/visibility';
+import VISIBILITY from './Article/visibility';
 
 // from params
 const experienceIdSelector = R.prop('id');


### PR DESCRIPTION
## 這個 PR 是？

修正 `Article` 未將 `hideContent` 傳入 `Aside`，導致 `LOCKED` 狀態下文章資訊未被隱藏。

順帶將 `visibility.js` 改為預設匯出並新增 `VisibilityPropTypes`。

## 我應該如何手動測試？

http://localhost:3000/companies/%E5%9C%8B%E5%AE%B6%E4%B8%AD%E5%B1%B1%E7%A7%91%E5%AD%B8%E7%A0%94%E7%A9%B6%E9%99%A2

- [ ] 以未登入或無權限狀態開啟體驗分享頁
- [ ] 確認文章資訊區塊內容有正確隱藏
- [ ] 登入後確認內容正常顯示

|Before|After|
|-|-|
|<img width="750" height="1334" alt="畫面擷取於 2026-05-09 09 49 29" src="https://github.com/user-attachments/assets/9019f8ad-8b11-40bc-8018-d93d227fe60a" />|<img width="750" height="1334" alt="畫面擷取於 2026-05-09 09 49 21" src="https://github.com/user-attachments/assets/abf76355-979e-4b4f-9b46-3c1dc06f29ce" />|

