### PR TITLE
feat: add manual workflows to release dev/dev2 into master with --no-ff

### DIFF
--- a/.github/workflows/release-dev-to-master.yml
+++ b/.github/workflows/release-dev-to-master.yml
@@ -1,0 +1,61 @@
+name: Release dev to master
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Dry run (do not push to master)"
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    if: github.repository == 'goodjoblife/GoodJobShare'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          ref: master
+
+      - name: Find related PR
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --base master --head dev --state open --json number,title,url --limit 1)
+          if [ "$(echo "$PR_JSON" | jq length)" -gt 0 ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "number=$(echo "$PR_JSON" | jq -r '.[0].number')" >> "$GITHUB_OUTPUT"
+            echo "title=$(echo "$PR_JSON" | jq -r '.[0].title')" >> "$GITHUB_OUTPUT"
+            echo "url=$(echo "$PR_JSON" | jq -r '.[0].url')" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Release dev to master
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin dev
+
+          if [ "${{ steps.find_pr.outputs.found }}" = "true" ]; then
+            git merge origin/dev --no-ff \
+              -m "Merge branch 'dev' into master (#${{ steps.find_pr.outputs.number }})" \
+              -m "${{ steps.find_pr.outputs.title }}" \
+              -m "${{ steps.find_pr.outputs.url }}"
+          else
+            git merge origin/dev --no-ff -m "Merge branch 'dev' into master"
+          fi
+
+      - name: Push
+        if: ${{ !inputs.dryrun }}
+        run: git push origin master

--- a/.github/workflows/release-dev2-to-master.yml
+++ b/.github/workflows/release-dev2-to-master.yml
@@ -1,0 +1,55 @@
+name: Release dev2 to master
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    if: github.repository == 'goodjoblife/GoodJobShare'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          ref: master
+
+      - name: Find related PR
+        id: find_pr
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_JSON=$(gh pr list --repo "$GITHUB_REPOSITORY" --base master --head dev2 --state open --json number,title,url --limit 1)
+          if [ "$(echo "$PR_JSON" | jq length)" -gt 0 ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "number=$(echo "$PR_JSON" | jq -r '.[0].number')" >> "$GITHUB_OUTPUT"
+            echo "title=$(echo "$PR_JSON" | jq -r '.[0].title')" >> "$GITHUB_OUTPUT"
+            echo "url=$(echo "$PR_JSON" | jq -r '.[0].url')" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Release dev2 to master
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin dev2
+
+          if [ "${{ steps.find_pr.outputs.found }}" = "true" ]; then
+            git merge origin/dev2 --no-ff \
+              -m "Merge branch 'dev2' into master (#${{ steps.find_pr.outputs.number }})" \
+              -m "${{ steps.find_pr.outputs.title }}" \
+              -m "${{ steps.find_pr.outputs.url }}"
+          else
+            git merge origin/dev2 --no-ff -m "Merge branch 'dev2' into master"
+          fi
+
+      - name: Push
+        run: git push origin master

--- a/.github/workflows/release-dev2-to-master.yml
+++ b/.github/workflows/release-dev2-to-master.yml
@@ -2,6 +2,11 @@ name: Release dev2 to master
 
 on:
   workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "Dry run (do not push to master)"
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -52,4 +57,5 @@ jobs:
           fi
 
       - name: Push
+        if: ${{ !inputs.dryrun }}
         run: git push origin master


### PR DESCRIPTION
## Summary
- 新增兩支 `workflow_dispatch` workflow：`release-dev-to-master.yml`、`release-dev2-to-master.yml`，手動觸發時分別將 `dev` / `dev2` 以 `--no-ff` merge 進 `master`
- Merge 前會查詢是否有對應的 open PR（head: dev/dev2, base: master），若有則將 PR number/title/url 帶入 merge commit message
- 支援 `dryrun` 輸入參數：勾選時仍會在 runner 上本地執行 merge，但不會 push 到 master，方便先確認 commit message 內容
- 沿用既有的 GitHub App token 設定（同 `sync-master-to-dev.yml` / `sync-master-to-dev2.yml`）來繞過 master 的 branch protection 推送

## Edge cases

**dev/dev2 沒有領先 master**（例如剛被 `sync-master-to-dev.yml` 同步過，中間沒有新 commit）
`git merge --no-ff` 判定沒東西可合併，印出 `Already up to date.`，不建立新 commit，exit code 0；接著的 `git push` 也是 no-op（`Everything up-to-date`）。整個 workflow 顯示成功，但實際上什麼都沒發生，不會有風險。

**dev/dev2 領先 master 但合併有 conflict**
`git merge --no-ff` 失敗（exit code 1），GitHub Actions 的 `run:` 預設用 `bash -e`，該 step 立即中止，後面的 `Push` step 因為前一步失敗而被跳過——master 不會被動到。Workflow run 會顯示失敗，log 裡有 git 印出的衝突檔案清單。Runner 上衝突的 working tree 只存在於該次 ephemeral runner，job 結束即丟棄，不會留下殘留狀態。這種情況下需要有人手動本地 `git merge` 解衝突後再推，或先開一個 dev→master 的 PR 用 GitHub 網頁解 conflict，再重新觸發此 workflow。

## Test plan
- [ ] 在 Actions 頁面手動觸發 `Release dev to master`，勾選 `dryrun`，確認流程執行成功但未 push
- [ ] 在 Actions 頁面手動觸發 `Release dev2 to master`，勾選 `dryrun`，確認流程執行成功但未 push
- [ ] 確認有對應 PR 時，merge commit message 有正確帶入 PR 資訊
- [ ] 確認沒有對應 PR 時，仍能以預設訊息完成 merge 並推送
- [ ] 確認 dev/dev2 沒有領先 master 時，workflow 顯示成功但無實際動作
- [ ] 確認 dev/dev2 有 conflict 時，workflow 顯示失敗且 master 未被動到

🤖 Generated with [Claude Code](https://claude.com/claude-code)