### PR TITLE
test: add unit tests for usePermission

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@types/prop-types": "^15.7.15",
     "@types/qs": "^6.14.0",
     "@types/ramda": "^0.30.2",
@@ -70,6 +71,7 @@
     "postcss-nested": "^3.0.0",
     "postcss-simple-vars": "^4.1.0",
     "prettier": "^1.14.2",
+    "react-test-renderer": "^19.2.6",
     "redux-logger": "^2.7.4",
     "stylelint": "^9.10.1",
     "stylelint-config-prettier": "^4.0.0",

--- a/src/hooks/usePermission.d.ts
+++ b/src/hooks/usePermission.d.ts
@@ -1,0 +1,7 @@
+declare const usePermission: () => [
+  boolean,
+  () => Promise<void>,
+  (publishId: string) => boolean,
+];
+
+export default usePermission;

--- a/src/hooks/usePermission.test.tsx
+++ b/src/hooks/usePermission.test.tsx
@@ -18,6 +18,12 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <PermissionContextProvider>{children}</PermissionContextProvider>
 );
 
+type UsePermissionReturn = [
+  boolean,
+  () => Promise<void>,
+  (publishId: string) => boolean,
+];
+
 describe('usePermission', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -29,10 +35,15 @@ describe('usePermission', () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      await act(() => result.current[1]());
+      const [, fetchPermission] = result.current as UsePermissionReturn;
+      await act(() => fetchPermission());
 
       expect(localStorage.getItem('visitedWebsite')).toBe('true');
-      const [permissionFetched, , canViewPublishId] = result.current;
+      const [
+        permissionFetched,
+        ,
+        canViewPublishId,
+      ] = result.current as UsePermissionReturn;
       expect(permissionFetched).toBe(true);
       expect(canViewPublishId('any-id')).toBe(true);
     });
@@ -42,9 +53,14 @@ describe('usePermission', () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(true);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      await act(() => result.current[1]());
+      const [, fetchPermission] = result.current as UsePermissionReturn;
+      await act(() => fetchPermission());
 
-      const [permissionFetched, , canViewPublishId] = result.current;
+      const [
+        permissionFetched,
+        ,
+        canViewPublishId,
+      ] = result.current as UsePermissionReturn;
       expect(permissionFetched).toBe(true);
       expect(canViewPublishId('any-id')).toBe(true);
     });
@@ -54,9 +70,14 @@ describe('usePermission', () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      await act(() => result.current[1]());
+      const [, fetchPermission] = result.current as UsePermissionReturn;
+      await act(() => fetchPermission());
 
-      const [permissionFetched, , canViewPublishId] = result.current;
+      const [
+        permissionFetched,
+        ,
+        canViewPublishId,
+      ] = result.current as UsePermissionReturn;
       expect(permissionFetched).toBe(true);
       expect(canViewPublishId('any-id')).toBe(false);
     });
@@ -69,9 +90,10 @@ describe('usePermission', () => {
       mockUseIsMyPublishId.mockReturnValue((id: string) => id === 'my-id');
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      await act(() => result.current[1]());
+      const [, fetchPermission] = result.current as UsePermissionReturn;
+      await act(() => fetchPermission());
 
-      const [, , canViewPublishId] = result.current;
+      const [, , canViewPublishId] = result.current as UsePermissionReturn;
       expect(canViewPublishId('my-id')).toBe(true);
       expect(canViewPublishId('other-id')).toBe(false);
     });

--- a/src/hooks/usePermission.test.tsx
+++ b/src/hooks/usePermission.test.tsx
@@ -18,12 +18,6 @@ const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
   <PermissionContextProvider>{children}</PermissionContextProvider>
 );
 
-type UsePermissionReturn = [
-  boolean,
-  () => Promise<void>,
-  (publishId: string) => boolean,
-];
-
 describe('usePermission', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -35,15 +29,10 @@ describe('usePermission', () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      const [, fetchPermission] = result.current as UsePermissionReturn;
-      await act(() => fetchPermission());
+      await act(() => result.current[1]());
 
       expect(localStorage.getItem('visitedWebsite')).toBe('true');
-      const [
-        permissionFetched,
-        ,
-        canViewPublishId,
-      ] = result.current as UsePermissionReturn;
+      const [permissionFetched, , canViewPublishId] = result.current;
       expect(permissionFetched).toBe(true);
       expect(canViewPublishId('any-id')).toBe(true);
     });
@@ -53,14 +42,9 @@ describe('usePermission', () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(true);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      const [, fetchPermission] = result.current as UsePermissionReturn;
-      await act(() => fetchPermission());
+      await act(() => result.current[1]());
 
-      const [
-        permissionFetched,
-        ,
-        canViewPublishId,
-      ] = result.current as UsePermissionReturn;
+      const [permissionFetched, , canViewPublishId] = result.current;
       expect(permissionFetched).toBe(true);
       expect(canViewPublishId('any-id')).toBe(true);
     });
@@ -70,14 +54,9 @@ describe('usePermission', () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      const [, fetchPermission] = result.current as UsePermissionReturn;
-      await act(() => fetchPermission());
+      await act(() => result.current[1]());
 
-      const [
-        permissionFetched,
-        ,
-        canViewPublishId,
-      ] = result.current as UsePermissionReturn;
+      const [permissionFetched, , canViewPublishId] = result.current;
       expect(permissionFetched).toBe(true);
       expect(canViewPublishId('any-id')).toBe(false);
     });
@@ -90,10 +69,9 @@ describe('usePermission', () => {
       mockUseIsMyPublishId.mockReturnValue((id: string) => id === 'my-id');
 
       const { result } = renderHook(() => usePermission(), { wrapper });
-      const [, fetchPermission] = result.current as UsePermissionReturn;
-      await act(() => fetchPermission());
+      await act(() => result.current[1]());
 
-      const [, , canViewPublishId] = result.current as UsePermissionReturn;
+      const [, , canViewPublishId] = result.current;
       expect(canViewPublishId('my-id')).toBe(true);
       expect(canViewPublishId('other-id')).toBe(false);
     });

--- a/src/hooks/usePermission.test.tsx
+++ b/src/hooks/usePermission.test.tsx
@@ -25,7 +25,7 @@ describe('usePermission', () => {
   });
 
   describe('fetchPermission', () => {
-    it('第一次造訪時給予 canView = true，並寫入 localStorage', async () => {
+    it('sets canView = true and writes to localStorage on first visit', async () => {
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
 
       const { result } = renderHook(() => usePermission(), { wrapper });
@@ -37,7 +37,7 @@ describe('usePermission', () => {
       expect(canViewPublishId('any-id')).toBe(true);
     });
 
-    it('再次造訪時依 API 結果給予 canView = true', async () => {
+    it('sets canView = true based on API result on subsequent visits', async () => {
       localStorage.setItem('visitedWebsite', 'true');
       mockQueryHasSearchPermissionApi.mockResolvedValue(true);
 
@@ -49,7 +49,7 @@ describe('usePermission', () => {
       expect(canViewPublishId('any-id')).toBe(true);
     });
 
-    it('再次造訪時依 API 結果給予 canView = false', async () => {
+    it('sets canView = false based on API result on subsequent visits', async () => {
       localStorage.setItem('visitedWebsite', 'true');
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
 
@@ -63,7 +63,7 @@ describe('usePermission', () => {
   });
 
   describe('canViewPublishId', () => {
-    it('自己的 publishId 無論 canView 為何皆回傳 true', async () => {
+    it("returns true for the user's own publishId regardless of canView", async () => {
       localStorage.setItem('visitedWebsite', 'true');
       mockQueryHasSearchPermissionApi.mockResolvedValue(false);
       mockUseIsMyPublishId.mockReturnValue((id: string) => id === 'my-id');

--- a/src/hooks/usePermission.test.tsx
+++ b/src/hooks/usePermission.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+import usePermission from './usePermission';
+import PermissionContextProvider from 'components/common/PermissionContextProvider';
+import { queryHasSearchPermissionApi } from 'apis/me';
+import useIsMyPublishId from './useIsMyPublishId';
+
+jest.mock('apis/me', () => ({ queryHasSearchPermissionApi: jest.fn() }));
+jest.mock('hooks/auth', () => ({ useToken: jest.fn(() => 'test-token') }));
+jest.mock('./useIsMyPublishId');
+
+const mockQueryHasSearchPermissionApi = queryHasSearchPermissionApi as jest.MockedFunction<
+  typeof queryHasSearchPermissionApi
+>;
+const mockUseIsMyPublishId = useIsMyPublishId as jest.Mock;
+
+const wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+  <PermissionContextProvider>{children}</PermissionContextProvider>
+);
+
+describe('usePermission', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUseIsMyPublishId.mockReturnValue(() => false);
+  });
+
+  describe('fetchPermission', () => {
+    it('第一次造訪時給予 canView = true，並寫入 localStorage', async () => {
+      mockQueryHasSearchPermissionApi.mockResolvedValue(false);
+
+      const { result } = renderHook(() => usePermission(), { wrapper });
+      await act(() => result.current[1]());
+
+      expect(localStorage.getItem('visitedWebsite')).toBe('true');
+      const [permissionFetched, , canViewPublishId] = result.current;
+      expect(permissionFetched).toBe(true);
+      expect(canViewPublishId('any-id')).toBe(true);
+    });
+
+    it('再次造訪時依 API 結果給予 canView = true', async () => {
+      localStorage.setItem('visitedWebsite', 'true');
+      mockQueryHasSearchPermissionApi.mockResolvedValue(true);
+
+      const { result } = renderHook(() => usePermission(), { wrapper });
+      await act(() => result.current[1]());
+
+      const [permissionFetched, , canViewPublishId] = result.current;
+      expect(permissionFetched).toBe(true);
+      expect(canViewPublishId('any-id')).toBe(true);
+    });
+
+    it('再次造訪時依 API 結果給予 canView = false', async () => {
+      localStorage.setItem('visitedWebsite', 'true');
+      mockQueryHasSearchPermissionApi.mockResolvedValue(false);
+
+      const { result } = renderHook(() => usePermission(), { wrapper });
+      await act(() => result.current[1]());
+
+      const [permissionFetched, , canViewPublishId] = result.current;
+      expect(permissionFetched).toBe(true);
+      expect(canViewPublishId('any-id')).toBe(false);
+    });
+  });
+
+  describe('canViewPublishId', () => {
+    it('自己的 publishId 無論 canView 為何皆回傳 true', async () => {
+      localStorage.setItem('visitedWebsite', 'true');
+      mockQueryHasSearchPermissionApi.mockResolvedValue(false);
+      mockUseIsMyPublishId.mockReturnValue((id: string) => id === 'my-id');
+
+      const { result } = renderHook(() => usePermission(), { wrapper });
+      await act(() => result.current[1]());
+
+      const [, , canViewPublishId] = result.current;
+      expect(canViewPublishId('my-id')).toBe(true);
+      expect(canViewPublishId('other-id')).toBe(false);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,11 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
+"@babel/runtime@^7.12.5":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
 "@babel/runtime@^7.15.4":
   version "7.27.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.3.tgz#10491113799fb8d77e1d9273384d5d68deeea8f6"
@@ -1819,6 +1824,14 @@
     css.escape "^1.5.1"
     lodash "^4.17.15"
     redent "^3.0.0"
+
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
 
 "@testing-library/react@^11.1.0":
   version "11.1.0"
@@ -11186,6 +11199,13 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.6, react-error-overlay@^6.0.7:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -11230,6 +11250,11 @@ react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^19.2.6:
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.6.tgz#aeee6159b159eb7f520d672cffcc69e7052d288f"
+  integrity sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -11333,6 +11358,14 @@ react-sticky@^6.0.1:
   dependencies:
     prop-types "^15.5.8"
     raf "^3.3.0"
+
+react-test-renderer@^19.2.6:
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.6.tgz#42e9f9fcc4fe11d4bbf7acff536a2e5b8a8cfd45"
+  integrity sha512-GbS6V23YduFTPiWJ5xICbKEjRcqx1Z90js/V5miqhz7qp/d6xSe9Dd6NjSQODFRdzdsqRMPW82E/sFpPRbY5Mw==
+  dependencies:
+    react-is "^19.2.6"
+    scheduler "^0.27.0"
 
 react-textarea-autosize@^4.3.0:
   version "4.3.2"
@@ -12077,6 +12110,11 @@ scheduler@^0.18.0:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

- 安裝 `@testing-library/react-hooks` 以支援 hook 的單元測試
- 新增 `usePermission` 的 unit tests，覆蓋以下情境：
  - 第一次造訪時給予 `canView = true`，並寫入 localStorage
  - 再次造訪時依 API 結果決定 `canView`
  - 自己的 `publishId` 無論 `canView` 為何皆可查看

## Test plan

- [ ] `CI=true npx yarn testonly --testPathPattern="usePermission"` 4 個測試全過

🤖 Generated with [Claude Code](https://claude.com/claude-code)