### PR TITLE
fix: 修正 aspect 評分區塊在無資料時誤顯示

### DIFF
--- a/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
@@ -35,8 +35,11 @@ const InterviewExperiences = ({
       {aspectModels.length > 0 && (
         <Wrapper size="l">
           <div className={styles.scoreCards}>
-            {aspectModels.map(model => (
-              <AspectScoreCard key={model.aspect} aspect={model.aspect} />
+            {aspectModels.map(aspectModel => (
+              <AspectScoreCard
+                key={aspectModel.aspect}
+                aspect={aspectModel.aspect}
+              />
             ))}
           </div>
         </Wrapper>

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
@@ -11,6 +11,7 @@ import { Wrapper } from 'common/base';
 import { useCreatePageLinkTo } from 'common/Pagination/Pagination';
 import AspectScoreCard, { useAspectsData } from '../Overview/AspectScoreCard';
 import { Aspects } from 'constants/companyJobTitle';
+import useCompanyName from 'pages/Company/useCompanyName';
 
 const InterviewExperiences = ({
   pageType,
@@ -22,7 +23,8 @@ const InterviewExperiences = ({
   topNJobTitles,
 }) => {
   const [createPageLinkTo, handleSectionRef] = useCreatePageLinkTo();
-  const aspectModels = useAspectsData(Aspects);
+  const companyName = useCompanyName();
+  const aspectModels = useAspectsData(companyName, Aspects);
 
   return (
     <CompanyAndJobTitleWrapper

--- a/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/InterviewExperiences/index.js
@@ -9,6 +9,8 @@ import Sorter from '../Sorter';
 import styles from '../styles.module.css';
 import { Wrapper } from 'common/base';
 import { useCreatePageLinkTo } from 'common/Pagination/Pagination';
+import AspectScoreCard, { useAspectsData } from '../Overview/AspectScoreCard';
+import { Aspects } from 'constants/companyJobTitle';
 
 const InterviewExperiences = ({
   pageType,
@@ -20,6 +22,7 @@ const InterviewExperiences = ({
   topNJobTitles,
 }) => {
   const [createPageLinkTo, handleSectionRef] = useCreatePageLinkTo();
+  const aspectModels = useAspectsData(Aspects);
 
   return (
     <CompanyAndJobTitleWrapper
@@ -27,6 +30,15 @@ const InterviewExperiences = ({
       pageName={pageName}
       tabType={tabType}
     >
+      {aspectModels.length > 0 && (
+        <Wrapper size="l">
+          <div className={styles.scoreCards}>
+            {aspectModels.map(model => (
+              <AspectScoreCard key={model.aspect} aspect={model.aspect} />
+            ))}
+          </div>
+        </Wrapper>
+      )}
       <Wrapper ref={handleSectionRef} size="m">
         <div className={styles.interactive}>
           <Searchbar pageType={pageType} tabType={tabType} />

--- a/src/components/CompanyAndJobTitle/Overview/AspectScoreCard.tsx
+++ b/src/components/CompanyAndJobTitle/Overview/AspectScoreCard.tsx
@@ -30,6 +30,26 @@ const useAspectData = ({
   return stat;
 };
 
+export const useAspectsData = (aspects: Aspect[]): AspectRatingStatistics[] => {
+  const companyName = useCompanyName();
+  const box = useSelector(
+    companyWorkExperiencesAspectStatisticsBoxSelectorByName(companyName),
+  );
+
+  if (!isFetched(box) || !box.data) return [];
+
+  return aspects
+    .map(aspect =>
+      box.data!.companyAspectRatingStatistics.find(
+        item => item.aspect === aspect,
+      ),
+    )
+    .filter(
+      (stat): stat is AspectRatingStatistics =>
+        stat != null && stat.ratingCount > 0,
+    );
+};
+
 interface AspectScoreCardProps {
   aspect: Aspect;
 }

--- a/src/components/CompanyAndJobTitle/Overview/AspectScoreCard.tsx
+++ b/src/components/CompanyAndJobTitle/Overview/AspectScoreCard.tsx
@@ -32,8 +32,10 @@ const useAspectData = ({
   return stats.find(item => item.aspect === aspect);
 };
 
-export const useAspectsData = (aspects: Aspect[]): AspectRatingStatistics[] => {
-  const companyName = useCompanyName();
+export const useAspectsData = (
+  companyName: string,
+  aspects: Aspect[],
+): AspectRatingStatistics[] => {
   const stats = useAllAspectRatingStatistics(companyName);
   return stats.filter(
     stat => aspects.includes(stat.aspect as Aspect) && stat.ratingCount > 0,

--- a/src/components/CompanyAndJobTitle/Overview/AspectScoreCard.tsx
+++ b/src/components/CompanyAndJobTitle/Overview/AspectScoreCard.tsx
@@ -11,43 +11,33 @@ import { companyWorkExperiencesAspectStatisticsBoxSelectorByName } from 'selecto
 import { isFetched } from 'utils/fetchBox';
 import { AspectRatingStatistics } from 'apis/aspectRatingStatistics';
 
+const useAllAspectRatingStatistics = (
+  companyName: string,
+): AspectRatingStatistics[] => {
+  const box = useSelector(
+    companyWorkExperiencesAspectStatisticsBoxSelectorByName(companyName),
+  );
+  if (!isFetched(box) || !box.data) return [];
+  return box.data.companyAspectRatingStatistics;
+};
+
 const useAspectData = ({
   companyName,
   aspect,
 }: {
   companyName: string;
   aspect: Aspect;
-}): AspectRatingStatistics | null | undefined => {
-  const box = useSelector(
-    companyWorkExperiencesAspectStatisticsBoxSelectorByName(companyName),
-  );
-
-  if (!isFetched(box) || !box.data) return null;
-
-  const stat = box.data.companyAspectRatingStatistics.find(
-    item => item.aspect === aspect,
-  );
-  return stat;
+}): AspectRatingStatistics | undefined => {
+  const stats = useAllAspectRatingStatistics(companyName);
+  return stats.find(item => item.aspect === aspect);
 };
 
 export const useAspectsData = (aspects: Aspect[]): AspectRatingStatistics[] => {
   const companyName = useCompanyName();
-  const box = useSelector(
-    companyWorkExperiencesAspectStatisticsBoxSelectorByName(companyName),
+  const stats = useAllAspectRatingStatistics(companyName);
+  return stats.filter(
+    stat => aspects.includes(stat.aspect as Aspect) && stat.ratingCount > 0,
   );
-
-  if (!isFetched(box) || !box.data) return [];
-
-  return aspects
-    .map(aspect =>
-      box.data!.companyAspectRatingStatistics.find(
-        item => item.aspect === aspect,
-      ),
-    )
-    .filter(
-      (stat): stat is AspectRatingStatistics =>
-        stat != null && stat.ratingCount > 0,
-    );
 };
 
 interface AspectScoreCardProps {

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -26,8 +26,8 @@ const GenderAspectSnippetBlock = () => {
 
   return (
     <SnippetBlock title="性別友善">
-      {aspectModels.map(model => (
-        <AspectScoreCard key={model.aspect} aspect={model.aspect} />
+      {aspectModels.map(aspectModel => (
+        <AspectScoreCard key={aspectModel.aspect} aspect={aspectModel.aspect} />
       ))}
     </SnippetBlock>
   );

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -17,9 +17,11 @@ import SummaryBlock from './SummaryBlock';
 import usePermission from 'hooks/usePermission';
 import { fetchBoxPropType } from 'utils/fetchBox';
 import AspectScoreCard, { useAspectsData } from './AspectScoreCard';
+import useCompanyName from 'pages/Company/useCompanyName';
 
 const GenderAspectSnippetBlock = () => {
-  const models = useAspectsData([Aspect.GENDER]);
+  const companyName = useCompanyName();
+  const models = useAspectsData(companyName, [Aspect.GENDER]);
   if (models.length === 0) return null;
 
   return (

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { generatePath } from 'react-router';
 
 import { Section } from 'common/base';
 import BoxRenderer from 'common/StatusRenderer';
@@ -17,34 +16,19 @@ import {
 import SummaryBlock from './SummaryBlock';
 import usePermission from 'hooks/usePermission';
 import { fetchBoxPropType } from 'utils/fetchBox';
-import { useAspectsData } from './AspectScoreCard';
-import ScoreCard from './ScoreCard';
-import useCompanyName from 'pages/Company/useCompanyName';
-import { companyWorkExperiencesAspectPath } from 'constants/linkTo';
+import AspectScoreCard, { useAspectsData } from './AspectScoreCard';
 
 const GenderAspectSnippetBlock = () => {
-  const companyName = useCompanyName();
   const models = useAspectsData([Aspect.GENDER]);
   if (models.length === 0) return null;
 
-  const scoreCards = models.map(model => {
-    const path = generatePath(companyWorkExperiencesAspectPath, {
-      companyName,
-      aspect: model.aspect,
-    });
-    return (
-      <ScoreCard
-        key={model.aspect}
-        title={model.aspect}
-        value={model.averageRating}
-        maxValue={5}
-        linkTo={path}
-        dataCount={model.ratingCount}
-      />
-    );
-  });
-
-  return <SnippetBlock title="性別友善">{scoreCards}</SnippetBlock>;
+  return (
+    <SnippetBlock title="性別友善">
+      {models.map(model => (
+        <AspectScoreCard key={model.aspect} aspect={model.aspect} />
+      ))}
+    </SnippetBlock>
+  );
 };
 
 const Overview = ({

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { generatePath } from 'react-router';
 
 import { Section } from 'common/base';
 import BoxRenderer from 'common/StatusRenderer';
@@ -16,14 +17,32 @@ import {
 import SummaryBlock from './SummaryBlock';
 import usePermission from 'hooks/usePermission';
 import { fetchBoxPropType } from 'utils/fetchBox';
-import AspectScoreCard from './AspectScoreCard';
+import { useAspectsData } from './AspectScoreCard';
+import ScoreCard from './ScoreCard';
+import useCompanyName from 'pages/Company/useCompanyName';
+import { companyWorkExperiencesAspectPath } from 'constants/linkTo';
 
 const GenderAspectSnippetBlock = () => {
-  const aspects = [Aspect.GENDER];
-  const scoreCards = aspects.map(aspect => (
-    <AspectScoreCard key={aspect} aspect={aspect} />
-  ));
-  if (scoreCards.length === 0) return null;
+  const companyName = useCompanyName();
+  const models = useAspectsData([Aspect.GENDER]);
+  if (models.length === 0) return null;
+
+  const scoreCards = models.map(model => {
+    const path = generatePath(companyWorkExperiencesAspectPath, {
+      companyName,
+      aspect: model.aspect,
+    });
+    return (
+      <ScoreCard
+        key={model.aspect}
+        title={model.aspect}
+        value={model.averageRating}
+        maxValue={5}
+        linkTo={path}
+        dataCount={model.ratingCount}
+      />
+    );
+  });
 
   return <SnippetBlock title="性別友善">{scoreCards}</SnippetBlock>;
 };

--- a/src/components/CompanyAndJobTitle/Overview/Overview.js
+++ b/src/components/CompanyAndJobTitle/Overview/Overview.js
@@ -21,12 +21,12 @@ import useCompanyName from 'pages/Company/useCompanyName';
 
 const GenderAspectSnippetBlock = () => {
   const companyName = useCompanyName();
-  const models = useAspectsData(companyName, [Aspect.GENDER]);
-  if (models.length === 0) return null;
+  const aspectModels = useAspectsData(companyName, [Aspect.GENDER]);
+  if (aspectModels.length === 0) return null;
 
   return (
     <SnippetBlock title="性別友善">
-      {models.map(model => (
+      {aspectModels.map(model => (
         <AspectScoreCard key={model.aspect} aspect={model.aspect} />
       ))}
     </SnippetBlock>

--- a/src/components/CompanyAndJobTitle/WorkExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/index.js
@@ -11,6 +11,7 @@ import { Wrapper } from 'common/base';
 import { useCreatePageLinkTo } from 'common/Pagination/Pagination';
 import AspectScoreCard, { useAspectsData } from '../Overview/AspectScoreCard';
 import { Aspects } from 'constants/companyJobTitle';
+import useCompanyName from 'pages/Company/useCompanyName';
 
 const WorkExperiences = ({
   pageType,
@@ -21,7 +22,8 @@ const WorkExperiences = ({
   pageSize,
 }) => {
   const [createPageLinkTo, handleSectionRef] = useCreatePageLinkTo();
-  const aspectModels = useAspectsData(Aspects);
+  const companyName = useCompanyName();
+  const aspectModels = useAspectsData(companyName, Aspects);
 
   return (
     <CompanyAndJobTitleWrapper

--- a/src/components/CompanyAndJobTitle/WorkExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/index.js
@@ -9,7 +9,7 @@ import Sorter from '../Sorter';
 import styles from '../styles.module.css';
 import { Wrapper } from 'common/base';
 import { useCreatePageLinkTo } from 'common/Pagination/Pagination';
-import AspectScoreCard from '../Overview/AspectScoreCard';
+import AspectScoreCard, { useAspectsData } from '../Overview/AspectScoreCard';
 import { Aspects } from 'constants/companyJobTitle';
 
 const WorkExperiences = ({
@@ -21,6 +21,7 @@ const WorkExperiences = ({
   pageSize,
 }) => {
   const [createPageLinkTo, handleSectionRef] = useCreatePageLinkTo();
+  const aspectModels = useAspectsData(Aspects);
 
   return (
     <CompanyAndJobTitleWrapper
@@ -28,13 +29,15 @@ const WorkExperiences = ({
       pageName={pageName}
       tabType={tabType}
     >
-      <Wrapper size="l">
-        <div className={styles.scoreCards}>
-          {Aspects.map(aspect => (
-            <AspectScoreCard key={aspect} aspect={aspect} />
-          ))}
-        </div>
-      </Wrapper>
+      {aspectModels.length > 0 && (
+        <Wrapper size="l">
+          <div className={styles.scoreCards}>
+            {aspectModels.map(model => (
+              <AspectScoreCard key={model.aspect} aspect={model.aspect} />
+            ))}
+          </div>
+        </Wrapper>
+      )}
       <Wrapper ref={handleSectionRef} size="m">
         <div className={styles.interactive}>
           <Searchbar pageType={pageType} tabType={tabType} />

--- a/src/components/CompanyAndJobTitle/WorkExperiences/index.js
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/index.js
@@ -34,8 +34,11 @@ const WorkExperiences = ({
       {aspectModels.length > 0 && (
         <Wrapper size="l">
           <div className={styles.scoreCards}>
-            {aspectModels.map(model => (
-              <AspectScoreCard key={model.aspect} aspect={model.aspect} />
+            {aspectModels.map(aspectModel => (
+              <AspectScoreCard
+                key={aspectModel.aspect}
+                aspect={aspectModel.aspect}
+              />
             ))}
           </div>
         </Wrapper>


### PR DESCRIPTION
## 這個 PR 是？

原本以 JSX 元素數量判斷 aspect 評分區塊是否顯示，但有兩個問題：
1. ScoreCard 漏掉過濾無資料的項目，導致元素數量永遠不為零
2. 即使 functional component 內部 return null，React 仍會將其視為有效元素，filter 無法排除

改為先產生資料模型（過濾 `ratingCount > 0`），再以模型陣列是否為空決定是否渲染區塊，並統一套用至總覽、工作經驗、面試經驗三個頁籤。

## 我應該如何手動測試？

- [ ] 開啟有 aspect 評分資料的公司頁面，確認總覽、工作經驗、面試經驗頁籤均正常顯示評分區塊
- [ ] 工作經驗 http://localhost:3000/companies/%E7%9F%BD%E6%A0%BC%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/work-experiences
- [ ] 面試經驗 http://localhost:3000/companies/%E7%9F%BD%E6%A0%BC%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8/interview-experiences

## Screenshots

|Before|After|
|-|-|
|<img width="750" height="1334" alt="Screen Shot 2026-05-14 at 21 10 14" src="https://github.com/user-attachments/assets/134d2959-667b-4054-adc8-b1a5a8c01119" />|<img width="750" height="1334" alt="Screen Shot 2026-05-14 at 21 10 04" src="https://github.com/user-attachments/assets/258818f7-2ba3-40c8-b1aa-e274de93b46e" />|