### PR TITLE
chore: add GitHub Actions to sync master to dev and dev2

### DIFF
--- a/.github/workflows/sync-master-to-dev.yml
+++ b/.github/workflows/sync-master-to-dev.yml
@@ -16,7 +16,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/sync-master-to-dev.yml
+++ b/.github/workflows/sync-master-to-dev.yml
@@ -1,0 +1,26 @@
+name: Sync master to dev
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Push master to dev
+        run: |
+          git push origin master:dev || echo "Skipped: not a fast-forward"

--- a/.github/workflows/sync-master-to-dev2.yml
+++ b/.github/workflows/sync-master-to-dev2.yml
@@ -16,7 +16,7 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/sync-master-to-dev2.yml
+++ b/.github/workflows/sync-master-to-dev2.yml
@@ -1,0 +1,26 @@
+name: Sync master to dev2
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Push master to dev2
+        run: |
+          git push origin master:dev2 || echo "Skipped: not a fast-forward"


### PR DESCRIPTION
## Summary

- Add `.github/workflows/sync-master-to-dev.yml` — syncs `master` → `dev` on every push to master
- Add `.github/workflows/sync-master-to-dev2.yml` — syncs `master` → `dev2` on every push to master
- Both workflows use a GitHub App token (`APP_ID` + `APP_PRIVATE_KEY` secrets) to bypass branch protection rules

## Test plan

- [ ] Merge a commit to master and verify dev / dev2 are updated
- [ ] Confirm the GitHub App secrets are configured in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)