### PR TITLE
chore/doc: 建立 SSR fetchData 慣例文件

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,7 @@ npm run testonly    # unit tests only
 - **`src/pages/`** — route-level (page) components. If a component is directly mounted by a route in `src/routes.js`, it belongs here, not inside `src/components/`.
 - **`src/components/`** — reusable UI components, organized by domain (e.g. `CompanyAndJobTitle/`, `SalaryWorkTime/`). A component's location and name should reflect its actual domain, not where it was first created. Rename and move when reuse expands beyond the original context.
 `src/apis/` contains all API calls to the backend. When writing or modifying API-related code, follow the TypeScript typing guidelines in [src/apis/README.md](src/apis/README.md).
+
+### Server-Side Rendering (SSR) with `fetchData`
+
+Pages that need SSR data fetching attach a static `fetchData` method to the component. See [docs/ssr-fetch-data.md](docs/ssr-fetch-data.md).

--- a/docs/ssr-fetch-data.md
+++ b/docs/ssr-fetch-data.md
@@ -1,0 +1,55 @@
+# SSR `fetchData` Convention
+
+Pages that need SSR data fetching attach a static `fetchData` method to the component.
+
+## Key files
+
+- `src/types/serverSideRender.ts` — `ServerSideRender<Params>` interface
+
+## Conventions
+
+### 1. Typing the component
+
+Define a `Params` type for the URL params, then intersect `React.FC` with `ServerSideRender<Params>`:
+
+```tsx
+import { ServerSideRender } from 'types/serverSideRender';
+
+type Params = {
+  companyName: string;
+  aspect: string;
+};
+
+const MyProvider: React.FC & ServerSideRender<Params> = () => {
+  // render
+};
+```
+
+### 2. Writing `fetchData`
+
+Destructure `store: { dispatch }` and spread the rest as `props`. Use routing selectors on `props` to extract URL params and query string. Return `Promise<unknown>`.
+
+```tsx
+MyProvider.fetchData = async ({
+  store: { dispatch },
+  ...props
+}): Promise<unknown> => {
+  const params = paramsSelector<Params>(props);
+  const query = querySelector(props);
+  // derive values from params/query, then dispatch
+  return dispatch(someAction(...));
+};
+```
+
+### 3. Routing selectors
+
+Selectors from `common/routing/selectors` (`paramsSelector`, `querySelector`, etc.) must **only** be called inside `fetchData`. They depend on `match` and `location` injected by the SSR framework, which are not available during client-side rendering.
+
+In components, use React Router hooks instead:
+
+| Selector | Hook equivalent |
+|---|---|
+| `paramsSelector` | `useParams()` |
+| `pathnameSelector` / `searchSelector` | `useLocation()` |
+| `querySelector` | `useLocation()` + `qs.parse()` |
+| `pathSelector` | `useRouteMatch()` |

--- a/src/components/common/routing/selectors.ts
+++ b/src/components/common/routing/selectors.ts
@@ -2,13 +2,21 @@ import { match } from 'react-router-dom';
 import { Location } from 'history';
 import qs from 'qs';
 
-// RouteProps is the parameter injected from server.js fetchData
-// It is used in SSR with static fetchData method
+// RouteProps is the parameter injected from server.js fetchData.
+// It is used in SSR with the static fetchData method.
+//
+// IMPORTANT: Selectors in this file must ONLY be called inside fetchData.
+// They depend on `match` and `location` being injected by the SSR framework,
+// which only happens in that context.
+// In components, use React Router hooks instead:
+//   - useParams()    instead of paramsSelector
+//   - useLocation()  instead of pathnameSelector / searchSelector / querySelector
+//   - useRouteMatch() instead of pathSelector
 type RouteProps<
   Params extends Record<string, string> = Record<string, string>
 > = {
-  match?: match<Params>;
-  location?: Location;
+  match: match<Params>;
+  location: Location;
 };
 
 export const pathSelector = ({ match }: RouteProps): string | undefined =>
@@ -16,7 +24,7 @@ export const pathSelector = ({ match }: RouteProps): string | undefined =>
 
 export const paramsSelector = <Params extends Record<string, string>>({
   match,
-}: RouteProps<Params>): Params | undefined => match && match.params;
+}: RouteProps<Params>): Params => match && match.params;
 
 export const pathnameSelector = ({
   location,

--- a/src/types/serverSideRender.ts
+++ b/src/types/serverSideRender.ts
@@ -1,5 +1,6 @@
 import { Dispatch, GetState } from 'reducers';
 import { match } from 'react-router-dom';
+import { Location } from 'history';
 
 interface Store {
   dispatch: Dispatch;
@@ -12,8 +13,10 @@ export interface ServerSideRender<
   fetchData: ({
     store,
     match,
+    location,
   }: {
     store: Store;
     match: match<Params>;
+    location: Location;
   }) => Promise<unknown>;
 }


### PR DESCRIPTION
Close #  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？

建立 SSR `fetchData` 的使用慣例文件，並補強相關型別定義。

- 新增 `docs/ssr-fetch-data.md`：說明元件型別定義、`fetchData` 撰寫方式，以及 routing selectors 的使用限制與對應 React Router hooks 對照表
- 更新 `AGENTS.md`：新增 SSR `fetchData` 慣例段落，指向上述文件
- 強化 `selectors.ts` 的警告註解，並將 `RouteProps` 的 `match`、`location` 從 optional 改為 required，反映實際使用情境
- 補強 `ServerSideRender` interface：在 `fetchData` 簽名中加入 `location: Location`

## 我應該如何手動測試？

- [ ] `npm run test` 全部通過（lint + unit tests）
- [ ] 確認使用 `fetchData` 的頁面（如公司頁、薪資頁）SSR 行為正常