### PR TITLE
chore: upgrade marked from 0.3.6 to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "express": "^4.20.0",
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
-    "marked": "^0.3.6",
+    "marked": "^18.0.0",
     "path": "^0.12.7",
     "prop-types": "^15.6.0",
     "qs": "^6.15.2",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "express": "^4.20.0",
     "history": "^4.7.2",
     "isomorphic-fetch": "^2.2.1",
-    "marked": "^18.0.0",
+    "marked": "^4.3.0",
     "path": "^0.12.7",
     "prop-types": "^15.6.0",
     "qs": "^6.15.2",

--- a/src/components/LaborRightsSingle/MarkdownParser.tsx
+++ b/src/components/LaborRightsSingle/MarkdownParser.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import marked from 'marked';
+import { marked } from 'marked';
 import styles from './MarkdownParser.module.css';
 
 type MarkdownParserProps = {
@@ -11,7 +11,7 @@ const MarkdownParser: React.FC<MarkdownParserProps> = ({ content = '' }) => (
     className={styles.md}
     // eslint-disable-next-line react/no-danger
     dangerouslySetInnerHTML={{
-      __html: marked(content),
+      __html: marked.parse(content) as string,
     }}
   />
 );

--- a/src/components/LaborRightsSingle/marked.d.ts
+++ b/src/components/LaborRightsSingle/marked.d.ts
@@ -1,0 +1,6 @@
+declare module 'marked' {
+  export function marked(src: string): string;
+  export namespace marked {
+    function parse(src: string): string;
+  }
+}

--- a/src/components/LaborRightsSingle/marked.d.ts
+++ b/src/components/LaborRightsSingle/marked.d.ts
@@ -1,4 +1,0 @@
-declare module 'marked' {
-  declare function marked(arg0: string): string;
-  export = marked;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8654,10 +8654,10 @@ markdown-table@^1.1.0:
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-marked@^0.3.6:
-  version "0.3.19"
-  resolved "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz"
-  integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
+marked@^18.0.0:
+  version "18.0.4"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.4.tgz#7a54421f506c8729db32f852719972d2f939a77b"
+  integrity sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8654,10 +8654,10 @@ markdown-table@^1.1.0:
   resolved "https://registry.npmjs.org/markdown-table/-/markdown-table-1.1.3.tgz"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
-marked@^18.0.0:
-  version "18.0.4"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-18.0.4.tgz#7a54421f506c8729db32f852719972d2f939a77b"
-  integrity sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary

- Upgrade `marked` from `^0.3.6` to `^4.3.0`
- Update import to named export: `import { marked } from 'marked'`
- Update call site to `marked.parse(content)`
- Add hand-written `marked.d.ts` (marked v4 has no bundled types; `@types/marked` v6 is a stub for v5+)

> marked v5+ switched to ES modules only, which causes `process is not defined` in browser builds under Razzle 3 / webpack 4. v4 is the latest CJS-compatible release.

## Test plan

- [x] Verify `LaborRightsSingle` page renders markdown content correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)