### PR TITLE
refactor: rename TimeAndSalary to SalaryWorkTime

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -24,8 +24,8 @@ import {
   companyOverviewBoxSelectorByName,
   companyOverviewStatisticsBoxSelectorByName,
   companyRatingStatisticsBoxSelectorByName,
-  companyTimeAndSalaryBoxSelectorByName,
-  companyTimeAndSalaryStatisticsBoxSelectorByName,
+  companySalaryWorkTimeBoxSelectorByName,
+  companySalaryWorkTimeStatisticsBoxSelectorByName,
   companyTopNJobTitlesBoxSelectorByName,
   companyWorkExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
@@ -264,7 +264,7 @@ const setInterviewExperiences = (companyName, box) => ({
   box,
 });
 
-export const queryCompanyTimeAndSalary = (
+export const queryCompanySalaryWorkTime = (
   {
     companyName,
     jobTitle,
@@ -277,7 +277,7 @@ export const queryCompanyTimeAndSalary = (
   },
   { force = false } = {},
 ) => async (dispatch, getState) => {
-  const box = companyTimeAndSalaryBoxSelectorByName(companyName)(getState());
+  const box = companySalaryWorkTimeBoxSelectorByName(companyName)(getState());
   if (
     !force &&
     (isFetching(box) ||
@@ -345,11 +345,11 @@ const setCompanyTopNJobTitles = (companyName, box) => ({
   box,
 });
 
-export const queryCompanyTimeAndSalaryStatistics = ({ companyName }) => async (
+export const queryCompanySalaryWorkTimeStatistics = ({ companyName }) => async (
   dispatch,
   getState,
 ) => {
-  const box = companyTimeAndSalaryStatisticsBoxSelectorByName(companyName)(
+  const box = companySalaryWorkTimeStatisticsBoxSelectorByName(companyName)(
     getState(),
   );
   if (

--- a/src/actions/jobTitle.js
+++ b/src/actions/jobTitle.js
@@ -14,8 +14,8 @@ import {
   jobTitleInterviewExperiencesBoxSelectorByName,
   jobTitleOverviewBoxSelectorByName,
   jobTitleOverviewStatisticsBoxSelectorByName,
-  jobTitleTimeAndSalaryBoxSelectorByName,
-  jobTitleTimeAndSalaryStatisticsBoxSelectorByName,
+  jobTitleSalaryWorktimeBoxSelectorByName,
+  jobTitleSalaryWorkTimeStatisticsBoxSelectorByName,
   jobTitleWorkExperiencesBoxSelectorByName,
 } from 'selectors/companyAndJobTitle';
 import { isGraphqlError } from 'utils/errors';
@@ -216,7 +216,7 @@ export const queryJobTitleTimeAndSalary = (
   },
   { force = false } = {},
 ) => async (dispatch, getState) => {
-  const box = jobTitleTimeAndSalaryBoxSelectorByName(jobTitle)(getState());
+  const box = jobTitleSalaryWorktimeBoxSelectorByName(jobTitle)(getState());
   if (
     !force &&
     (isFetching(box) ||
@@ -282,7 +282,7 @@ export const queryJobTitleTimeAndSalaryStatistics = ({ jobTitle }) => async (
   dispatch,
   getState,
 ) => {
-  const box = jobTitleTimeAndSalaryStatisticsBoxSelectorByName(jobTitle)(
+  const box = jobTitleSalaryWorkTimeStatisticsBoxSelectorByName(jobTitle)(
     getState(),
   );
   if (

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/SalaryWorkTimeSection.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/SalaryWorkTimeSection.js
@@ -10,7 +10,7 @@ import EmptyView from '../EmptyView';
 import ViewLog from './ViewLog';
 import WorkingHourBlock from './WorkingHourBlock';
 
-const TimeAndSalary = ({
+const SalaryWorkTimeSection = ({
   salaryWorkTimes,
   pageType,
   pageName,
@@ -56,7 +56,7 @@ const TimeAndSalary = ({
   );
 };
 
-TimeAndSalary.propTypes = {
+SalaryWorkTimeSection.propTypes = {
   createPageLinkTo: PropTypes.func.isRequired,
   onCloseReport: PropTypes.func.isRequired,
   page: PropTypes.number,
@@ -68,4 +68,4 @@ TimeAndSalary.propTypes = {
   totalCount: PropTypes.number.isRequired,
 };
 
-export default TimeAndSalary;
+export default SalaryWorkTimeSection;

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/index.js
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/index.js
@@ -12,7 +12,7 @@ import PageBoxRenderer from '../PageBoxRenderer';
 import Helmet from './Helmet';
 import OvertimeSection from './OvertimeSection';
 import SalaryFilter from './SalaryFilter';
-import TimeAndSalarySection from './TimeAndSalary';
+import SalaryWorkTimeSection from './SalaryWorkTimeSection';
 import SearchBar from '../SearchBar';
 import SummarySection from './SummarySection';
 import styles from './TimeAndSalary.module.css';
@@ -117,7 +117,7 @@ const TimeAndSalary = ({
                   page={page}
                   topNJobTitles={topNJobTitles}
                 />
-                <TimeAndSalarySection
+                <SalaryWorkTimeSection
                   pageType={pageType}
                   pageName={pageName}
                   tabType={tabType}

--- a/src/components/common/PermissionBlock/LoginToUnlock.js
+++ b/src/components/common/PermissionBlock/LoginToUnlock.js
@@ -13,7 +13,7 @@ import useUnlockedDescriptionBySubmission from './useUnlockedDescriptionBySubmis
 
 const LoginToUnlock = ({ to, onAuthenticatedClick }) => {
   const experienceCount = useExperienceCount();
-  const timeAndSalaryCount = useSalaryWorkTimeCount();
+  const salaryWorkTimeCount = useSalaryWorkTimeCount();
   const [isLoggedIn, login] = useLogin();
   const unlockedDescription = useUnlockedDescriptionBySubmission();
 
@@ -25,7 +25,7 @@ const LoginToUnlock = ({ to, onAuthenticatedClick }) => {
         </P>
       </div>
       <P size="l" className={styles.ctaText}>
-        解鎖全站共 {timeAndSalaryCount + experienceCount} 筆薪資、面試資料
+        解鎖全站共 {salaryWorkTimeCount + experienceCount} 筆薪資、面試資料
       </P>
       {!isLoggedIn && (
         <P

--- a/src/pages/Company/CompanySalaryWorkTimeProvider.js
+++ b/src/pages/Company/CompanySalaryWorkTimeProvider.js
@@ -4,8 +4,8 @@ import { useDispatch, useSelector } from 'react-redux';
 import {
   queryCompanyEsgSalaryData,
   queryCompanyOverviewStatistics,
-  queryCompanyTimeAndSalary,
-  queryCompanyTimeAndSalaryStatistics,
+  queryCompanySalaryWorkTime,
+  queryCompanySalaryWorkTimeStatistics,
   queryCompanyTopNJobTitles,
   queryRatingStatistics,
 } from 'actions/company';
@@ -30,8 +30,8 @@ import usePermission from 'hooks/usePermission';
 import {
   companyEsgSalaryDataBoxSelectorByName,
   companyOverviewStatisticsBoxSelectorByName,
-  companyTimeAndSalaryBoxSelectorByName as timeAndSalaryBoxSelectorByName,
-  companyTimeAndSalaryStatisticsBoxSelectorByName as timeAndSalaryStatisticsBoxSelectorByName,
+  companySalaryWorkTimeBoxSelectorByName as timeAndSalaryBoxSelectorByName,
+  companySalaryWorkTimeStatisticsBoxSelectorByName as timeAndSalaryStatisticsBoxSelectorByName,
   salaryWorkTimeStatistics as salaryWorkTimeStatisticsSelector,
 } from 'selectors/companyAndJobTitle';
 import {
@@ -100,10 +100,10 @@ const CompanySalaryWorkTimeProvider = () => {
     [experience],
   );
 
-  const handleQueryCompanyTimeAndSalary = useCallback(
+  const handleQueryCompanySalaryWorkTime = useCallback(
     ({ force = false } = {}) => {
       dispatch(
-        queryCompanyTimeAndSalary(
+        queryCompanySalaryWorkTime(
           {
             companyName,
             jobTitle: jobTitle || undefined,
@@ -137,7 +137,7 @@ const CompanySalaryWorkTimeProvider = () => {
 
   useEffect(() => {
     dispatch(
-      queryCompanyTimeAndSalaryStatistics({
+      queryCompanySalaryWorkTimeStatistics({
         companyName,
       }),
     );
@@ -164,8 +164,8 @@ const CompanySalaryWorkTimeProvider = () => {
   }, [dispatch, companyName]);
 
   useEffect(() => {
-    handleQueryCompanyTimeAndSalary();
-  }, [handleQueryCompanyTimeAndSalary]);
+    handleQueryCompanySalaryWorkTime();
+  }, [handleQueryCompanySalaryWorkTime]);
 
   const [, fetchPermission] = usePermission();
   useEffect(() => {
@@ -191,7 +191,7 @@ const CompanySalaryWorkTimeProvider = () => {
       salaryWorkTimeStatistics={salaryWorkTimeStatistics}
       boxSelector={boxSelector}
       statisticsBox={statisticsBox}
-      onCloseReport={() => handleQueryCompanyTimeAndSalary({ force: true })}
+      onCloseReport={() => handleQueryCompanySalaryWorkTime({ force: true })}
     />
   );
 };
@@ -217,12 +217,12 @@ CompanySalaryWorkTimeProvider.fetchData = ({
     queryCompanyOverviewStatistics(companyName),
   );
   const dispatchTimeAndSalaryStatistics = dispatch(
-    queryCompanyTimeAndSalaryStatistics({
+    queryCompanySalaryWorkTimeStatistics({
       companyName,
     }),
   );
   const dispatchTimeAndSalary = dispatch(
-    queryCompanyTimeAndSalary({
+    queryCompanySalaryWorkTime({
       companyName,
       jobTitle,
       start,

--- a/src/pages/Company/CompanySalaryWorkTimeProvider.js
+++ b/src/pages/Company/CompanySalaryWorkTimeProvider.js
@@ -80,7 +80,7 @@ const useEsgSalaryDataBox = companyName => {
   return useSelector(selector);
 };
 
-const CompanyTimeAndSalaryProvider = () => {
+const CompanySalaryWorkTimeProvider = () => {
   const dispatch = useDispatch();
   const pageType = PageType.COMPANY;
   const companyName = useCompanyName();
@@ -196,7 +196,7 @@ const CompanyTimeAndSalaryProvider = () => {
   );
 };
 
-CompanyTimeAndSalaryProvider.fetchData = ({
+CompanySalaryWorkTimeProvider.fetchData = ({
   store: { dispatch },
   ...props
 }) => {
@@ -254,4 +254,4 @@ CompanyTimeAndSalaryProvider.fetchData = ({
   ]);
 };
 
-export default CompanyTimeAndSalaryProvider;
+export default CompanySalaryWorkTimeProvider;

--- a/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
+++ b/src/pages/JobTitle/JobTitleInterviewExperiencesProvider.js
@@ -45,7 +45,7 @@ const useInterviewExperiencesBoxSelector = jobTitle => {
   );
 };
 
-const JobTitleTimeAndSalaryProvider = () => {
+const JobTitleInterviewExperiencesProvider = () => {
   const dispatch = useDispatch();
   const pageType = PageType.JOB_TITLE;
   const jobTitle = useJobTitle();
@@ -86,7 +86,7 @@ const JobTitleTimeAndSalaryProvider = () => {
   );
 };
 
-JobTitleTimeAndSalaryProvider.fetchData = ({
+JobTitleInterviewExperiencesProvider.fetchData = ({
   store: { dispatch },
   ...props
 }) => {
@@ -109,4 +109,4 @@ JobTitleTimeAndSalaryProvider.fetchData = ({
   );
 };
 
-export default JobTitleTimeAndSalaryProvider;
+export default JobTitleInterviewExperiencesProvider;

--- a/src/pages/JobTitle/JobTitleSalaryWorkTimeProvider.js
+++ b/src/pages/JobTitle/JobTitleSalaryWorkTimeProvider.js
@@ -69,7 +69,7 @@ const useTimeAndSalaryBoxSelector = pageName => {
   );
 };
 
-const JobTitleTimeAndSalaryProvider = () => {
+const JobTitleSalaryWorkTimeProvider = () => {
   const dispatch = useDispatch();
   const pageType = PageType.JOB_TITLE;
   const jobTitle = useJobTitle();
@@ -161,7 +161,7 @@ const JobTitleTimeAndSalaryProvider = () => {
   );
 };
 
-JobTitleTimeAndSalaryProvider.fetchData = ({
+JobTitleSalaryWorkTimeProvider.fetchData = ({
   store: { dispatch },
   ...props
 }) => {
@@ -195,4 +195,4 @@ JobTitleTimeAndSalaryProvider.fetchData = ({
   ]);
 };
 
-export default JobTitleTimeAndSalaryProvider;
+export default JobTitleSalaryWorkTimeProvider;

--- a/src/pages/JobTitle/JobTitleSalaryWorkTimeProvider.js
+++ b/src/pages/JobTitle/JobTitleSalaryWorkTimeProvider.js
@@ -26,8 +26,8 @@ import { usePage } from 'hooks/routing/page';
 import usePermission from 'hooks/usePermission';
 import {
   jobTitleOverviewStatisticsBoxSelectorByName as overviewStatisticsBoxSelectorByName,
-  jobTitleTimeAndSalaryBoxSelectorByName as timeAndSalaryBoxSelectorByName,
-  jobTitleTimeAndSalaryStatisticsBoxSelectorByName as timeAndSalaryStatisticsBoxSelectorByName,
+  jobTitleSalaryWorktimeBoxSelectorByName as timeAndSalaryBoxSelectorByName,
+  jobTitleSalaryWorkTimeStatisticsBoxSelectorByName as timeAndSalaryStatisticsBoxSelectorByName,
   salaryWorkTimeStatistics as salaryWorkTimeStatisticsSelector,
 } from 'selectors/companyAndJobTitle';
 import {

--- a/src/reducers/companyIndex.ts
+++ b/src/reducers/companyIndex.ts
@@ -48,11 +48,11 @@ export type CompanyOverviewStatistics = {
   overtimeFrequencyCount: OvertimeFrequencyCount | null;
 };
 
-// TODO: replace with proper CompanyTimeAndSalaryResult type
-export type CompanyTimeAndSalaryResult = unknown;
+// TODO: replace with proper CompanySalaryWorkTimeResult type
+export type CompanySalaryWorkTimeResult = unknown;
 
 // TODO: replace with proper CompanyTimeAndSalaryStatistics type
-export type CompanyTimeAndSalaryStatistics = unknown;
+export type CompanySalaryWorkTimeStatistics = unknown;
 
 // TODO: replace with proper CompanyInterviewExperienceResult type
 export type CompanyInterviewExperienceResult = unknown;
@@ -84,11 +84,11 @@ type State = {
   >;
   timeAndSalaryByName: Record<
     string,
-    FetchBox<CompanyTimeAndSalaryResult | null>
+    FetchBox<CompanySalaryWorkTimeResult | null>
   >;
   timeAndSalaryStatisticsByName: Record<
     string,
-    FetchBox<CompanyTimeAndSalaryStatistics | null>
+    FetchBox<CompanySalaryWorkTimeStatistics | null>
   >;
   interviewExperiencesByName: Record<
     string,
@@ -191,7 +191,7 @@ const reducer = createReducer(preloadedState, {
       box,
     }: {
       companyName: string;
-      box: FetchBox<CompanyTimeAndSalaryResult | null>;
+      box: FetchBox<CompanySalaryWorkTimeResult | null>;
     },
   ) => {
     return {
@@ -209,7 +209,7 @@ const reducer = createReducer(preloadedState, {
       box,
     }: {
       companyName: string;
-      box: FetchBox<CompanyTimeAndSalaryStatistics | null>;
+      box: FetchBox<CompanySalaryWorkTimeStatistics | null>;
     },
   ) => {
     return {

--- a/src/reducers/jobTitleIndex.ts
+++ b/src/reducers/jobTitleIndex.ts
@@ -42,11 +42,11 @@ export type JobTitleOverviewStatistics = {
   overtimeFrequencyCount: OvertimeFrequencyCount | null;
 };
 
-// TODO: replace with proper JobTitleTimeAndSalaryResult type
-export type JobTitleTimeAndSalaryResult = unknown;
+// TODO: replace with proper JobTitleSalaryWorkTimeResult type
+export type JobTitleSalaryWorkTimeResult = unknown;
 
-// TODO: replace with proper JobTitleTimeAndSalaryStatistics type
-export type JobTitleTimeAndSalaryStatistics = unknown;
+// TODO: replace with proper JobTitleSalaryWorkTimeStatistics type
+export type JobTitleSalaryWorkTimeStatistics = unknown;
 
 // TODO: replace with proper JobTitleInterviewExperienceResult type
 export type JobTitleInterviewExperienceResult = unknown;
@@ -71,11 +71,11 @@ type State = {
   >;
   timeAndSalaryByName: Record<
     string,
-    FetchBox<JobTitleTimeAndSalaryResult | null>
+    FetchBox<JobTitleSalaryWorkTimeResult | null>
   >;
   timeAndSalaryStatisticsByName: Record<
     string,
-    FetchBox<JobTitleTimeAndSalaryStatistics | null>
+    FetchBox<JobTitleSalaryWorkTimeStatistics | null>
   >;
   interviewExperiencesByName: Record<
     string,
@@ -157,7 +157,7 @@ const reducer = createReducer(preloadedState, {
       box,
     }: {
       jobTitle: string;
-      box: FetchBox<JobTitleTimeAndSalaryResult | null>;
+      box: FetchBox<JobTitleSalaryWorkTimeResult | null>;
     },
   ) => {
     return {
@@ -175,7 +175,7 @@ const reducer = createReducer(preloadedState, {
       box,
     }: {
       jobTitle: string;
-      box: FetchBox<JobTitleTimeAndSalaryStatistics | null>;
+      box: FetchBox<JobTitleSalaryWorkTimeStatistics | null>;
     },
   ) => {
     return {

--- a/src/routes.js
+++ b/src/routes.js
@@ -17,13 +17,13 @@ import {
 import CompanyIndexProvider from 'pages/Company/CompanyIndexProvider';
 import CompanyInterviewExperiencesProvider from 'pages/Company/CompanyInterviewExperiencesProvider';
 import CompanyOverviewProvider from 'pages/Company/CompanyOverviewProvider';
-import CompanyTimeAndSalaryProvider from 'pages/Company/CompanyTimeAndSalaryProvider';
+import CompanySalaryWorkTimeProvider from 'pages/Company/CompanySalaryWorkTimeProvider';
 import CompanyWorkExperiencesProvider from 'pages/Company/CompanyWorkExperiencesProvider';
 import { companyNameSelector } from 'pages/Company/useCompanyName';
 import JobTitleIndexProvider from 'pages/JobTitle/JobTitleIndexProvider';
 import JobTitleInterviewExperiencesProvider from 'pages/JobTitle/JobTitleInterviewExperiencesProvider';
 import JobTitleOverviewProvider from 'pages/JobTitle/JobTitleOverviewProvider';
-import JobTitleTimeAndSalaryProvider from 'pages/JobTitle/JobTitleTimeAndSalaryProvider';
+import JobTitleSalaryWorkTimeProvider from 'pages/JobTitle/JobTitleSalaryWorkTimeProvider';
 import JobTitleWorkExperiencesProvider from 'pages/JobTitle/JobTitleWorkExperiencesProvider';
 import { jobTitleSelector } from 'pages/JobTitle/useJobTitle';
 import SearchPage from 'pages/SearchPage';
@@ -133,7 +133,7 @@ const routes = [
       },
       {
         path: companySalaryWorkTimesPath,
-        component: CompanyTimeAndSalaryProvider,
+        component: CompanySalaryWorkTimeProvider,
         exact: true,
       },
       {
@@ -176,7 +176,7 @@ const routes = [
       },
       {
         path: jobTitleSalaryWorkTimesPath,
-        component: JobTitleTimeAndSalaryProvider,
+        component: JobTitleSalaryWorkTimeProvider,
         exact: true,
       },
       {

--- a/src/selectors/companyAndJobTitle.ts
+++ b/src/selectors/companyAndJobTitle.ts
@@ -58,12 +58,12 @@ export const companyOverviewStatisticsBoxSelectorByName = (
 ) => (state: RootState): FetchBox<CompanyOverviewStatistics | null> =>
   state.companyIndex.overviewStatisticsByName[companyName] || getUnfetched();
 
-export const companyTimeAndSalaryBoxSelectorByName = (companyName: string) => (
+export const companySalaryWorkTimeBoxSelectorByName = (companyName: string) => (
   state: RootState,
 ): FetchBox<CompanyTimeAndSalaryResult | null> =>
   state.companyIndex.timeAndSalaryByName[companyName] || getUnfetched();
 
-export const companyTimeAndSalaryStatisticsBoxSelectorByName = (
+export const companySalaryWorkTimeStatisticsBoxSelectorByName = (
   companyName: string,
 ) => (state: RootState): FetchBox<CompanyTimeAndSalaryStatistics | null> =>
   state.companyIndex.timeAndSalaryStatisticsByName[companyName] ||
@@ -114,12 +114,12 @@ export const jobTitleOverviewStatisticsBoxSelectorByName = (
 ) => (state: RootState): FetchBox<JobTitleOverviewStatistics | null> =>
   state.jobTitleIndex.overviewStatisticsByName[jobTitle] || getUnfetched();
 
-export const jobTitleTimeAndSalaryBoxSelectorByName = (jobTitle: string) => (
+export const jobTitleSalaryWorktimeBoxSelectorByName = (jobTitle: string) => (
   state: RootState,
 ): FetchBox<JobTitleTimeAndSalaryResult | null> =>
   state.jobTitleIndex.timeAndSalaryByName[jobTitle] || getUnfetched();
 
-export const jobTitleTimeAndSalaryStatisticsBoxSelectorByName = (
+export const jobTitleSalaryWorkTimeStatisticsBoxSelectorByName = (
   jobTitle: string,
 ) => (state: RootState): FetchBox<JobTitleTimeAndSalaryStatistics | null> =>
   state.jobTitleIndex.timeAndSalaryStatisticsByName[jobTitle] || getUnfetched();

--- a/src/selectors/companyAndJobTitle.ts
+++ b/src/selectors/companyAndJobTitle.ts
@@ -9,8 +9,8 @@ import {
   CompanyIsSubscribed,
   CompanyOverview,
   CompanyOverviewStatistics,
-  CompanyTimeAndSalaryResult,
-  CompanyTimeAndSalaryStatistics,
+  CompanySalaryWorkTimeResult,
+  CompanySalaryWorkTimeStatistics,
   CompanyWorkExperienceResult,
   TopNJobTitles,
 } from 'reducers/companyIndex';
@@ -19,8 +19,8 @@ import {
   JobTitleInterviewExperienceResult,
   JobTitleOverview,
   JobTitleOverviewStatistics,
-  JobTitleTimeAndSalaryResult,
-  JobTitleTimeAndSalaryStatistics,
+  JobTitleSalaryWorkTimeResult,
+  JobTitleSalaryWorkTimeStatistics,
   JobTitleWorkExperienceResult,
 } from 'reducers/jobTitleIndex';
 import FetchBox, { getUnfetched, isFetched } from 'utils/fetchBox';
@@ -60,12 +60,12 @@ export const companyOverviewStatisticsBoxSelectorByName = (
 
 export const companySalaryWorkTimeBoxSelectorByName = (companyName: string) => (
   state: RootState,
-): FetchBox<CompanyTimeAndSalaryResult | null> =>
+): FetchBox<CompanySalaryWorkTimeResult | null> =>
   state.companyIndex.timeAndSalaryByName[companyName] || getUnfetched();
 
 export const companySalaryWorkTimeStatisticsBoxSelectorByName = (
   companyName: string,
-) => (state: RootState): FetchBox<CompanyTimeAndSalaryStatistics | null> =>
+) => (state: RootState): FetchBox<CompanySalaryWorkTimeStatistics | null> =>
   state.companyIndex.timeAndSalaryStatisticsByName[companyName] ||
   getUnfetched();
 
@@ -116,12 +116,12 @@ export const jobTitleOverviewStatisticsBoxSelectorByName = (
 
 export const jobTitleSalaryWorktimeBoxSelectorByName = (jobTitle: string) => (
   state: RootState,
-): FetchBox<JobTitleTimeAndSalaryResult | null> =>
+): FetchBox<JobTitleSalaryWorkTimeResult | null> =>
   state.jobTitleIndex.timeAndSalaryByName[jobTitle] || getUnfetched();
 
 export const jobTitleSalaryWorkTimeStatisticsBoxSelectorByName = (
   jobTitle: string,
-) => (state: RootState): FetchBox<JobTitleTimeAndSalaryStatistics | null> =>
+) => (state: RootState): FetchBox<JobTitleSalaryWorkTimeStatistics | null> =>
   state.jobTitleIndex.timeAndSalaryStatisticsByName[jobTitle] || getUnfetched();
 
 export const jobTitleInterviewExperiencesBoxSelectorByName = (


### PR DESCRIPTION
Aligns file, component, selector, action, and provider names with the established SalaryWorkTime naming convention used in routes and paths.

Pure rename — no logic changes.