### PR TITLE
fix: 修正面向體驗載入閃爍並保留排序時的捲軸位置

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -624,7 +624,7 @@ export const queryCompanyWorkExperiencesAspectStatistics = ({
     return;
   }
 
-  dispatch(setWorkExperiencesAspectStatistics(companyName, toFetching()));
+  dispatch(setWorkExperiencesAspectStatistics(companyName, toFetching(box)));
 
   try {
     const data = await queryCompanyAspectRatingStatisticsApi({
@@ -666,7 +666,7 @@ export const queryCompanyWorkExperiencesAspectExperiences = ({
     return;
   }
 
-  dispatch(setWorkExperiencesAspectExperiences(companyName, toFetching()));
+  dispatch(setWorkExperiencesAspectExperiences(companyName, toFetching(box)));
 
   try {
     const data = await queryCompanyWorkExperiencesApi({

--- a/src/client.js
+++ b/src/client.js
@@ -39,7 +39,7 @@ function shouldUpdateScroll(prevProps, props) {
     props && props.location && props.location.state && props.location.state.y;
 
   if (shouldScroll && shouldScrollToY && scrollY) {
-    return [0, scrollY];
+    return [0, Math.min(scrollY, window.scrollY)];
   }
 
   return shouldScroll;

--- a/src/components/CompanyAndJobTitle/Sorter.js
+++ b/src/components/CompanyAndJobTitle/Sorter.js
@@ -1,10 +1,11 @@
 import qs from 'qs';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useHistory } from 'react-router';
 
 import Sort from 'common/icons/Sort';
 import RoundedSelect from 'common/RoundedSelect';
 import { useQuery } from 'hooks/routing';
+import useMobile from 'hooks/useMobile';
 
 export const SORT_BY = {
   LATEST_FIRST: 'LATEST_FIRST',
@@ -18,30 +19,59 @@ export const sortByFromQuerySelector = query => {
   return SORT_BY.FEATURED_FIRST;
 };
 
+const useSectionY = () => {
+  const sectionRef = useRef(null);
+  const isMobile = useMobile();
+  const [y, setY] = useState(null);
+
+  /* eslint-disable react-hooks/exhaustive-deps */
+  // DOM state changes don't notify React,
+  // so dependencies are omitted to always run the effect
+  // to ensure the latest scroll position is calculated.
+  useEffect(() => {
+    if (sectionRef.current) {
+      const rect = sectionRef.current.getBoundingClientRect();
+      let newY = rect.top + window.scrollY;
+      if (isMobile) {
+        newY -= 50; /* nav height */
+      }
+      if (newY !== y) {
+        setY(newY);
+      }
+    }
+  });
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  return [y, sectionRef];
+};
+
 export const useSortByFromQuery = () => {
   const history = useHistory();
   const query = useQuery();
   const sortBy = sortByFromQuerySelector(query);
+  const [y, sectionRef] = useSectionY();
   const setSortBy = useCallback(
     nextSortBy => {
       if (sortBy === nextSortBy) return;
       const { p, sort_by, ...restQuery } = query; // remove page when sort_by changes
       const nextQuery = { ...restQuery, sort_by: nextSortBy };
-      const nextUrl = qs.stringify(nextQuery, { addQueryPrefix: true });
-      history.push(nextUrl);
+      const search = qs.stringify(nextQuery, { addQueryPrefix: true });
+      history.push({ search, state: { y } });
     },
-    [sortBy, query, history],
+    [sortBy, query, history, y],
   );
-  return [sortBy, setSortBy];
+  return [sortBy, setSortBy, sectionRef];
 };
 
 const Sorter = () => {
-  const [sortBy, setSortBy] = useSortByFromQuery();
+  const [sortBy, setSortBy, sectionRef] = useSortByFromQuery();
   return (
-    <RoundedSelect Icon={Sort} value={sortBy} onChange={setSortBy}>
-      <option value={SORT_BY.FEATURED_FIRST}>近期精選貼文</option>
-      <option value={SORT_BY.LATEST_FIRST}>按照時間排序(新-&gt;舊)</option>
-    </RoundedSelect>
+    <div ref={sectionRef}>
+      <RoundedSelect Icon={Sort} value={sortBy} onChange={setSortBy}>
+        <option value={SORT_BY.FEATURED_FIRST}>近期精選貼文</option>
+        <option value={SORT_BY.LATEST_FIRST}>按照時間排序(新-&gt;舊)</option>
+      </RoundedSelect>
+    </div>
   );
 };
 

--- a/src/components/CompanyAndJobTitle/Sorter.js
+++ b/src/components/CompanyAndJobTitle/Sorter.js
@@ -1,11 +1,11 @@
 import qs from 'qs';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback } from 'react';
 import { useHistory } from 'react-router';
 
 import Sort from 'common/icons/Sort';
 import RoundedSelect from 'common/RoundedSelect';
 import { useQuery } from 'hooks/routing';
-import useMobile from 'hooks/useMobile';
+import useSectionY from 'hooks/useSectionY';
 
 export const SORT_BY = {
   LATEST_FIRST: 'LATEST_FIRST',
@@ -17,32 +17,6 @@ export const sortByFromQuerySelector = query => {
   const availableSortBy = Object.values(SORT_BY);
   if (availableSortBy.includes(sortBy)) return sortBy;
   return SORT_BY.FEATURED_FIRST;
-};
-
-const useSectionY = () => {
-  const sectionRef = useRef(null);
-  const isMobile = useMobile();
-  const [y, setY] = useState(null);
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  // DOM state changes don't notify React,
-  // so dependencies are omitted to always run the effect
-  // to ensure the latest scroll position is calculated.
-  useEffect(() => {
-    if (sectionRef.current) {
-      const rect = sectionRef.current.getBoundingClientRect();
-      let newY = rect.top + window.scrollY;
-      if (isMobile) {
-        newY -= 50; /* nav height */
-      }
-      if (newY !== y) {
-        setY(newY);
-      }
-    }
-  });
-  /* eslint-enable react-hooks/exhaustive-deps */
-
-  return [y, sectionRef];
 };
 
 export const useSortByFromQuery = () => {

--- a/src/components/common/Pagination/Pagination.js
+++ b/src/components/common/Pagination/Pagination.js
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import qs from 'qs';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { P } from 'common/base';
 import ArrowLeft from 'common/icons/ArrowLeft';
 import { useQuery } from 'hooks/routing';
-import useMobile from 'hooks/useMobile';
+import useSectionY from 'hooks/useSectionY';
 
 import {
   getCurrentCount,
@@ -17,32 +17,6 @@ import {
   isPreviousDisabled,
 } from './helpers';
 import styles from './Pagination.module.css';
-
-const useSectionY = () => {
-  const sectionRef = useRef(null);
-  const isMobile = useMobile();
-  const [y, setY] = useState(null);
-
-  /* eslint-disable react-hooks/exhaustive-deps */
-  // DOM state changes don't notify React,
-  // so dependencies are omitted to always run the effect
-  // to ensure the latest scroll position is calculated.
-  useEffect(() => {
-    if (sectionRef.current) {
-      const rect = sectionRef.current.getBoundingClientRect();
-      let newY = rect.top + window.scrollY;
-      if (isMobile) {
-        newY -= 50; /* nav height */
-      }
-      if (newY !== y) {
-        setY(newY);
-      }
-    }
-  });
-  /* eslint-enable react-hooks/exhaustive-deps */
-
-  return [y, sectionRef];
-};
 
 // Portal for generating the link and ref
 export const useCreatePageLinkTo = () => {

--- a/src/hooks/useSectionY.js
+++ b/src/hooks/useSectionY.js
@@ -1,0 +1,31 @@
+import { useEffect, useRef, useState } from 'react';
+
+import useMobile from 'hooks/useMobile';
+
+const useSectionY = () => {
+  const sectionRef = useRef(null);
+  const isMobile = useMobile();
+  const [y, setY] = useState(null);
+
+  /* eslint-disable react-hooks/exhaustive-deps */
+  // DOM state changes don't notify React,
+  // so dependencies are omitted to always run the effect
+  // to ensure the latest scroll position is calculated.
+  useEffect(() => {
+    if (sectionRef.current) {
+      const rect = sectionRef.current.getBoundingClientRect();
+      let newY = rect.top + window.scrollY;
+      if (isMobile) {
+        newY -= 50; /* nav height */
+      }
+      if (newY !== y) {
+        setY(newY);
+      }
+    }
+  });
+  /* eslint-enable react-hooks/exhaustive-deps */
+
+  return [y, sectionRef];
+};
+
+export default useSectionY;


### PR DESCRIPTION
## 這個 PR 是？

修正兩個面向體驗（Aspect Experience）的使用者體驗問題：

- **載入閃爍**：`toFetching()` 缺少 `box` 參數，導致切換篩選時原有資料被清空、出現空白閃爍。補上 `toFetching(box)` 後，載入期間可保留舊資料。
- **排序切換後捲軸跑掉**：切換排序時，現在會記錄 Sorter 元件的 Y 位置並透過 `history.state.y` 傳遞，讓頁面在重新渲染後回到相同位置。同時，若使用者已滾動至目標位置以上，也不會強制往下捲。

另將 `useSectionY` 從 `Pagination` 中提取為獨立共用 hook，供 Sorter 複用。

## Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/596d8a0c-df9a-4ad4-959b-e5fd697c564e

</td>
<td>

https://github.com/user-attachments/assets/38718bc4-b3b3-4490-9017-535aea2b161d

</td>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/5a20bf00-3990-415e-a243-1f1fe1193954

</td>
<td>

https://github.com/user-attachments/assets/de0fc416-dfb2-4b49-a29b-657ae2dae1da

</td>
</tr>
</table>

## Questions:

- 我需要更新 Packages 嗎？ No
- 有哪些文件需要被更新嗎？ No

## 我應該如何手動測試？

1. 前往任一公司頁面，切換至「工作經驗」的面向頁籤（如[台積電](http://localhost:3000/companies/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0%E8%82%A1%E4%BB%BD%E6%9C%89%E9%99%90%E5%85%AC%E5%8F%B8(%E5%8F%B0%E7%A9%8D%E9%9B%BB)%20TSMC/work-experiences/%E5%85%AC%E5%8F%B8%2F%E5%9C%98%E9%9A%8A%E6%96%87%E5%8C%96)）
2. 重複切換篩選器，確認載入中不再出現內容空白閃爍
3. 切換排序方式，確認頁面停在 Sorter 位置附近，不會跳到頁面頂部或底部
