### PR TITLE
fix: 修正面向頁面換頁的卷軸位置

### DIFF
--- a/src/components/CompanyAndJobTitle/WorkExperiences/Aspects/index.tsx
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/Aspects/index.tsx
@@ -47,7 +47,7 @@ const AspectSection: React.FC<AspectProps> = ({
   pageSize,
 }) => {
   const parentPath = generateTabURL({ pageType, pageName, tabType });
-  const [createPageLinkTo] = useCreatePageLinkTo();
+  const [createPageLinkTo, handleSectionRef] = useCreatePageLinkTo();
 
   return (
     <CompanyAndJobTitleWrapper
@@ -80,7 +80,7 @@ const AspectSection: React.FC<AspectProps> = ({
           }}
         />
       </Wrapper>
-      <Wrapper size="m">
+      <Wrapper ref={handleSectionRef} size="m">
         <RatingFilter />
         <PageBoxRenderer
           pageType={pageType}

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import qs from 'qs';
 import React, { useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
@@ -18,14 +17,19 @@ import {
 } from './helpers';
 import styles from './Pagination.module.css';
 
-// Portal for generating the link and ref
-export const useCreatePageLinkTo = () => {
+export const useCreatePageLinkTo = (): readonly [
+  (
+    p: number,
+  ) => { pathname: string; search: string; state: { y: number | null } },
+  React.RefObject<HTMLElement>,
+  number | null,
+] => {
   const location = useLocation();
   const queryParams = useQuery();
   const [y, handleSectionRef] = useSectionY();
 
   const createPageLinkTo = useCallback(
-    p => {
+    (p: number) => {
       const pathname = location.pathname;
       const search = qs.stringify(
         { ...queryParams, p },
@@ -40,10 +44,22 @@ export const useCreatePageLinkTo = () => {
     [y, queryParams, location.pathname],
   );
 
-  return [createPageLinkTo, handleSectionRef, y];
+  return [createPageLinkTo, handleSectionRef, y] as const;
 };
 
-const Pagination = ({ totalCount, unit, currentPage, createPageLinkTo }) => {
+type Props = {
+  createPageLinkTo: (p: number) => object;
+  currentPage?: number;
+  totalCount?: number;
+  unit?: number;
+};
+
+const Pagination = ({
+  totalCount,
+  unit,
+  currentPage,
+  createPageLinkTo,
+}: Props): React.ReactElement | null => {
   const totalPage = getTotalPage(totalCount, unit);
   const currentCount = getCurrentCount(totalCount, unit, currentPage);
 
@@ -62,35 +78,23 @@ const Pagination = ({ totalCount, unit, currentPage, createPageLinkTo }) => {
           最前頁
         </Link>
         {isPreviousDisabled(currentPage) ? (
-          <div className="buttonPage" disabled>
+          <div className="buttonPage" aria-disabled>
             <ArrowLeft />
             前一頁
           </div>
         ) : (
-          <Link
-            className="buttonPage"
-            disabled={isPreviousDisabled(currentPage)}
-            to={
-              isPreviousDisabled(currentPage)
-                ? ''
-                : createPageLinkTo(currentPage - 1)
-            }
-          >
+          <Link className="buttonPage" to={createPageLinkTo(currentPage - 1)}>
             <ArrowLeft />
             前一頁
           </Link>
         )}
         {isNextDisabled(currentPage, totalPage) ? (
-          <div className="buttonPage" disabled>
+          <div className="buttonPage" aria-disabled>
             下一頁
             <ArrowLeft style={{ transform: 'scaleX(-1)' }} />
           </div>
         ) : (
-          <Link
-            className="buttonPage"
-            disabled={isNextDisabled(currentPage, totalPage)}
-            to={createPageLinkTo(currentPage + 1)}
-          >
+          <Link className="buttonPage" to={createPageLinkTo(currentPage + 1)}>
             下一頁
             <ArrowLeft style={{ transform: 'scaleX(-1)' }} />
           </Link>
@@ -98,13 +102,6 @@ const Pagination = ({ totalCount, unit, currentPage, createPageLinkTo }) => {
       </div>
     </div>
   );
-};
-
-Pagination.propTypes = {
-  createPageLinkTo: PropTypes.func.isRequired,
-  currentPage: PropTypes.number,
-  totalCount: PropTypes.number,
-  unit: PropTypes.number,
 };
 
 export default Pagination;

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -21,7 +21,7 @@ export const useCreatePageLinkTo = (): readonly [
   (
     p: number,
   ) => { pathname: string; search: string; state: { y: number | null } },
-  React.RefObject<HTMLElement>,
+  React.RefObject<HTMLElement | null>,
   number | null,
 ] => {
   const location = useLocation();
@@ -83,7 +83,10 @@ const Pagination = ({
             前一頁
           </div>
         ) : (
-          <Link className="buttonPage" to={createPageLinkTo(currentPage - 1)}>
+          <Link
+            className="buttonPage"
+            to={createPageLinkTo((currentPage || 1) - 1)}
+          >
             <ArrowLeft />
             前一頁
           </Link>
@@ -94,7 +97,10 @@ const Pagination = ({
             <ArrowLeft style={{ transform: 'scaleX(-1)' }} />
           </div>
         ) : (
-          <Link className="buttonPage" to={createPageLinkTo(currentPage + 1)}>
+          <Link
+            className="buttonPage"
+            to={createPageLinkTo((currentPage || 1) + 1)}
+          >
             下一頁
             <ArrowLeft style={{ transform: 'scaleX(-1)' }} />
           </Link>

--- a/src/components/common/global.module.css
+++ b/src/components/common/global.module.css
@@ -246,7 +246,8 @@
       }
     }
 
-    &[disabled] {
+    &[disabled],
+    &[aria-disabled] {
       background-color: rgba(224, 224, 224, 0.4);
       color: #ccc;
       pointer-events: none;

--- a/src/hooks/useSectionY.ts
+++ b/src/hooks/useSectionY.ts
@@ -1,11 +1,14 @@
-import { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import useMobile from 'hooks/useMobile';
 
-const useSectionY = () => {
-  const sectionRef = useRef(null);
+const useSectionY = (): [
+  number | null,
+  React.RefObject<HTMLElement | null>,
+] => {
+  const sectionRef = useRef<HTMLElement | null>(null);
   const isMobile = useMobile();
-  const [y, setY] = useState(null);
+  const [y, setY] = useState<number | null>(null);
 
   /* eslint-disable react-hooks/exhaustive-deps */
   // DOM state changes don't notify React,


### PR DESCRIPTION
#1736

## 這個 PR 是？

`AspectSection` 缺少從 `useCreatePageLinkTo` 取出的 `handleSectionRef`，導致分頁連結的 `state.y` 始終為 undefined。換頁後頁面會捲到最頂端，而非捲回 Aspects 區塊的位置，與 `InterviewExperiences`、`WorkExperiences`、`TimeAndSalary` 的行為不一致。

修正方式是將 `handleSectionRef` 掛到區塊的外層 `Wrapper` 上，與其他區塊的做法對齊。

## 我應該如何手動測試？

- [ ] 前往有多頁「面向體驗」的公司或職稱頁面
- [ ] 點擊分頁按鈕換頁
- [ ] 確認頁面捲動到 Aspects 區塊的位置，而非回到頁面最頂端

## Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/f33741be-6147-4649-b8e8-f441ff40d98f

</td>
<td>

https://github.com/user-attachments/assets/bdd7dd8e-3073-4849-8192-f1e48cf8ade4

</td>
</tr>
</table>