### PR TITLE
fix: 修正薪資區間下界為 0 時顯示 'null' 的問題

### DIFF
--- a/src/components/common/formatter.js
+++ b/src/components/common/formatter.js
@@ -46,8 +46,8 @@ export const formatSalaryAmountRange = salary => {
     return '-';
   }
   const [head, tail] = getSalaryAmountRange(salary);
-  const headString = numToChineseReadableString(head) ?? '0';
-  const tailString = numToChineseReadableString(tail) ?? '0';
+  const headString = numToChineseReadableString(head);
+  const tailString = numToChineseReadableString(tail);
   return `${headString} ~ ${tailString}`;
 };
 

--- a/src/components/common/formatter.js
+++ b/src/components/common/formatter.js
@@ -46,8 +46,8 @@ export const formatSalaryAmountRange = salary => {
     return '-';
   }
   const [head, tail] = getSalaryAmountRange(salary);
-  const headString = numToChineseReadableString(head);
-  const tailString = numToChineseReadableString(tail);
+  const headString = numToChineseReadableString(head) ?? '0';
+  const tailString = numToChineseReadableString(tail) ?? '0';
   return `${headString} ~ ${tailString}`;
 };
 

--- a/src/utils/formUtils.js
+++ b/src/utils/formUtils.js
@@ -3,8 +3,11 @@
  * @param {Integer} num the number to be converted
  */
 export const numToChineseReadableString = num => {
-  if (num <= 0) {
+  if (num < 0) {
     return null;
+  }
+  if (num === 0) {
+    return '0';
   }
   const base = [1, 10000, 100000000];
   const baseWord = ['', '萬', '億'];


### PR DESCRIPTION
Close #1695

## 這個 PR 是？

`numToChineseReadableString` 對 `0` 回傳 `null`，導致 `formatSalaryAmountRange` 在模板字串中將其轉成字面的 `"null"`。當薪資金額低於區間大小時就會觸發（例如月薪 35,000 < 60,000），畫面會顯示 `月薪 null ~ 6萬`。

修正方式：`num === 0` 時直接回傳 `'0'`。

## 我應該如何手動測試？

- [ ] 啟動開發伺服器：
  ```sh
  npm run start
  ```
- [ ] 前往 http://localhost:3000/experiences/677946bc50a2b9a73fecd4df
- [ ] 確認薪資區間顯示為 `月薪 0 ~ 6萬`，而非 `月薪 null ~ 6萬`

|Before|After|
|-|-|
|<img width="750" height="1334" alt="Screen Shot 2026-05-13 at 15 47 16" src="https://github.com/user-attachments/assets/369dba0a-9971-48a0-99c2-d6b507b12496" />|<img width="750" height="1334" alt="Screen Shot 2026-05-13 at 15 47 46" src="https://github.com/user-attachments/assets/0f9d5b4e-f661-4324-a2d9-6f4435819a56" />|