### PR TITLE
perf: lazy-load ScoreDistributionChart to code-split recharts

### DIFF
--- a/src/components/CompanyAndJobTitle/WorkExperiences/Aspects/Summary.tsx
+++ b/src/components/CompanyAndJobTitle/WorkExperiences/Aspects/Summary.tsx
@@ -1,3 +1,4 @@
+import loadable from '@loadable/component';
 import React from 'react';
 
 import { RatingBin } from 'apis/aspectRatingStatistics';
@@ -5,8 +6,11 @@ import Card from 'common/Card';
 import Pen from 'common/icons/Pen';
 import OverallRating from 'common/OverallRating';
 
-import ScoreDistributionChart from './ScoreDistributionChart';
 import styles from './styles.module.css';
+
+const ScoreDistributionChart = loadable(() =>
+  import('./ScoreDistributionChart'),
+);
 
 type SummaryProps = {
   averageRating: number;


### PR DESCRIPTION
## Summary
- `common/Charts/SalaryDistributionChart` and `common/Charts/JobTitleDistributionChart` already lazy-load via `loadable()`, but `ScoreDistributionChart` (used in `CompanyAndJobTitle/WorkExperiences/Aspects/Summary.tsx`) was still statically imported.
- Since all three components depend on `recharts`, the static import kept the entire `recharts` library in the main bundle regardless of the other two being code-split.
- Switched `ScoreDistributionChart` to `loadable()`, matching the existing pattern, so `recharts` is split into its own chunk.

## Numbers (gzip, `npm run build`)

| File | Before | After |
|---|---|---|
| main bundle (`bundle.*.js`) | 504.56 KB | 358.76 KB (**-145.8 KB**) |
| new chunk (`0.*.chunk.js`, contains recharts) | — | 135.53 KB |
| chunk (`1.*.chunk.js`, chart wrappers) | 703 B / 807 B | 1.28 KB |

Net effect: pages that don't render any of these charts no longer download `recharts`.

## Test plan
- [x] `npm run build` succeeds and shows the bundle size drop above
- [ ] Manually verify Company/JobTitle "評價與心得" (Aspects) page still renders the score distribution chart correctly