### PR TITLE
chore: use enum original name directly, remove redundant aliases

### DIFF
--- a/src/actions/search.js
+++ b/src/actions/search.js
@@ -1,4 +1,4 @@
-import { pageType } from 'constants/companyJobTitle';
+import { PageType } from 'constants/companyJobTitle';
 import {
   fetchSearchCompany as fetchSearchCompanyApi,
   fetchSearchJobTitle as fetchSearchJobTitleApi,
@@ -28,13 +28,13 @@ export const queryKeyword = ({ keyword }) => async (dispatch, getState) => {
       companyName: keyword,
       hasData: true,
     }).then(items =>
-      items.map(item => ({ ...item, pageType: pageType.COMPANY })),
+      items.map(item => ({ ...item, pageType: PageType.COMPANY })),
     );
 
     const searchJobTitles = fetchSearchJobTitleApi({
       jobTitle: keyword,
     }).then(items =>
-      items.map(item => ({ ...item, pageType: pageType.JOB_TITLE })),
+      items.map(item => ({ ...item, pageType: PageType.JOB_TITLE })),
     );
 
     const [companyData, jobTitleData] = await Promise.all([

--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.js
@@ -11,8 +11,8 @@ import styles from './CompanyAndJobTitleWrapper.module.css';
 import SubscribeNotificationButton from 'components/CompanyAndJobTitle/SubscribeNotificationButton';
 import StatisticsCard from 'components/CompanyAndJobTitle/StatisticsCard';
 import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
+  PageType,
+  TabType,
   tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
 } from 'constants/companyJobTitle';
 import { Wrapper } from 'common/base';
@@ -41,9 +41,9 @@ const CompanyAndJobTitleWrapper = ({
 
   const pageH1 = useMemo(() => {
     switch (tabType) {
-      case TAB_TYPE.WORK_EXPERIENCE:
-      case TAB_TYPE.INTERVIEW_EXPERIENCE:
-      case TAB_TYPE.TIME_AND_SALARY:
+      case TabType.WORK_EXPERIENCE:
+      case TabType.INTERVIEW_EXPERIENCE:
+      case TabType.TIME_AND_SALARY:
         return `${pageName} ${TAB_TYPE_DETAIL_TRANSLATION[tabType]}`;
       default:
         return pageName;
@@ -61,7 +61,7 @@ const CompanyAndJobTitleWrapper = ({
         <div>
           <div className={styles.titleContainer}>
             <Heading className={styles.title}>{pageH1}</Heading>
-            {pageType === PAGE_TYPE.COMPANY && (
+            {pageType === PageType.COMPANY && (
               <SubscribeNotificationButton companyName={pageName} />
             )}
           </div>

--- a/src/components/CompanyAndJobTitle/Experience.js
+++ b/src/components/CompanyAndJobTitle/Experience.js
@@ -11,8 +11,8 @@ import styles from './Experience.module.css';
 import { formatSimpleDate } from 'utils/dateUtil';
 import { CONTENT_TYPE, ACTION } from 'constants/viewLog';
 import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
+  PageType,
+  TabType,
   tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
 } from 'constants/companyJobTitle';
 
@@ -47,16 +47,16 @@ const useTracePreviewRef = ({ experience }) => {
 const useExperienceTitle = ({ experience, pageType, tabType }) =>
   useMemo(() => {
     let str = '';
-    if (pageType === PAGE_TYPE.COMPANY && experience?.job_title?.name) {
+    if (pageType === PageType.COMPANY && experience?.job_title?.name) {
       str = experience.job_title.name;
-    } else if (pageType === PAGE_TYPE.JOB_TITLE && experience?.company?.name) {
+    } else if (pageType === PageType.JOB_TITLE && experience?.company?.name) {
       str = experience.company.name;
     } else if (experience?.title) {
       str = experience.title;
     }
     switch (tabType) {
-      case TAB_TYPE.INTERVIEW_EXPERIENCE:
-      case TAB_TYPE.WORK_EXPERIENCE:
+      case TabType.INTERVIEW_EXPERIENCE:
+      case TabType.WORK_EXPERIENCE:
         return `${str} ${TAB_TYPE_DETAIL_TRANSLATION[tabType]}`;
       default:
         return str;

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/Helmet.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/Helmet.js
@@ -3,11 +3,7 @@ import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
-import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
-  generateTabURL,
-} from 'constants/companyJobTitle';
+import { PageType, TabType, generateTabURL } from 'constants/companyJobTitle';
 
 const CompanyInterviewExperienceHelmet = ({
   companyName,
@@ -32,9 +28,9 @@ const CompanyInterviewExperienceHelmet = ({
 
   // canonical url
   const path = generateTabURL({
-    pageType: PAGE_TYPE.COMPANY,
+    pageType: PageType.COMPANY,
     pageName: companyName,
-    tabType: TAB_TYPE.INTERVIEW_EXPERIENCE,
+    tabType: TabType.INTERVIEW_EXPERIENCE,
   });
   const url = formatCanonicalPath(path);
 
@@ -79,9 +75,9 @@ const JobTitleInterviewExperienceHelmet = ({ jobTitle, page, totalCount }) => {
 
   // canonical url
   const path = generateTabURL({
-    pageType: PAGE_TYPE.JOB_TITLE,
+    pageType: PageType.JOB_TITLE,
     pageName: jobTitle,
-    tabType: TAB_TYPE.INTERVIEW_EXPERIENCE,
+    tabType: TabType.INTERVIEW_EXPERIENCE,
   });
   const url = formatCanonicalPath(path);
 
@@ -110,11 +106,11 @@ JobTitleInterviewExperienceHelmet.propTypes = {
 };
 
 const InterviewExperienceHelmet = props => {
-  if (props.pageType === PAGE_TYPE.JOB_TITLE) {
+  if (props.pageType === PageType.JOB_TITLE) {
     return (
       <JobTitleInterviewExperienceHelmet {...props} jobTitle={props.pageName} />
     );
-  } else if (props.pageType === PAGE_TYPE.COMPANY) {
+  } else if (props.pageType === PageType.COMPANY) {
     return (
       <CompanyInterviewExperienceHelmet
         {...props}

--- a/src/components/CompanyAndJobTitle/Overview/Helmet.js
+++ b/src/components/CompanyAndJobTitle/Overview/Helmet.js
@@ -6,10 +6,7 @@ import EmployerAggregateRatingSeo from './EmployerAggregateRatingSeo';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { SITE_NAME } from 'constants/helmetData';
-import {
-  pageType as PAGE_TYPE,
-  generatePageURL,
-} from 'constants/companyJobTitle';
+import { PageType, generatePageURL } from 'constants/companyJobTitle';
 
 // if length of given array > 0, return `${array length}${unit}`
 // otherwise return defaultStr
@@ -60,7 +57,7 @@ const CompanyOverviewHelmet = ({
   const description = `想了解${companyName}嗎？由內部員工分享${jobTitles}等職位的${combinedStr}，幫助你更瞭解${companyName}！`;
 
   const path = generatePageURL({
-    pageType: PAGE_TYPE.COMPANY,
+    pageType: PageType.COMPANY,
     pageName: companyName,
   });
   const url = formatCanonicalPath(path);
@@ -123,7 +120,7 @@ const JobTitleOverviewHelmet = ({
   const description = `查看由${jobTitle}分享的${salaryWorkTimesStr}薪水及加班數據、${workExperiencesStr}評價，以及由面試者分享的${interviewExperiencesStr}面試經驗。`;
 
   const path = generatePageURL({
-    pageType: PAGE_TYPE.JOB_TITLE,
+    pageType: PageType.JOB_TITLE,
     pageName: jobTitle,
   });
   const url = formatCanonicalPath(path);
@@ -151,9 +148,9 @@ JobTitleOverviewHelmet.propTypes = {
 };
 
 const OverviewHelmet = props => {
-  if (props.pageType === PAGE_TYPE.JOB_TITLE) {
+  if (props.pageType === PageType.JOB_TITLE) {
     return <JobTitleOverviewHelmet {...props} jobTitle={props.pageName} />;
-  } else if (props.pageType === PAGE_TYPE.COMPANY) {
+  } else if (props.pageType === PageType.COMPANY) {
     return <CompanyOverviewHelmet {...props} companyName={props.pageName} />;
   } else {
     return null;

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -8,7 +8,7 @@ import WorkingHourTable from '../TimeAndSalary/WorkingHourTable';
 import WorkExperienceEntry from '../WorkExperiences/ExperienceEntry';
 import InterviewExperienceEntry from '../InterviewExperiences/ExperienceEntry';
 import {
-  tabType as TAB_TYPE,
+  TabType,
   tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
   generateTabURL,
 } from 'constants/companyJobTitle';
@@ -34,17 +34,17 @@ const Overview = ({
   return (
     <Section Tag="main" paddingBottom>
       <SnippetBlock
-        title={TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]}
+        title={TAB_TYPE_DETAIL_TRANSLATION[TabType.TIME_AND_SALARY]}
         linkText={`查看 ${salaryWorkTimesCount} 筆完整的薪水、加班數據資料 >>`}
         linkTo={generateTabURL({
           pageType,
           pageName,
-          tabType: TAB_TYPE.TIME_AND_SALARY,
+          tabType: TabType.TIME_AND_SALARY,
         })}
         isEmpty={salaryWorkTimesCount === 0}
         pageType={pageType}
         pageName={pageName}
-        tabType={TAB_TYPE.TIME_AND_SALARY}
+        tabType={TabType.TIME_AND_SALARY}
       >
         <BoxRenderer
           box={statisticsBox}
@@ -69,19 +69,19 @@ const Overview = ({
         />
       </SnippetBlock>
       <SnippetBlock
-        title={TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.WORK_EXPERIENCE]}
+        title={TAB_TYPE_DETAIL_TRANSLATION[TabType.WORK_EXPERIENCE]}
         linkText={`查看 ${workExperiencesCount} 篇完整的 ${
-          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.WORK_EXPERIENCE]
+          TAB_TYPE_DETAIL_TRANSLATION[TabType.WORK_EXPERIENCE]
         } >>`}
         linkTo={generateTabURL({
           pageType,
           pageName,
-          tabType: TAB_TYPE.WORK_EXPERIENCE,
+          tabType: TabType.WORK_EXPERIENCE,
         })}
         isEmpty={workExperiencesCount === 0}
         pageType={pageType}
         pageName={pageName}
-        tabType={TAB_TYPE.WORK_EXPERIENCE}
+        tabType={TabType.WORK_EXPERIENCE}
       >
         {workExperiences.map(d => (
           <WorkExperienceEntry
@@ -93,19 +93,19 @@ const Overview = ({
         ))}
       </SnippetBlock>
       <SnippetBlock
-        title={TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.INTERVIEW_EXPERIENCE]}
+        title={TAB_TYPE_DETAIL_TRANSLATION[TabType.INTERVIEW_EXPERIENCE]}
         linkText={`查看 ${interviewExperiencesCount} 篇完整的${
-          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.INTERVIEW_EXPERIENCE]
+          TAB_TYPE_DETAIL_TRANSLATION[TabType.INTERVIEW_EXPERIENCE]
         } >>`}
         linkTo={generateTabURL({
           pageType,
           pageName,
-          tabType: TAB_TYPE.INTERVIEW_EXPERIENCE,
+          tabType: TabType.INTERVIEW_EXPERIENCE,
         })}
         isEmpty={interviewExperiencesCount === 0}
         pageType={pageType}
         pageName={pageName}
-        tabType={TAB_TYPE.INTERVIEW_EXPERIENCE}
+        tabType={TabType.INTERVIEW_EXPERIENCE}
       >
         {interviewExperiences.map(d => (
           <InterviewExperienceEntry

--- a/src/components/CompanyAndJobTitle/Searchbar.js
+++ b/src/components/CompanyAndJobTitle/Searchbar.js
@@ -11,7 +11,7 @@ import Magnifiner from 'common/icons/Magnifiner';
 import styles from './Searchbar.module.css';
 
 import {
-  pageType as pageTypes,
+  PageType,
   pageTypeTranslation,
   tabTypeTranslation,
 } from 'constants/companyJobTitle';
@@ -43,14 +43,14 @@ const Searchbar = ({ className, label, placeholder, onSubmit, pageType }) => {
   const onBlur = useCallback(() => {
     onSubmit(searchText);
     switch (pageType) {
-      case pageTypes.COMPANY:
+      case PageType.COMPANY:
         ReactGA.event({
           category: GA_CATEGORY.COMPANY_PAGE,
           action: GA_ACTION.SEARCH_JOB_TITLE,
           label: searchText,
         });
         break;
-      case pageTypes.JOB_TITLE:
+      case PageType.JOB_TITLE:
         ReactGA.event({
           category: GA_CATEGORY.JOB_TITLE_PAGE,
           action: GA_ACTION.SEARCH_COMPANY,
@@ -108,10 +108,10 @@ const WrappedSearchbar = ({ pageType, tabType }) => {
 
   const searchingPageType = (() => {
     switch (pageType) {
-      case pageTypes.COMPANY:
-        return pageTypes.JOB_TITLE;
-      case pageTypes.JOB_TITLE:
-        return pageTypes.COMPANY;
+      case PageType.COMPANY:
+        return PageType.JOB_TITLE;
+      case PageType.JOB_TITLE:
+        return PageType.COMPANY;
       default:
         return null;
     }

--- a/src/components/CompanyAndJobTitle/StatisticsCard/index.js
+++ b/src/components/CompanyAndJobTitle/StatisticsCard/index.js
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import Skeleton from 'react-loading-skeleton';
 import { companyRatingStatisticsBoxSelectorByName } from 'selectors/companyAndJobTitle';
-import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { PageType } from 'constants/companyJobTitle';
 import { isFetching } from 'utils/fetchBox';
 import styles from './StatisticsCard.module.css';
 import ThumbImage from 'common/icons/thumb.svg';
@@ -13,7 +13,7 @@ const StatisticsCard = ({ pageType, pageName }) => {
     companyRatingStatisticsBoxSelectorByName(pageName),
   );
 
-  if (pageType !== PAGE_TYPE.COMPANY) {
+  if (pageType !== PageType.COMPANY) {
     return null;
   }
 

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/Helmet.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/Helmet.js
@@ -4,8 +4,8 @@ import ReactHelmet from 'react-helmet';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
 import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
+  PageType,
+  TabType,
   tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
   generateTabURL,
 } from 'constants/companyJobTitle';
@@ -20,11 +20,9 @@ const CompanySalaryWorkTimeHelmet = ({
   // title
   const title =
     page === 1
-      ? `${companyName} ${
-          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]
-        }`
+      ? `${companyName} ${TAB_TYPE_DETAIL_TRANSLATION[TabType.TIME_AND_SALARY]}`
       : `${companyName} ${
-          TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]
+          TAB_TYPE_DETAIL_TRANSLATION[TabType.TIME_AND_SALARY]
         } - 第${page}頁`;
 
   // description
@@ -38,9 +36,9 @@ const CompanySalaryWorkTimeHelmet = ({
 
   // canonical url
   const path = generateTabURL({
-    pageType: PAGE_TYPE.COMPANY,
+    pageType: PageType.COMPANY,
     pageName: companyName,
-    tabType: TAB_TYPE.TIME_AND_SALARY,
+    tabType: TabType.TIME_AND_SALARY,
   });
   const url = formatCanonicalPath(path);
 
@@ -77,7 +75,7 @@ CompanySalaryWorkTimeHelmet.propTypes = {
 const JobTitleSalaryWorkTimeHelmet = ({ jobTitle, page, totalCount }) => {
   // title
   const title = `${jobTitle} ${
-    TAB_TYPE_DETAIL_TRANSLATION[TAB_TYPE.TIME_AND_SALARY]
+    TAB_TYPE_DETAIL_TRANSLATION[TabType.TIME_AND_SALARY]
   } - 第${page}頁`;
 
   // description
@@ -88,9 +86,9 @@ const JobTitleSalaryWorkTimeHelmet = ({ jobTitle, page, totalCount }) => {
 
   // canonical url
   const path = generateTabURL({
-    pageType: PAGE_TYPE.JOB_TITLE,
+    pageType: PageType.JOB_TITLE,
     pageName: jobTitle,
-    tabType: TAB_TYPE.TIME_AND_SALARY,
+    tabType: TabType.TIME_AND_SALARY,
   });
   const url = formatCanonicalPath(path);
 
@@ -120,11 +118,11 @@ JobTitleSalaryWorkTimeHelmet.propTypes = {
 };
 
 const Helmet = props => {
-  if (props.pageType === PAGE_TYPE.JOB_TITLE) {
+  if (props.pageType === PageType.JOB_TITLE) {
     return (
       <JobTitleSalaryWorkTimeHelmet {...props} jobTitle={props.pageName} />
     );
-  } else if (props.pageType === PAGE_TYPE.COMPANY) {
+  } else if (props.pageType === PageType.COMPANY) {
     return (
       <CompanySalaryWorkTimeHelmet {...props} companyName={props.pageName} />
     );

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/WorkingHourTable.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/WorkingHourTable.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import R from 'ramda';
 import { InfoButton } from 'common/Modal';
 import Table from 'common/table/Table';
-import { pageType as pageTypeMapping } from 'constants/companyJobTitle';
+import { PageType } from 'constants/companyJobTitle';
 import { InfoSalaryModal, InfoTimeModal } from './InfoModal';
 import styles from './WorkingHourTable.module.css';
 import {
@@ -58,7 +58,7 @@ const columnProps = [
     dataField: 'job_title',
     dataFormatter: getNameAsJobTitle,
     Children: () => '職稱',
-    isEnabled: ({ pageType }) => pageType === pageTypeMapping.COMPANY,
+    isEnabled: ({ pageType }) => pageType === PageType.COMPANY,
   },
   {
     className: styles.colPosition,
@@ -66,7 +66,7 @@ const columnProps = [
     dataField: 'company',
     dataFormatter: getNameAsCompanyName,
     Children: () => '公司名稱',
-    isEnabled: ({ pageType }) => pageType === pageTypeMapping.JOB_TITLE,
+    isEnabled: ({ pageType }) => pageType === PageType.JOB_TITLE,
   },
   {
     className: styles.colType,
@@ -227,10 +227,7 @@ const WorkingHourTable = ({ data, pageType, onCloseReport }) => {
 WorkingHourTable.propTypes = {
   data: PropTypes.array.isRequired,
   onCloseReport: PropTypes.func.isRequired,
-  pageType: PropTypes.oneOf([
-    pageTypeMapping.COMPANY,
-    pageTypeMapping.JOB_TITLE,
-  ]),
+  pageType: PropTypes.oneOf([PageType.COMPANY, PageType.JOB_TITLE]),
 };
 
 export default WorkingHourTable;

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/index.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/index.js
@@ -9,7 +9,7 @@ import OvertimeSection from './OvertimeSection';
 import Searchbar from '../Searchbar';
 import SummarySection from './SummarySection';
 import EsgBlock from '../TimeAndSalary/EsgBlock';
-import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { PageType } from 'constants/companyJobTitle';
 import { fetchBoxPropType } from 'utils/fetchBox';
 import { Wrapper } from 'common/base';
 import { useCreatePageLinkTo } from 'common/Pagination/Pagination';
@@ -36,7 +36,7 @@ const TimeAndSalary = ({
       pageName={pageName}
       tabType={tabType}
     >
-      {pageType === PAGE_TYPE.COMPANY && (
+      {pageType === PageType.COMPANY && (
         <BoxRenderer
           box={esgSalaryDataBox}
           render={data => {

--- a/src/components/CompanyAndJobTitle/WorkExperiences/Helmet.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/Helmet.js
@@ -3,11 +3,7 @@ import Helmet from 'react-helmet';
 import PropTypes from 'prop-types';
 import { formatTitle, formatCanonicalPath } from 'utils/helmetHelper';
 import { SITE_NAME } from 'constants/helmetData';
-import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
-  generateTabURL,
-} from 'constants/companyJobTitle';
+import { PageType, TabType, generateTabURL } from 'constants/companyJobTitle';
 
 const CompanyWorkExperienceHelmet = ({ companyName, page, totalCount }) => {
   // title
@@ -22,9 +18,9 @@ const CompanyWorkExperienceHelmet = ({ companyName, page, totalCount }) => {
 
   // canonical url
   const path = generateTabURL({
-    pageType: PAGE_TYPE.COMPANY,
+    pageType: PageType.COMPANY,
     pageName: companyName,
-    tabType: TAB_TYPE.WORK_EXPERIENCE,
+    tabType: TabType.WORK_EXPERIENCE,
   });
   const url = formatCanonicalPath(path);
 
@@ -64,9 +60,9 @@ const JobTitleWorkExperienceHelmet = ({ jobTitle, page, totalCount }) => {
 
   // canonical url
   const path = generateTabURL({
-    pageType: PAGE_TYPE.JOB_TITLE,
+    pageType: PageType.JOB_TITLE,
     pageName: jobTitle,
-    tabType: TAB_TYPE.WORK_EXPERIENCE,
+    tabType: TabType.WORK_EXPERIENCE,
   });
   const url = formatCanonicalPath(path);
 
@@ -95,11 +91,11 @@ JobTitleWorkExperienceHelmet.propTypes = {
 };
 
 const WorkExperienceHelmet = props => {
-  if (props.pageType === PAGE_TYPE.JOB_TITLE) {
+  if (props.pageType === PageType.JOB_TITLE) {
     return (
       <JobTitleWorkExperienceHelmet {...props} jobTitle={props.pageName} />
     );
-  } else if (props.pageType === PAGE_TYPE.COMPANY) {
+  } else if (props.pageType === PageType.COMPANY) {
     return (
       <CompanyWorkExperienceHelmet {...props} companyName={props.pageName} />
     );

--- a/src/components/CompanyAndJobTitle/utils.js
+++ b/src/components/CompanyAndJobTitle/utils.js
@@ -1,4 +1,3 @@
-// TODO, to ts
 import {
   pageTypeTranslation,
   tabTypeTranslation,

--- a/src/components/CompanyAndJobTitle/utils.js
+++ b/src/components/CompanyAndJobTitle/utils.js
@@ -1,7 +1,8 @@
+// TODO, to ts
 import {
   pageTypeTranslation,
   tabTypeTranslation,
-  tabType as TAG_TYPE,
+  TabType,
   generateIndexURL,
   generatePageURL,
   generateTabURL,
@@ -44,7 +45,7 @@ export const generateBreadCrumbData = ({
   ];
 
   // TODO: adhoc solution if the page is OVERVIEW
-  if (tabType === TAG_TYPE.OVERVIEW) {
+  if (tabType === TabType.OVERVIEW) {
     return data;
   }
 

--- a/src/components/ExperienceDetail/ChartsZone/index.js
+++ b/src/components/ExperienceDetail/ChartsZone/index.js
@@ -2,10 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
 import R from 'ramda';
-import {
-  pageType as PAGE_TYPE,
-  generatePageURL,
-} from 'constants/companyJobTitle';
+import { PageType, generatePageURL } from 'constants/companyJobTitle';
 import ChartWrapper from '../../LandingPage/ChartWrapper';
 import loadable from '@loadable/component';
 import styles from '../../LandingPage/SummarySection.module.css';
@@ -42,7 +39,7 @@ const ChartsZone = ({
           className={styles.chartWrapper}
           title={`${companyName}的薪水`}
           to={generatePageURL({
-            pageType: PAGE_TYPE.COMPANY,
+            pageType: PageType.COMPANY,
             pageName: companyName,
           })}
         >
@@ -58,7 +55,7 @@ const ChartsZone = ({
           className={styles.chartWrapper}
           title={`${jobTitle}的薪水分佈`}
           to={generatePageURL({
-            pageType: PAGE_TYPE.JOB_TITLE,
+            pageType: PageType.JOB_TITLE,
             pageName: jobTitle,
           })}
         >

--- a/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
+++ b/src/components/ExperienceDetail/MoreExperiencesBlock/index.js
@@ -11,7 +11,7 @@ import {
   loadMoreRelatedExperiences,
 } from 'actions/experience';
 import { relatedExperiencesStateSelector } from 'selectors/experienceSelector';
-import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { PageType } from 'constants/companyJobTitle';
 import { GA_CATEGORY, GA_ACTION } from 'constants/gaConstants';
 import Button from 'common/button/Button';
 import styles from './MoreExperiencesBlock.module.css';
@@ -53,7 +53,7 @@ const MoreExperiencesBlock = ({ experience }) => {
   const relatedExperiencesState = useSelector(relatedExperiencesStateSelector);
 
   const location = useLocation();
-  const { state: { pageType = PAGE_TYPE.COMPANY } = {} } = location;
+  const { state: { pageType = PageType.COMPANY } = {} } = location;
   const [, , canViewPublishId] = usePermission();
   const handleLoadMore = useCallback(
     () => dispatch(loadMoreRelatedExperiences()),

--- a/src/components/ExperienceDetail/index.js
+++ b/src/components/ExperienceDetail/index.js
@@ -25,10 +25,7 @@ import {
   queryRelatedExperiencesOnExperience,
 } from 'actions/experience';
 import { COMMENT_ZONE } from 'constants/formElements';
-import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
-} from 'constants/companyJobTitle';
+import { PageType, TabType } from 'constants/companyJobTitle';
 import { generateBreadCrumbData } from '../CompanyAndJobTitle/utils';
 import styles from './ExperienceDetail.module.css';
 import { experienceBoxSelectorAtId } from 'selectors/experienceSelector';
@@ -42,13 +39,13 @@ const useExperienceId = () => {
 };
 
 const experienceTypeToTabType = {
-  work: TAB_TYPE.WORK_EXPERIENCE,
-  interview: TAB_TYPE.INTERVIEW_EXPERIENCE,
+  work: TabType.WORK_EXPERIENCE,
+  interview: TabType.INTERVIEW_EXPERIENCE,
 };
 
 const pageTypeToNameSelector = {
-  [PAGE_TYPE.COMPANY]: R.path(['company', 'name']),
-  [PAGE_TYPE.JOB_TITLE]: R.path(['job_title', 'name']),
+  [PageType.COMPANY]: R.path(['company', 'name']),
+  [PageType.JOB_TITLE]: R.path(['job_title', 'name']),
 };
 
 const useExperienceBox = experienceId => {
@@ -79,7 +76,7 @@ const ExperienceDetail = ({ ...props }) => {
   useTrace(experienceId);
 
   const location = useLocation();
-  const pageType = R.pathOr(PAGE_TYPE.COMPANY, ['state', 'pageType'], location);
+  const pageType = R.pathOr(PageType.COMPANY, ['state', 'pageType'], location);
 
   const scrollToCommentZone = useCallback(() => {
     scroller.scrollTo(COMMENT_ZONE, { smooth: true, offset: -75 });

--- a/src/components/LandingPage/SummarySection.js
+++ b/src/components/LandingPage/SummarySection.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import { zip } from 'ramda';
 import loadable from '@loadable/component';
 import Carousel, { CarouselPage } from 'common/Carousel';
-import {
-  pageType as PAGE_TYPE,
-  generatePageURL,
-} from 'constants/companyJobTitle';
+import { PageType, generatePageURL } from 'constants/companyJobTitle';
 import ChartWrapper from './ChartWrapper';
 import styles from './SummarySection.module.css';
 const SalaryDistributionChart = loadable(() =>
@@ -45,7 +42,7 @@ const SummarySection = ({
                   className={styles.chartWrapper}
                   title={`${companyAverageSalary.name}的薪水`}
                   to={generatePageURL({
-                    pageType: PAGE_TYPE.COMPANY,
+                    pageType: PageType.COMPANY,
                     pageName: companyAverageSalary.name,
                   })}
                 >
@@ -64,7 +61,7 @@ const SummarySection = ({
                   className={styles.chartWrapper}
                   title={`${jobTitleSalaryDistribution.name}的薪水分佈`}
                   to={generatePageURL({
-                    pageType: PAGE_TYPE.JOB_TITLE,
+                    pageType: PageType.JOB_TITLE,
                     pageName: jobTitleSalaryDistribution.name,
                   })}
                 >

--- a/src/components/Me/ShareBlockElement/index.js
+++ b/src/components/Me/ShareBlockElement/index.js
@@ -6,11 +6,7 @@ import { Link } from 'react-router-dom';
 import Bookmark from 'common/icons/Bookmark';
 import { Heading, P } from 'common/base';
 import Modal from 'common/Modal';
-import {
-  pageType as PAGE_TYPE,
-  tabType as TAB_TYPE,
-  generateTabURL,
-} from 'constants/companyJobTitle';
+import { PageType, TabType, generateTabURL } from 'constants/companyJobTitle';
 import styles from './ShareBlockElement.module.css';
 
 const ShareBlock = ({
@@ -58,9 +54,9 @@ const ShareBlock = ({
           {type === '薪時' ? (
             <Link
               to={generateTabURL({
-                pageType: PAGE_TYPE.COMPANY,
+                pageType: PageType.COMPANY,
                 pageName: to,
-                tabType: TAB_TYPE.TIME_AND_SALARY,
+                tabType: TabType.TIME_AND_SALARY,
               })}
               title="檢視薪時"
               className="hoverBlue"

--- a/src/components/ShareExperience/InterviewForm/TypeForm/index.js
+++ b/src/components/ShareExperience/InterviewForm/TypeForm/index.js
@@ -42,7 +42,7 @@ import { getUserPseudoId } from 'utils/GAUtils';
 import rollbar from 'utils/rollbar';
 
 import { GA_MEASUREMENT_ID } from '../../../../config';
-import { tabType } from '../../../../constants/companyJobTitle';
+import { TabType } from 'constants/companyJobTitle';
 
 const header = <Header title="請輸入你的一份面試經驗" />;
 const renderCompanyJobTitleHeader = ({ companyName, jobTitle }) => (
@@ -59,11 +59,11 @@ const questions = [
   createInterviewDateQuestion(),
   createInterviewRegionQuestion(),
   createInterviewResultQuestion(),
-  createSalaryQuestion({ type: tabType.INTERVIEW_EXPERIENCE }),
+  createSalaryQuestion({ type: TabType.INTERVIEW_EXPERIENCE }),
   createJobTenureQuestion(),
   createInterviewSectionsQuestion(),
   createSensitiveQuestionsQuestion(),
-  createSubmitQuestion({ type: tabType.INTERVIEW_EXPERIENCE }),
+  createSubmitQuestion({ type: TabType.INTERVIEW_EXPERIENCE }),
 ];
 
 const bodyFromDraft = evolve({

--- a/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
+++ b/src/components/ShareExperience/TimeSalaryForm/TypeForm.js
@@ -42,7 +42,7 @@ import {
 import { ER0007, ERROR_CODE_MSG } from 'constants/errorCodeMsg';
 
 import { parseSalaryAmount, evolve } from '../utils';
-import { generateTabURL, pageType, tabType } from 'constants/companyJobTitle';
+import { generateTabURL, PageType, TabType } from 'constants/companyJobTitle';
 
 import { createSalaryWorkTime } from 'actions/salaryWorkTime';
 import { transferKeyToSnakecase } from 'utils/objectUtil';
@@ -71,7 +71,7 @@ const questions = [
   createSectorQuestion(),
   createEmployTypeQuestion(),
   createGenderQuestion(),
-  createRequiredSalaryQuestion({ type: tabType.TIME_AND_SALARY }),
+  createRequiredSalaryQuestion({ type: TabType.TIME_AND_SALARY }),
   createExperienceInYearQuestion(),
   createDayPromisedWorkTimeQuestion(),
   createDayRealWorkTimeQuestion(),
@@ -79,7 +79,7 @@ const questions = [
   createOvertimeFrequencyQuestion(),
   createOvertimeSalaryQuestion(),
   createCompensatoryDayOffQuestion(),
-  createSubmitQuestion({ type: tabType.TIME_AND_SALARY }),
+  createSubmitQuestion({ type: TabType.TIME_AND_SALARY }),
 ];
 
 const bodyFromDraft = evolve({
@@ -192,9 +192,9 @@ const TypeForm = ({ open, onClose, hideProgressBar = false }) => {
       onClose={onClose}
       redirectPathnameOnSuccess={(_, draft) =>
         generateTabURL({
-          pageType: pageType.COMPANY,
+          pageType: PageType.COMPANY,
           pageName: draft[DATA_KEY_COMPANY_NAME],
-          tabType: tabType.TIME_AND_SALARY,
+          tabType: TabType.TIME_AND_SALARY,
         })
       }
       hideProgressBar={hideProgressBar}

--- a/src/components/ShareExperience/WorkExperiencesForm/TypeForm.js
+++ b/src/components/ShareExperience/WorkExperiencesForm/TypeForm.js
@@ -32,7 +32,7 @@ import {
 } from '../constants';
 
 import { parseSalaryAmount, evolve } from '../utils';
-import { tabType } from '../../../constants/companyJobTitle';
+import { TabType } from 'constants/companyJobTitle';
 
 import { createWorkExperienceWithRating } from 'actions/experiences';
 import { transferKeyToSnakecase } from 'utils/objectUtil';
@@ -59,10 +59,10 @@ const questions = [
   createExperienceInYearQuestion(),
   createWorkRegionQuestion(),
   createEmployTypeQuestion(),
-  createRequiredSalaryQuestion({ type: tabType.WORK_EXPERIENCE }),
+  createRequiredSalaryQuestion({ type: TabType.WORK_EXPERIENCE }),
   createWeekWorkTimeQuestion(),
   createSectionsQuestion(),
-  createSubmitQuestion({ type: tabType.WORK_EXPERIENCE }),
+  createSubmitQuestion({ type: TabType.WORK_EXPERIENCE }),
 ];
 
 const bodyFromDraft = evolve({

--- a/src/components/ShareExperience/questionCreators.js
+++ b/src/components/ShareExperience/questionCreators.js
@@ -58,10 +58,10 @@ import { employmentTypeOptions, salaryTypeOptions } from './common/optionMap';
 import WorkTimeExample from './WorkTimeExample';
 import Emoji from '../common/icons/Emoji';
 import {
-  pageType as PAGE_TYPE,
+  PageType,
   tabTypeTranslation,
-  tabType,
-} from '../../constants/companyJobTitle';
+  TabType,
+} from 'constants/companyJobTitle';
 import { QUESTION_TYPE } from '../common/FormBuilder/QuestionBuilder';
 import { salaryHint } from 'utils/formUtils';
 import { useTotalCount } from 'hooks/useCount';
@@ -87,7 +87,7 @@ export const createCompanyQuestion = ({ header }) => ({
       map(({ name, businessNumber }) => ({
         label: (
           <AutoCompleteItem
-            pageType={PAGE_TYPE.COMPANY}
+            pageType={PageType.COMPANY}
             name={name}
             businessNumber={businessNumber}
           />
@@ -234,7 +234,7 @@ export const createJobTenureQuestion = () => ({
 });
 
 export const createRequiredSalaryQuestion = ({ type }) => ({
-  title: type === tabType.INTERVIEW_EXPERIENCE ? '面談薪資' : '薪資',
+  title: type === TabType.INTERVIEW_EXPERIENCE ? '面談薪資' : '薪資',
   type: QUESTION_TYPE.SELECT_TEXT,
   dataKey: DATA_KEY_SALARY,
   defaultValue: [null, ''],
@@ -259,7 +259,7 @@ export const createRequiredSalaryQuestion = ({ type }) => ({
     else return hint;
   },
   footnote:
-    type === tabType.INTERVIEW_EXPERIENCE
+    type === TabType.INTERVIEW_EXPERIENCE
       ? '若錄取，請以包含平常的薪資、分紅、年終、獎金等預期會獲得的價值計算'
       : '薪資請以包含平常的薪資、分紅、年終、績效獎金等實質上獲得的價值去計算。',
 });

--- a/src/components/TimeAndSalary/common/formatter.js
+++ b/src/components/TimeAndSalary/common/formatter.js
@@ -2,16 +2,13 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { formatSalaryAmount, formatSalaryType } from 'common/formatter';
 import employmentType from 'constants/employmentType';
-import {
-  pageType as PAGE_TYPE,
-  generatePageURL,
-} from 'constants/companyJobTitle';
+import { PageType, generatePageURL } from 'constants/companyJobTitle';
 import styles from './formatter.module.css';
 
 export const getNameAsCompanyName = (o, row) => (
   <Link
     to={generatePageURL({
-      pageType: PAGE_TYPE.COMPANY,
+      pageType: PageType.COMPANY,
       pageName: o.name,
     })}
   >
@@ -23,7 +20,7 @@ export const getNameAsCompanyName = (o, row) => (
 export const getNameAsJobTitle = (o, row) => (
   <Link
     to={generatePageURL({
-      pageType: PAGE_TYPE.JOB_TITLE,
+      pageType: PageType.JOB_TITLE,
       pageName: o.name,
     })}
   >

--- a/src/components/common/form/TextInput/SearchTextInput.js
+++ b/src/components/common/form/TextInput/SearchTextInput.js
@@ -7,7 +7,7 @@ import TextInput from '.';
 
 import { fetchSearchCompany, fetchSearchJobTitle } from 'apis/timeAndSalaryApi';
 import AutoCompleteItem from 'components/ShareExperience/AutoCompleteItem';
-import { pageType as PAGE_TYPE } from 'constants/companyJobTitle';
+import { PageType } from 'constants/companyJobTitle';
 
 const take5 = R.take(5);
 
@@ -54,7 +54,7 @@ const SearchTextInput = forwardRef(
               ...take5(companies).map(({ name, businessNumber }) => ({
                 label: (
                   <AutoCompleteItem
-                    pageType={PAGE_TYPE.COMPANY}
+                    pageType={PageType.COMPANY}
                     name={name}
                     businessNumber={businessNumber}
                   />
@@ -63,10 +63,7 @@ const SearchTextInput = forwardRef(
               })),
               ...take5(jobTitles).map(name => ({
                 label: (
-                  <AutoCompleteItem
-                    pageType={PAGE_TYPE.JOB_TITLE}
-                    name={name}
-                  />
+                  <AutoCompleteItem pageType={PageType.JOB_TITLE} name={name} />
                 ),
                 value: name,
               })),

--- a/src/constants/companyJobTitle.ts
+++ b/src/constants/companyJobTitle.ts
@@ -5,9 +5,7 @@ enum PageType {
   COMPANY = 'COMPANY',
 }
 
-const pageType = PageType;
-
-export { pageType, PageType };
+export { PageType };
 
 export const pageTypeTranslation: Record<PageType, string> = {
   [PageType.JOB_TITLE]: '職稱',
@@ -26,9 +24,7 @@ enum TabType {
   INTERVIEW_EXPERIENCE = 'INTERVIEW_EXPERIENCE',
 }
 
-const tabType = TabType;
-
-export { tabType, TabType };
+export { TabType };
 
 export const tabTypeTranslation: Record<TabType, string> = {
   [TabType.OVERVIEW]: '總覽',

--- a/src/pages/Company/CompanyIndexProvider.js
+++ b/src/pages/Company/CompanyIndexProvider.js
@@ -4,7 +4,7 @@ import { querySelector } from 'common/routing/selectors';
 import { pageFromQuerySelector } from 'selectors/routing';
 import CompanyAndJobTitleIndexPage from 'components/CompanyAndJobTitle/IndexPage';
 import usePagination from 'components/CompanyAndJobTitle/IndexPage/usePagination';
-import { pageType as PAGE_TYPE, PAGE_SIZE } from 'constants/companyJobTitle';
+import { PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import { fetchCompanyNames } from 'actions/company';
 import {
   companyIndexesBoxSelectorAtPage,
@@ -27,7 +27,7 @@ const CompanyIndexProvider = () => {
     <Wrapper size="l">
       <CompanyAndJobTitleIndexPage
         totalCount={totalCount}
-        pageType={PAGE_TYPE.COMPANY}
+        pageType={PageType.COMPANY}
         indexesBox={companyIndexesBox}
         page={page}
         getPageLink={getPageLink}

--- a/src/pages/Company/CompanyInterviewExperiencesProvider.js
+++ b/src/pages/Company/CompanyInterviewExperiencesProvider.js
@@ -4,11 +4,7 @@ import InterviewExperiences from 'components/CompanyAndJobTitle/InterviewExperie
 import { paramsSelector, querySelector } from 'common/routing/selectors';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-  PAGE_SIZE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import {
   queryCompanyInterviewExperiences,
   queryCompanyTopNJobTitles,
@@ -54,7 +50,7 @@ const useInterviewExperiencesBoxSelector = companyName => {
 
 const CompanyInterviewExperiencesProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.COMPANY;
+  const pageType = PageType.COMPANY;
   const companyName = useCompanyName();
   const [jobTitle] = useSearchTextFromQuery();
   const [sortBy] = useSortByFromQuery();
@@ -97,7 +93,7 @@ const CompanyInterviewExperiencesProvider = () => {
       pageName={companyName}
       page={page}
       pageSize={PAGE_SIZE}
-      tabType={TAB_TYPE.INTERVIEW_EXPERIENCE}
+      tabType={TabType.INTERVIEW_EXPERIENCE}
       topNJobTitles={topNJobTitles.interview}
       boxSelector={boxSelector}
     />

--- a/src/pages/Company/CompanyOverviewProvider.js
+++ b/src/pages/Company/CompanyOverviewProvider.js
@@ -2,10 +2,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Overview from 'components/CompanyAndJobTitle/Overview';
 import usePermission from 'hooks/usePermission';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType } from 'constants/companyJobTitle';
 import {
   queryCompanyOverview,
   queryCompanyOverviewStatistics,
@@ -40,7 +37,7 @@ const useOverviewStatisticsBox = pageName => {
 
 const CompanyOverviewProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.COMPANY;
+  const pageType = PageType.COMPANY;
   const companyName = useCompanyName();
 
   const handleQueryCompanyOverview = useCallback(
@@ -84,7 +81,7 @@ const CompanyOverviewProvider = () => {
     <Overview
       pageType={pageType}
       pageName={companyName}
-      tabType={TAB_TYPE.OVERVIEW}
+      tabType={TabType.OVERVIEW}
       topNJobTitles={topNJobTitles.all}
       boxSelector={boxSelector}
       statisticsBox={statisticsBox}

--- a/src/pages/Company/CompanyTimeAndSalaryProvider.js
+++ b/src/pages/Company/CompanyTimeAndSalaryProvider.js
@@ -3,11 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import TimeAndSalary from 'components/CompanyAndJobTitle/TimeAndSalary';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-  PAGE_SIZE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import {
   queryCompanyEsgSalaryData,
   queryCompanyOverviewStatistics,
@@ -72,7 +68,7 @@ const useEsgSalaryDataBox = companyName => {
 
 const CompanyTimeAndSalaryProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.COMPANY;
+  const pageType = PageType.COMPANY;
   const companyName = useCompanyName();
   const [jobTitle] = useSearchTextFromQuery();
   const page = usePage();
@@ -152,7 +148,7 @@ const CompanyTimeAndSalaryProvider = () => {
       pageSize={PAGE_SIZE}
       topNJobTitles={topNJobTitles.salary}
       esgSalaryDataBox={esgSalaryDataBox}
-      tabType={TAB_TYPE.TIME_AND_SALARY}
+      tabType={TabType.TIME_AND_SALARY}
       salaryWorkTimeStatistics={salaryWorkTimeStatistics}
       boxSelector={boxSelector}
       statisticsBox={statisticsBox}

--- a/src/pages/Company/CompanyWorkExperiencesProvider.js
+++ b/src/pages/Company/CompanyWorkExperiencesProvider.js
@@ -3,11 +3,7 @@ import { useDispatch } from 'react-redux';
 import WorkExperiences from 'components/CompanyAndJobTitle/WorkExperiences';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-  PAGE_SIZE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import {
   queryCompanyWorkExperiences,
   queryRatingStatistics,
@@ -50,7 +46,7 @@ const useWorkExperiencesBoxSelector = pageName => {
 
 const CompanyWorkExperiencesProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.COMPANY;
+  const pageType = PageType.COMPANY;
   const companyName = useCompanyName();
   const [jobTitle] = useSearchTextFromQuery();
   const [sortBy] = useSortByFromQuery();
@@ -87,7 +83,7 @@ const CompanyWorkExperiencesProvider = () => {
       pageName={companyName}
       page={page}
       pageSize={PAGE_SIZE}
-      tabType={TAB_TYPE.WORK_EXPERIENCE}
+      tabType={TabType.WORK_EXPERIENCE}
       boxSelector={boxSelector}
     />
   );

--- a/src/pages/JobTitle/JobTitleIndexProvider.js
+++ b/src/pages/JobTitle/JobTitleIndexProvider.js
@@ -4,7 +4,7 @@ import { querySelector } from 'common/routing/selectors';
 import { pageFromQuerySelector } from 'selectors/routing';
 import CompanyAndJobTitleIndexPage from 'components/CompanyAndJobTitle/IndexPage';
 import usePagination from 'components/CompanyAndJobTitle/IndexPage/usePagination';
-import { pageType as PAGE_TYPE, PAGE_SIZE } from 'constants/companyJobTitle';
+import { PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import { fetchJobTitles } from 'actions/jobTitle';
 import {
   jobTitleIndexesBoxSelectorAtPage,
@@ -27,7 +27,7 @@ const JobTitleIndexProvider = () => {
   return (
     <CompanyAndJobTitleIndexPage
       totalCount={totalCount}
-      pageType={PAGE_TYPE.JOB_TITLE}
+      pageType={PageType.JOB_TITLE}
       indexesBox={jobTitleIndexesBox}
       page={page}
       getPageLink={getPageLink}

--- a/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -3,11 +3,7 @@ import { useDispatch } from 'react-redux';
 import InterviewExperiences from 'components/CompanyAndJobTitle/InterviewExperiences';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-  PAGE_SIZE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import { queryJobTitleInterviewExperiences } from 'actions/jobTitle';
 import { jobTitleInterviewExperiencesBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
@@ -49,7 +45,7 @@ const useInterviewExperiencesBoxSelector = jobTitle => {
 
 const JobTitleTimeAndSalaryProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.JOB_TITLE;
+  const pageType = PageType.JOB_TITLE;
   const jobTitle = useJobTitle();
   const [companyName] = useSearchTextFromQuery();
   const [sortBy] = useSortByFromQuery();
@@ -82,7 +78,7 @@ const JobTitleTimeAndSalaryProvider = () => {
       pageName={jobTitle}
       page={page}
       pageSize={PAGE_SIZE}
-      tabType={TAB_TYPE.INTERVIEW_EXPERIENCE}
+      tabType={TabType.INTERVIEW_EXPERIENCE}
       boxSelector={boxSelector}
     />
   );

--- a/src/pages/JobTitle/JobTitleOverviewProvider.js
+++ b/src/pages/JobTitle/JobTitleOverviewProvider.js
@@ -2,10 +2,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import Overview from 'components/CompanyAndJobTitle/Overview';
 import usePermission from 'hooks/usePermission';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType } from 'constants/companyJobTitle';
 import {
   queryJobTitleOverview,
   queryJobTitleOverviewStatistics,
@@ -37,7 +34,7 @@ const useOverviewStatisticsBox = pageName => {
 
 const JobTitleOverviewProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.JOB_TITLE;
+  const pageType = PageType.JOB_TITLE;
   const jobTitle = useJobTitle();
 
   const handleQueryJobTitleOverview = useCallback(
@@ -67,7 +64,7 @@ const JobTitleOverviewProvider = () => {
     <Overview
       pageType={pageType}
       pageName={jobTitle}
-      tabType={TAB_TYPE.OVERVIEW}
+      tabType={TabType.OVERVIEW}
       boxSelector={boxSelector}
       statisticsBox={statisticsBox}
       onCloseReport={() => handleQueryJobTitleOverview({ force: true })}

--- a/src/pages/JobTitle/JobTitleTimeAndSalaryProvider.js
+++ b/src/pages/JobTitle/JobTitleTimeAndSalaryProvider.js
@@ -3,11 +3,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import TimeAndSalary from 'components/CompanyAndJobTitle/TimeAndSalary';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-  PAGE_SIZE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import {
   queryJobTitleOverviewStatistics,
   queryJobTitleTimeAndSalary,
@@ -61,7 +57,7 @@ const useTimeAndSalaryBoxSelector = pageName => {
 
 const JobTitleTimeAndSalaryProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.JOB_TITLE;
+  const pageType = PageType.JOB_TITLE;
   const jobTitle = useJobTitle();
   const [companyName] = useSearchTextFromQuery();
   const page = usePage();
@@ -117,7 +113,7 @@ const JobTitleTimeAndSalaryProvider = () => {
       pageName={jobTitle}
       page={page}
       pageSize={PAGE_SIZE}
-      tabType={TAB_TYPE.TIME_AND_SALARY}
+      tabType={TabType.TIME_AND_SALARY}
       salaryWorkTimeStatistics={salaryWorkTimeStatistics}
       boxSelector={boxSelector}
       statisticsBox={statisticsBox}

--- a/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleWorkExperiencesProvider.js
@@ -3,11 +3,7 @@ import { useDispatch } from 'react-redux';
 import WorkExperiences from 'components/CompanyAndJobTitle/WorkExperiences';
 import usePermission from 'hooks/usePermission';
 import { usePage } from 'hooks/routing/page';
-import {
-  tabType as TAB_TYPE,
-  pageType as PAGE_TYPE,
-  PAGE_SIZE,
-} from 'constants/companyJobTitle';
+import { TabType, PageType, PAGE_SIZE } from 'constants/companyJobTitle';
 import { queryJobTitleWorkExperiences } from 'actions/jobTitle';
 import { jobTitleWorkExperiencesBoxSelectorByName as workExperiencesBoxSelectorByName } from 'selectors/companyAndJobTitle';
 import { paramsSelector, querySelector } from 'common/routing/selectors';
@@ -47,7 +43,7 @@ const useWorkExperiencesBoxSelector = pageName => {
 
 const JobTitleWorkExperiencesProvider = () => {
   const dispatch = useDispatch();
-  const pageType = PAGE_TYPE.JOB_TITLE;
+  const pageType = PageType.JOB_TITLE;
   const jobTitle = useJobTitle();
   const [companyName] = useSearchTextFromQuery();
   const [sortBy] = useSortByFromQuery();
@@ -80,7 +76,7 @@ const JobTitleWorkExperiencesProvider = () => {
       pageName={jobTitle}
       page={page}
       pageSize={PAGE_SIZE}
-      tabType={TAB_TYPE.WORK_EXPERIENCE}
+      tabType={TabType.WORK_EXPERIENCE}
       boxSelector={boxSelector}
     />
   );


### PR DESCRIPTION
## Summary

- Remove redundant `const pageType = PageType` and `const tabType = TabType` alias variables from `src/constants/companyJobTitle.ts`
- Update all 35 files to use the enum names (`PageType`, `TabType`) directly instead of the aliases

## Motivation

Using lowercase aliases (`pageType`, `tabType`) for TypeScript enums is a JavaScript legacy pattern. Now that these are proper TypeScript enums, callers should reference them by their canonical enum name directly, which is clearer and more idiomatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)