### PR TITLE
fix: normalize auth token null/undefined caused by redux-persist

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -27,7 +27,7 @@ export const SET_LOGIN = '@@auth/SET_LOGIN';
 export const SET_USER = '@@auth/SET_USER';
 export const LOG_OUT = '@@auth/LOG_OUT';
 
-const setLogin = (status, token = null) => ({
+const setLogin = (status, token = undefined) => ({
   type: SET_LOGIN,
   status,
   token,

--- a/src/hooks/usePermission.js
+++ b/src/hooks/usePermission.js
@@ -6,7 +6,7 @@ import useIsMyPublishId from './useIsMyPublishId';
 
 const useGetSearchPermission = ({ token }) => {
   return useCallback(async () => {
-    if (token === null) return false;
+    if (!token) return false;
     // Get permission only when token available
     return await queryHasSearchPermissionApi({ token });
   }, [token]);

--- a/src/reducers/auth.ts
+++ b/src/reducers/auth.ts
@@ -11,7 +11,9 @@ export type User = {
 
 const preloadedState: {
   status: AuthStatus;
-  token?: string;
+  // null is possible when redux-persist restores state from JSON (undefined is serialized as null)
+  // always access via tokenSelector to normalize null to undefined
+  token?: string | null;
   user?: User;
 } = {
   status: AuthStatus.UNKNOWN,

--- a/src/selectors/authSelector.ts
+++ b/src/selectors/authSelector.ts
@@ -6,6 +6,6 @@ import AuthStatus from 'constants/authStatus';
 export const statusSelector = (state: RootState): AuthStatus =>
   state.auth.status;
 export const tokenSelector = (state: RootState): string | undefined =>
-  state.auth.token;
+  state.auth.token !== null ? state.auth.token : undefined;
 export const userSelector = (state: RootState): User | undefined =>
   state.auth.user;


### PR DESCRIPTION
Close #1667  <!-- 當 PR merge，github 會自動幫你關 issue -->

## 這個 PR 是？

`redux-persist` 在序列化 Redux state 時會把 `undefined` 存成 `null`，導致頁面重整後 `token` 從 `undefined` 變成 `null`，造成需要登入才能使用的功能在重整後失效。

修正方式：
- `reducers/auth.ts`：將 `token` 型別從 `string | undefined` 改為 `string | null | undefined`，並加上註解說明為何 `null` 是合法值
- `selectors/authSelector.ts`：`tokenSelector` 統一將 `null` 正規化為 `undefined`，讓其他地方不需要處理 `null`
- `actions/auth.js`：`setLogin` 預設值從 `null` 改為 `undefined`，維持一致性
- `hooks/usePermission.js`：將 `token === null` 改為 `!token`，同時處理 `null` 與 `undefined`

## 我應該從何看起？

建議從 `reducers/auth.ts` 的型別修改開始，再看 `selectors/authSelector.ts` 的正規化邏輯，最後看其他兩個檔案的 callsite 調整。

## Questions

- 我需要更新 Packages 嗎？ No
- 有哪些文件需要被更新嗎？ No

## 我應該如何手動測試？

- [ ] 登入後重整頁面，確認登入狀態正常保持
- [ ] 確認需要登入才能使用的功能（如搜尋權限）在重整後仍可正常使用
- [ ] 登出後確認 token 清除正常