### PR TITLE
fix: 修正公司單一評價頁面白畫面 & 文章區塊跑版 (#1704/#1706)

### DIFF
--- a/src/apis/queryCompanyAspectRatingStatistics.ts
+++ b/src/apis/queryCompanyAspectRatingStatistics.ts
@@ -9,6 +9,7 @@ import {
 const queryCompanyAspectRatingStatisticsGql = /* GraphQL */ `
   query($companyName: String!) {
     company(name: $companyName) {
+      name
       companyAspectRatingStatistics {
         ...aspectRatingStatisticsFields
       }

--- a/src/components/CompanyAndJobTitle/WorkExperiences/Aspects/index.tsx
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/Aspects/index.tsx
@@ -77,37 +77,39 @@ const AspectSection: React.FC<AspectProps> = ({
             );
           }}
         />
-        <RatingFilter />
       </Wrapper>
-      <PageBoxRenderer
-        pageType={pageType}
-        pageName={pageName}
-        tabType={tabType}
-        boxSelector={experiencesBoxSelector}
-        render={({
-          workExperiences,
-          workExperiencesCount: totalCount,
-        }: CompanyAspectExperienceResult): React.ReactNode => (
-          <>
-            <Helmet
-              pageType={pageType}
-              pageName={pageName}
-              totalCount={totalCount}
-              page={page}
-            />
-            <WorkExperiencesSection
-              pageType={pageType}
-              pageName={pageName}
-              tabType={tabType}
-              data={workExperiences}
-              page={page}
-              pageSize={pageSize}
-              totalCount={totalCount}
-              createPageLinkTo={createPageLinkTo}
-            />
-          </>
-        )}
-      />
+      <Wrapper size="m">
+        <RatingFilter />
+        <PageBoxRenderer
+          pageType={pageType}
+          pageName={pageName}
+          tabType={tabType}
+          boxSelector={experiencesBoxSelector}
+          render={({
+            workExperiences,
+            workExperiencesCount: totalCount,
+          }: CompanyAspectExperienceResult): React.ReactNode => (
+            <>
+              <Helmet
+                pageType={pageType}
+                pageName={pageName}
+                totalCount={totalCount}
+                page={page}
+              />
+              <WorkExperiencesSection
+                pageType={pageType}
+                pageName={pageName}
+                tabType={tabType}
+                data={workExperiences}
+                page={page}
+                pageSize={pageSize}
+                totalCount={totalCount}
+                createPageLinkTo={createPageLinkTo}
+              />
+            </>
+          )}
+        />
+      </Wrapper>
     </CompanyAndJobTitleWrapper>
   );
 };


### PR DESCRIPTION
## Summary
- **#1704**：修正 `queryCompanyAspectRatingStatistics` 的 GraphQL query 缺少 `company.name` 欄位的問題。缺少 `name` 會讓 `PageBoxRenderer` 在比對 `data.name !== pageName` 時呼叫 `generateTabURL({ pageName: undefined, ... })`，造成 `react-router` 的 `generatePath` 拋出 `Expected "pageName" to be defined` 並使整頁白畫面。
- **#1706**：修正公司單一評價頁 (Aspects) 內容區塊跑版。`RatingFilter` 篩選 dropdown 與評價列表 `PageBoxRenderer` 原本沒有包在 `Wrapper size="m"` 內，寬度與評價列表頁不一致；將兩者一起放入 `Wrapper size="m"` 使寬度對齊。

Closes #1704
Closes #1706

## Test plan
- [ ] 開啟 `/companies/<companyName>/work-experiences/<aspect>` (如 TSMC `公司管理方式`、`公司/團隊文化`)，頁面可正常渲染、不再白畫面
- [ ] `RatingFilter` 與評價列表寬度一致，且與 `/companies/<companyName>/work-experiences` 列表頁一致
- [ ] `npm run test`

|Before|After|
|-|-|
|<img width="1280" height="950" alt="畫面擷取於 2026-05-21 23 44 02" src="https://github.com/user-attachments/assets/08ab8a89-5fa5-4716-ad26-84af6f4aa888" />|<img width="1280" height="950" alt="畫面擷取於 2026-05-21 23 52 48" src="https://github.com/user-attachments/assets/0fb731c2-94e0-434b-83dc-d2f0ff1715c1" />|


🤖 Generated with [Claude Code](https://claude.com/claude-code)