### PR TITLE
chore: migrate work experience APIs to TypeScript

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -22,11 +22,11 @@ import {
 import {
   getCompanyTimeAndSalary,
   getCompanyInterviewExperiences,
-  getCompanyWorkExperiences,
   queryCompaniesApi,
   getCompanyTimeAndSalaryStatistics,
   getCompanyTopNJobTitles,
 } from 'apis/company';
+import queryCompanyWorkExperiencesApi from 'apis/queryCompanyWorkExperiences';
 import queryCompanyEsgSalaryDataApi from 'apis/queryCompanyEsgSalaryData';
 import queryCompanyIsSubscribedApi from 'apis/queryCompanyIsSubscribed';
 import queryCompanyOverviewApi from 'apis/queryCompanyOverview';
@@ -526,7 +526,7 @@ export const queryCompanyWorkExperiences = ({
   dispatch(setWorkExperiences(companyName, toFetching(box)));
 
   try {
-    const data = await getCompanyWorkExperiences({
+    const data = await queryCompanyWorkExperiencesApi({
       companyName,
       jobTitle,
       start,
@@ -539,6 +539,7 @@ export const queryCompanyWorkExperiences = ({
       return dispatch(setWorkExperiences(companyName, getFetched(data)));
     }
 
+    /** @type {import('reducers/companyIndex').CompanyWorkExperienceResult} */
     const workExperiencesData = {
       name: data.name,
       jobTitle,

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -21,9 +21,9 @@ import {
   getJobTitleTimeAndSalary,
   getJobTitleTimeAndSalaryStatistics,
   getJobTitleInterviewExperiences,
-  getJobTitleWorkExperiences,
   queryJobTitlesApi,
 } from 'apis/jobTitle';
+import queryJobTitleWorkExperiencesApi from 'apis/queryJobTitleWorkExperiences';
 import { setExperience } from './experience';
 
 export const SET_OVERVIEW = '@@JOB_TITLE/SET_OVERVIEW';
@@ -394,7 +394,7 @@ export const queryJobTitleWorkExperiences = ({
   dispatch(setWorkExperiences(jobTitle, toFetching(box)));
 
   try {
-    const data = await getJobTitleWorkExperiences({
+    const data = await queryJobTitleWorkExperiencesApi({
       jobTitle,
       companyName,
       start,
@@ -407,6 +407,7 @@ export const queryJobTitleWorkExperiences = ({
       return dispatch(setWorkExperiences(jobTitle, getFetched(data)));
     }
 
+    /** @type {import('reducers/jobTitleIndex').JobTitleWorkExperienceResult} */
     const workExperiencesData = {
       name: data.name,
       companyName,

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -3,7 +3,6 @@ import graphqlClient from 'utils/graphqlClient';
 import {
   getCompanyTimeAndSalaryQuery,
   getCompanyInterviewExperiencesQuery,
-  getCompanyWorkExperiencesQuery,
   queryCompaniesHavingDataGql,
   getCompanyTimeAndSalaryStatisticsQuery,
   getCompanyTopNJobTitlesQuery,
@@ -41,18 +40,6 @@ export const getCompanyInterviewExperiences = ({
 }) =>
   graphqlClient({
     query: getCompanyInterviewExperiencesQuery,
-    variables: { companyName, jobTitle, start, limit, sortBy },
-  }).then(R.prop('company'));
-
-export const getCompanyWorkExperiences = ({
-  companyName,
-  jobTitle,
-  start,
-  limit,
-  sortBy,
-}) =>
-  graphqlClient({
-    query: getCompanyWorkExperiencesQuery,
     variables: { companyName, jobTitle, start, limit, sortBy },
   }).then(R.prop('company'));
 

--- a/src/apis/experience.ts
+++ b/src/apis/experience.ts
@@ -1,0 +1,61 @@
+import { JobAverageSalary, SalaryDistributionBin } from 'apis/salaryWorkTime';
+
+export enum ExperienceType {
+  WORK = 'work',
+  INTERVIEW = 'interview',
+  INTERN = 'intern',
+}
+
+type ExperienceReport = {
+  id: string;
+  reasonCategory: string;
+  reason: string | null;
+  createdAt: string;
+};
+
+type Salary = {
+  type: string;
+  amount: number;
+};
+
+type SectionWithRating = {
+  aspect: string;
+  subtitle: string;
+  content: string;
+  rating: number | null;
+};
+
+// Must be the same schema as
+// ${experiencePartialGql}
+// ${workExperiencesPartialGql()}
+export type WorkExperience = {
+  id: string;
+  type: ExperienceType.WORK;
+  originalCompanyName: string;
+  reportCount: number;
+  reports: ExperienceReport[];
+  company: {
+    name: string;
+    salary_work_time_statistics: {
+      job_average_salaries: JobAverageSalary[];
+    };
+  };
+  job_title: {
+    name: string;
+    salary_distribution: {
+      bins: SalaryDistributionBin[] | null;
+    };
+  };
+  region: string;
+  experience_in_year: number | null;
+  education: string | null;
+  salary: Salary | null;
+  title: string | null;
+  created_at: string;
+  sections: SectionWithRating[];
+  week_work_time: number | null;
+  recommend_to_others: string | null;
+  averageSectionRating: number | null;
+  reply_count: number;
+  like_count: number;
+};

--- a/src/apis/jobTitle.js
+++ b/src/apis/jobTitle.js
@@ -3,7 +3,6 @@ import graphqlClient from 'utils/graphqlClient';
 import {
   getJobTitleInterviewExperiencesQuery,
   getJobTitleTimeAndSalaryQuery,
-  getJobTitleWorkExperiencesQuery,
   queryJobTitlesHavingDataGql,
   getJobTitleTimeAndSalaryStatisticsQuery,
 } from 'graphql/jobTitle';
@@ -34,18 +33,6 @@ export const getJobTitleInterviewExperiences = ({
 }) =>
   graphqlClient({
     query: getJobTitleInterviewExperiencesQuery,
-    variables: { jobTitle, companyName, start, limit, sortBy },
-  }).then(R.prop('job_title'));
-
-export const getJobTitleWorkExperiences = ({
-  jobTitle,
-  companyName,
-  start,
-  limit,
-  sortBy,
-}) =>
-  graphqlClient({
-    query: getJobTitleWorkExperiencesQuery,
     variables: { jobTitle, companyName, start, limit, sortBy },
   }).then(R.prop('job_title'));
 

--- a/src/apis/queryCompanyWorkExperiences.ts
+++ b/src/apis/queryCompanyWorkExperiences.ts
@@ -1,0 +1,65 @@
+import R from 'ramda';
+import graphqlClient from 'utils/graphqlClient';
+import { Company } from 'graphql/company';
+import { WorkExperience } from 'apis/experience';
+import {
+  experiencePartialGql,
+  workExperiencesPartialGql,
+} from 'graphql/experience';
+
+const queryCompanyWorkExperiencesGql = /* GraphQL */ `
+  query(
+    $companyName: String!
+    $jobTitle: String
+    $start: Int!
+    $limit: Int!
+    $sortBy: DataResultSortOption
+  ) {
+    company(name: $companyName) {
+      name
+      workExperiencesResult(
+        jobTitle: $jobTitle
+        start: $start
+        limit: $limit
+        sortBy: $sortBy
+      ) {
+        count
+        workExperiences {
+          ${experiencePartialGql}
+          ${workExperiencesPartialGql()}
+        }
+      }
+    }
+  }
+`;
+
+type QueryCompanyWorkExperiencesData = {
+  company:
+    | (Company & {
+        workExperiencesResult: {
+          count: number;
+          workExperiences: WorkExperience[];
+        };
+      })
+    | null;
+};
+
+const queryCompanyWorkExperiences = ({
+  companyName,
+  jobTitle,
+  start,
+  limit,
+  sortBy,
+}: {
+  companyName: string;
+  jobTitle?: string;
+  start: number;
+  limit: number;
+  sortBy?: string;
+}): Promise<QueryCompanyWorkExperiencesData['company']> =>
+  graphqlClient<QueryCompanyWorkExperiencesData>({
+    query: queryCompanyWorkExperiencesGql,
+    variables: { companyName, jobTitle, start, limit, sortBy },
+  }).then(R.prop('company'));
+
+export default queryCompanyWorkExperiences;

--- a/src/apis/queryJobTitleWorkExperiences.ts
+++ b/src/apis/queryJobTitleWorkExperiences.ts
@@ -1,0 +1,65 @@
+import R from 'ramda';
+import graphqlClient from 'utils/graphqlClient';
+import { JobTitle } from 'graphql/jobTitle';
+import {
+  experiencePartialGql,
+  workExperiencesPartialGql,
+} from 'graphql/experience';
+import { WorkExperience } from 'apis/experience';
+
+const queryJobTitleWorkExperiencesGql = /* GraphQL */ `
+  query(
+    $jobTitle: String!
+    $companyName: String
+    $start: Int!
+    $limit: Int!
+    $sortBy: DataResultSortOption
+  ) {
+    job_title(name: $jobTitle) {
+      name
+      workExperiencesResult(
+        companyQuery: $companyName
+        start: $start
+        limit: $limit
+        sortBy: $sortBy
+      ) {
+        count
+        workExperiences {
+          ${experiencePartialGql}
+          ${workExperiencesPartialGql()}
+        }
+      }
+    }
+  }
+`;
+
+type QueryGetJobTitleWorkExperiencesData = {
+  job_title:
+    | (JobTitle & {
+        workExperiencesResult: {
+          count: number;
+          workExperiences: WorkExperience[];
+        };
+      })
+    | null;
+};
+
+const queryJobTitleWorkExperiences = ({
+  jobTitle,
+  companyName,
+  start,
+  limit,
+  sortBy,
+}: {
+  jobTitle: string;
+  companyName?: string;
+  start: number;
+  limit: number;
+  sortBy?: string;
+}): Promise<QueryGetJobTitleWorkExperiencesData['job_title']> =>
+  graphqlClient<QueryGetJobTitleWorkExperiencesData>({
+    query: queryJobTitleWorkExperiencesGql,
+    variables: { jobTitle, companyName, start, limit, sortBy },
+  }).then(R.prop('job_title'));
+
+export default queryJobTitleWorkExperiences;

--- a/src/components/CompanyAndJobTitle/PageBoxRenderer.tsx
+++ b/src/components/CompanyAndJobTitle/PageBoxRenderer.tsx
@@ -17,8 +17,8 @@ interface PageBoxRendererProps<T extends PageData> {
   pageName: string;
   pageType: PageType;
   tabType: TabType;
-  boxSelector: (state: RootState) => FetchBox<T>;
-  render: (data: NonNullable<T>) => React.ReactNode;
+  boxSelector: (state: RootState) => FetchBox<T | null>;
+  render: (data: T) => React.ReactNode;
 }
 
 const PageBoxRenderer = <T extends PageData>({

--- a/src/graphql/company.ts
+++ b/src/graphql/company.ts
@@ -1,7 +1,6 @@
 import {
   experiencePartialGql,
   interviewExperiencePartialGql,
-  workExperiencesPartialGql,
 } from './experience';
 
 // TODO: 暫時放在這裡，之後搬回 api/
@@ -120,32 +119,6 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
         interviewExperiences {
           ${experiencePartialGql}
           ${interviewExperiencePartialGql()}
-        }
-      }
-    }
-  }
-`;
-
-export const getCompanyWorkExperiencesQuery = /* GraphQL */ `
-  query(
-    $companyName: String!
-    $jobTitle: String
-    $start: Int!
-    $limit: Int!
-    $sortBy: DataResultSortOption
-  ) {
-    company(name: $companyName) {
-      name
-      workExperiencesResult(
-        jobTitle: $jobTitle
-        start: $start
-        limit: $limit
-        sortBy: $sortBy
-      ) {
-        count
-        workExperiences {
-          ${experiencePartialGql}
-          ${workExperiencesPartialGql()}
         }
       }
     }

--- a/src/graphql/jobTitle.ts
+++ b/src/graphql/jobTitle.ts
@@ -1,7 +1,6 @@
 import {
   experiencePartialGql,
   interviewExperiencePartialGql,
-  workExperiencesPartialGql,
 } from './experience';
 
 // TODO: 暫時放在這裡，之後搬回 api/
@@ -111,32 +110,6 @@ export const getJobTitleInterviewExperiencesQuery = /* GraphQL */ `
         interviewExperiences {
           ${experiencePartialGql}
           ${interviewExperiencePartialGql()}
-        }
-      }
-    }
-  }
-`;
-
-export const getJobTitleWorkExperiencesQuery = /* GraphQL */ `
-  query(
-    $jobTitle: String!
-    $companyName: String
-    $start: Int!
-    $limit: Int!
-    $sortBy: DataResultSortOption
-  ) {
-    job_title(name: $jobTitle) {
-      name
-      workExperiencesResult(
-        companyQuery: $companyName
-        start: $start
-        limit: $limit
-        sortBy: $sortBy
-      ) {
-        count
-        workExperiences {
-          ${experiencePartialGql}
-          ${workExperiencesPartialGql()}
         }
       }
     }

--- a/src/reducers/companyIndex.ts
+++ b/src/reducers/companyIndex.ts
@@ -18,6 +18,7 @@ import {
   InterviewExperienceInOverview,
   WorkExperienceInOverview,
 } from 'apis/overview';
+import { WorkExperience } from 'apis/experience';
 import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
 import { RatingStatistics } from 'apis/queryCompanyRatingStatistics';
 import {
@@ -56,8 +57,15 @@ export type CompanyTimeAndSalaryStatistics = unknown;
 // TODO: replace with proper CompanyInterviewExperienceResult type
 export type CompanyInterviewExperienceResult = unknown;
 
-// TODO: replace with proper CompanyWorkExperienceResult type
-export type CompanyWorkExperienceResult = unknown;
+export type CompanyWorkExperienceResult = {
+  name: string;
+  jobTitle: string | undefined;
+  start: number;
+  limit: number;
+  sortBy: string | undefined;
+  workExperiences: WorkExperience[];
+  workExperiencesCount: number;
+};
 
 // TODO: replace with proper CompanyIsSubscribed type
 export type CompanyIsSubscribed = unknown;

--- a/src/reducers/jobTitleIndex.ts
+++ b/src/reducers/jobTitleIndex.ts
@@ -19,6 +19,7 @@ import {
   OvertimeFrequencyCount,
   SalaryWorkTime,
 } from 'apis/salaryWorkTime';
+import { WorkExperience } from 'apis/experience';
 
 // TODO: replace with proper JobTitleInIndex type
 export type JobTitleInIndex = unknown;
@@ -50,8 +51,15 @@ export type JobTitleTimeAndSalaryStatistics = unknown;
 // TODO: replace with proper JobTitleInterviewExperienceResult type
 export type JobTitleInterviewExperienceResult = unknown;
 
-// TODO: replace with proper JobTitleWorkExperienceResult type
-export type JobTitleWorkExperienceResult = unknown;
+export type JobTitleWorkExperienceResult = {
+  name: string;
+  companyName?: string;
+  start: number;
+  limit: number;
+  sortBy?: string;
+  workExperiences: WorkExperience[];
+  workExperiencesCount: number;
+};
 
 type State = {
   indexesByPage: Record<number, FetchBox<JobTitleInIndex[]>>;


### PR DESCRIPTION
## 這個 PR 是？

為 dev2 分支上針對 `WorkExperience` 的 `aspect` 欄位做 TypeScript 型別化預先準備。

具體做了以下事情：

- 將 `getJobTitleWorkExperiences` API 從 `apis/jobTitle.js` 抽出，建立獨立的 TypeScript 檔案 `apis/queryJobTitleWorkExperiences.ts`
- 將 `WorkExperience` 型別（及其依賴的 local types）從 `apis/queryCompanyWorkExperiences.ts` 移到 domain 檔 `apis/experience.ts`，供兩個 query 共用
- 在 `reducers/jobTitleIndex.ts` 補上 `JobTitleWorkExperienceResult` 正確型別（原為 `unknown`）
- 清理 `apis/jobTitle.js` 與 `graphql/jobTitle.ts` 中不再使用的 export
- 在 `src/actions/jobTitle.js` 的 `workExperiencesData` 加上 `@type` JSDoc 標注

## 我應該如何手動測試？

- [ ] `npm run test` 通過