### PR TITLE
refactor: migrate queryExperienceCount and queryCompanies APIs to TypeScript

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -4,8 +4,8 @@ import {
   getCompanyInterviewExperiences,
   getCompanyTimeAndSalary,
   getCompanyTimeAndSalaryStatistics,
-  queryCompaniesApi,
 } from 'apis/company';
+import queryCompaniesApi from 'apis/queryCompanies';
 import queryCompanyAspectRatingStatisticsApi from 'apis/queryCompanyAspectRatingStatistics';
 import queryCompanyEsgSalaryDataApi from 'apis/queryCompanyEsgSalaryData';
 import queryCompanyIsSubscribedApi from 'apis/queryCompanyIsSubscribed';

--- a/src/actions/experiences.ts
+++ b/src/actions/experiences.ts
@@ -1,7 +1,7 @@
 import { AnyAction } from 'redux';
 
-import { queryExperienceCountApi } from 'apis/experiencesApi';
 import { postInterviewExperience as postInterviewExperienceApi } from 'apis/interviewExperiencesApi';
+import queryExperienceCountApi from 'apis/queryExperienceCount';
 import { postWorkExperienceWithRating as postWorkExperienceWithRatingApi } from 'apis/workExperiencesApi';
 import { Thunk } from 'reducers';
 import { tokenSelector } from 'selectors/authSelector';

--- a/src/apis/company.js
+++ b/src/apis/company.js
@@ -4,7 +4,6 @@ import {
   getCompanyInterviewExperiencesQuery,
   getCompanyTimeAndSalaryQuery,
   getCompanyTimeAndSalaryStatisticsQuery,
-  queryCompaniesHavingDataGql,
 } from 'graphql/company';
 import graphqlClient from 'utils/graphqlClient';
 
@@ -49,9 +48,3 @@ export const getCompanyInterviewExperiences = ({
     query: getCompanyInterviewExperiencesQuery,
     variables: { companyName, jobTitle, start, limit, sortBy },
   }).then(R.prop('company'));
-
-export const queryCompaniesApi = ({ start, limit }) =>
-  graphqlClient({
-    query: queryCompaniesHavingDataGql,
-    variables: { start, limit },
-  });

--- a/src/apis/experiencesApi.js
+++ b/src/apis/experiencesApi.js
@@ -4,7 +4,6 @@ import {
   changeExperienceStatusGql,
   createExperienceLikeGql,
   deleteExpereinceLikeGql,
-  queryExperienceCountGql,
   queryExperienceGql,
   queryExperienceLikeGql,
   queryExperienceRepliesGql,
@@ -130,11 +129,4 @@ export const queryRelatedExperiences = async ({ id, start, limit }) => {
   });
   const relatedExperiences = data.experience.relatedExperiences;
   return relatedExperiences.map(resolveSubtitlesInExperience);
-};
-
-export const queryExperienceCountApi = async () => {
-  const data = await graphqlClient({
-    query: queryExperienceCountGql,
-  });
-  return data.experienceCount;
 };

--- a/src/apis/queryCompanies.ts
+++ b/src/apis/queryCompanies.ts
@@ -1,0 +1,37 @@
+import graphqlClient from 'utils/graphqlClient';
+
+const queryCompaniesHavingDataGql = /* GraphQL */ `
+  query($start: Int!, $limit: Int!) {
+    companiesHavingData(start: $start, limit: $limit) {
+      name
+      businessNumber
+      dataCount
+    }
+    companiesHavingDataCount
+  }
+`;
+
+type CompanyHavingData = {
+  name: string;
+  businessNumber: string;
+  dataCount: number;
+};
+
+type QueryCompaniesData = {
+  companiesHavingData: CompanyHavingData[];
+  companiesHavingDataCount: number;
+};
+
+const queryCompanies = ({
+  start,
+  limit,
+}: {
+  start: number;
+  limit: number;
+}): Promise<QueryCompaniesData> =>
+  graphqlClient<QueryCompaniesData>({
+    query: queryCompaniesHavingDataGql,
+    variables: { start, limit },
+  });
+
+export default queryCompanies;

--- a/src/apis/queryCompanies.ts
+++ b/src/apis/queryCompanies.ts
@@ -11,14 +11,14 @@ const queryCompaniesHavingDataGql = /* GraphQL */ `
   }
 `;
 
-type CompanyHavingData = {
+export type CompanyInIndex = {
   name: string;
   businessNumber: string;
   dataCount: number;
 };
 
 type QueryCompaniesData = {
-  companiesHavingData: CompanyHavingData[];
+  companiesHavingData: CompanyInIndex[];
   companiesHavingDataCount: number;
 };
 

--- a/src/apis/queryCompanies.ts
+++ b/src/apis/queryCompanies.ts
@@ -13,7 +13,7 @@ const queryCompaniesHavingDataGql = /* GraphQL */ `
 
 export type CompanyInIndex = {
   name: string;
-  businessNumber: string;
+  businessNumber: string | null;
   dataCount: number;
 };
 

--- a/src/apis/queryExperienceCount.ts
+++ b/src/apis/queryExperienceCount.ts
@@ -1,0 +1,20 @@
+import graphqlClient from 'utils/graphqlClient';
+
+const queryExperienceCountGql = /* GraphQL */ `
+  query {
+    experienceCount
+  }
+`;
+
+type QueryExperienceCountData = {
+  experienceCount: number;
+};
+
+const queryExperienceCount = async (): Promise<number> => {
+  const data = await graphqlClient<QueryExperienceCountData>({
+    query: queryExperienceCountGql,
+  });
+  return data.experienceCount;
+};
+
+export default queryExperienceCount;

--- a/src/graphql/company.ts
+++ b/src/graphql/company.ts
@@ -120,14 +120,3 @@ export const getCompanyInterviewExperiencesQuery = /* GraphQL */ `
     }
   }
 `;
-
-export const queryCompaniesHavingDataGql = /* GraphQL */ `
-  query($start: Int!, $limit: Int!) {
-    companiesHavingData(start: $start, limit: $limit) {
-      name
-      businessNumber
-      dataCount
-    }
-    companiesHavingDataCount
-  }
-`;

--- a/src/graphql/experience.js
+++ b/src/graphql/experience.js
@@ -196,12 +196,6 @@ export const deleteExpereinceLikeGql = /* GraphQL */ `
   }
 `;
 
-export const queryExperienceCountGql = /* GraphQL */ `
-  query {
-    experienceCount
-  }
-`;
-
 export const changeExperienceStatusGql = /* GraphQL */ `
   mutation($input: ChangeExperienceStatusInput!) {
     changeExperienceStatus(input: $input) {

--- a/src/reducers/companyIndex.ts
+++ b/src/reducers/companyIndex.ts
@@ -20,6 +20,7 @@ import {
   InterviewExperienceInOverview,
   WorkExperienceInOverview,
 } from 'apis/overview';
+import { CompanyInIndex } from 'apis/queryCompanies';
 import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
 import { RatingStatistics } from 'apis/queryCompanyRatingStatistics';
 import { TopNJobTitles } from 'apis/queryCompanyTopNJobTitles';
@@ -31,9 +32,6 @@ import {
 import { Aspect } from 'constants/companyJobTitle';
 import createReducer from 'utils/createReducer';
 import FetchBox, { getUnfetched } from 'utils/fetchBox';
-
-// TODO: replace with proper CompanyInIndex type
-export type CompanyInIndex = unknown;
 
 // Flattened from QueryCompanyOverviewData, so a type is defined here
 export type CompanyOverview = {

--- a/src/selectors/companyAndJobTitle.ts
+++ b/src/selectors/companyAndJobTitle.ts
@@ -1,13 +1,13 @@
 import R from 'ramda';
 
 import { AspectStatisticsData } from 'apis/aspectRatingStatistics';
+import { CompanyInIndex } from 'apis/queryCompanies';
 import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
 import { RatingStatistics } from 'apis/queryCompanyRatingStatistics';
 import { TopNJobTitles } from 'apis/queryCompanyTopNJobTitles';
 import { RootState } from 'reducers';
 import {
   CompanyAspectExperienceResult,
-  CompanyInIndex,
   CompanyInterviewExperienceResult,
   CompanyIsSubscribed,
   CompanyOverview,


### PR DESCRIPTION
## Summary

- Extract `queryExperienceCountApi` from `apis/experiencesApi.js` into a new typed `apis/queryExperienceCount.ts`
- Extract `queryCompaniesApi` from `apis/company.js` into a new typed `apis/queryCompanies.ts`
- Rename `CompanyHavingData` to `CompanyInIndex` (exported) and replace the `unknown` placeholder in `reducers/companyIndex.ts`
- Update all import sites accordingly; remove now-unused GQL constants from `graphql/experience.js` and `graphql/company.ts`

## Test plan

- [ ] `npx tsc --noEmit` passes with no errors
- [ ] Company index page loads and paginates correctly
- [ ] Experience count displays correctly in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)