### PR TITLE
doc: guide for typescript type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ npm run testonly    # unit tests only
 - **`src/components/`** — reusable UI components, organized by domain (e.g. `CompanyAndJobTitle/`, `SalaryWorkTime/`). A component's location and name should reflect its actual domain, not where it was first created. Rename and move when reuse expands beyond the original context.
 `src/apis/` contains all API calls to the backend. When writing or modifying API-related code, follow the TypeScript typing guidelines in [src/apis/README.md](src/apis/README.md).
 
+### TypeScript Types
+
+For type definition conventions (`type` vs `interface`, where types live, nullable fields, enums, `unknown` placeholders), see [docs/typescript-types.md](docs/typescript-types.md).
+
 ### Server-Side Rendering (SSR) with `fetchData`
 
 Pages that need SSR data fetching attach a static `fetchData` method to the component. See [docs/ssr-fetch-data.md](docs/ssr-fetch-data.md).

--- a/docs/typescript-types.md
+++ b/docs/typescript-types.md
@@ -1,0 +1,59 @@
+# TypeScript Type Definition Conventions
+
+## `type` vs `interface`
+
+Use `type` by default for object shapes. Use `interface` only when the type is explicitly designed to be extended or implemented:
+
+```ts
+// ✓ object shapes
+type State = { ... };
+export type CompanyOverview = { ... };
+
+// ✓ interface when extension is the intent
+export interface ServerSideRender<Params> { fetchData: ... }
+export interface Thunk<A extends Action> { ... }
+```
+
+## Where types live
+
+Listed by priority — prefer the first location that fits:
+
+1. **`src/apis/<domain>.ts`** — shared types extracted from GraphQL fragments
+2. **`src/reducers/<slice>.ts`** — exported types that represent what is stored in Redux after the reducer flattens/transforms the API response; consumed by selectors and components. `type State` itself is always file-private; the whole state shape is exposed via `RootState` in `reducers/index.ts`. If the stored type can be imported directly from `src/apis/`, prefer importing over redefining.
+3. **`src/constants/`** — enums and their associated lookup maps
+4. **`src/types/`** — cross-cutting types (e.g. `ServerSideRender`)
+
+For API-specific rules see [src/apis/README.md](../src/apis/README.md).
+
+## Enums
+
+Use for discrete string-valued constant groups that need to be used as both values and types:
+
+```ts
+export enum Aspect {
+  GENDER = '性別友善度',
+  WORK_LIFE_BALANCE = '工作與生活平衡',
+  ...
+}
+```
+
+## Nullable fields
+
+Use `T | null`, not `?: T`. GraphQL nullable fields are always present in the response, never absent:
+
+```ts
+// ✓
+salary: { amount: number; type: string } | null;
+
+// ✗
+salary?: { amount: number; type: string };
+```
+
+## `unknown` placeholders
+
+Unresolved types are temporarily typed as `unknown` with a TODO. Replace them as the data shape becomes clear:
+
+```ts
+// TODO: replace with proper CompanyInIndex type
+export type CompanyInIndex = unknown;
+```


### PR DESCRIPTION
## 這個 PR 是？

新增 `docs/typescript-types.md`，記錄專案的 TypeScript 型別定義慣例：`type` vs `interface`、型別放哪、nullable 欄位、enum、`unknown` placeholder。並在 `AGENTS.md` 加上指向該文件的參考連結。

## 我應該如何手動測試？

- [x] 閱讀 `docs/typescript-types.md`，確認內容正確且清楚