### PR TITLE
chore: use GitHub App token in e2e-trigger workflow

### DIFF
--- a/.github/workflows/e2e-trigger.yml
+++ b/.github/workflows/e2e-trigger.yml
@@ -12,10 +12,18 @@ jobs:
     if: github.repository == 'goodjoblife/GoodJobShare'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: frontend-e2e
+
       - name: trigger frontend-e2e integration-test
         run: |
-          curl --user "${{ secrets.DEPLOY_CI_TOKEN }}" \
-            -X POST \
+          curl -X POST \
+            -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
             -d '{"event_type": "goodjobshare-updated"}' \
             https://api.github.com/repos/goodjoblife/frontend-e2e/dispatches


### PR DESCRIPTION
## Summary

- Replace `DEPLOY_CI_TOKEN` (Personal Access Token) with `actions/create-github-app-token@v1` in the `e2e-trigger` workflow
- Token is scoped to `frontend-e2e` repository only (minimum privilege)
- Consistent with the existing pattern used in `sync-master-to-dev` and `sync-master-to-dev2` workflows

## Test plan

- [ ] Confirm the workflow triggers successfully on push to `master` / `dev` / `dev2`
- [ ] Confirm the `repository_dispatch` event reaches `goodjoblife/frontend-e2e`
- [ ] `DEPLOY_CI_TOKEN` secret can be removed from repo settings after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)