### PR TITLE
chore: skip sync workflows on forked repos

### DIFF
--- a/.github/workflows/sync-master-to-dev.yml
+++ b/.github/workflows/sync-master-to-dev.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository == 'goodjoblife/GoodJobShare'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/sync-master-to-dev2.yml
+++ b/.github/workflows/sync-master-to-dev2.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sync:
+    if: github.repository == 'goodjoblife/GoodJobShare'
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App Token


### PR DESCRIPTION
## Summary

- Add `if: github.repository == 'goodjoblife/GoodJobShare'` condition to `sync-master-to-dev` and `sync-master-to-dev2` jobs
- Prevents the workflows from running on forked repositories, where `APP_ID`/`APP_PRIVATE_KEY` secrets are unavailable and would cause the job to fail with a noisy red status

## Test plan

- [ ] Confirm sync workflows still run on push to `master` in the upstream repo
- [ ] Confirm forked repos no longer produce a failing workflow run on push to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)