### PR TITLE
fix: serialize main.yml runs per ref to avoid image tag races

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
       - dev2
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
## Summary
- `docker-stage` / `docker-dev` / `docker-dev2` push to mutable tags (`:stage`, `:dev`, `:dev2`)
- 沒有 `concurrency` 設定時，同一分支短時間內多次 push 會觸發多個平行的 workflow run；若較舊 commit 的 run 跑得比較慢、比較晚 push，會把較新 commit 的 image 蓋掉，導致後續 deploy 部署到舊 code
- 加上 `concurrency: group: ${{ github.workflow }}-${{ github.ref }}`，讓同一 ref 的 run 排隊依序執行；`cancel-in-progress: false` 是因為要讓 run 完整跑完（image 已經在 push 了），而不是中途被砍掉留下不完整的狀態

## Test plan
- [ ] 短時間內對同一分支連續 push 兩次，確認第二個 workflow run 會等待第一個 run 完成後才開始，而不是同時平行跑
- [ ] 確認 PR 事件觸發的 run 不受影響（不同 PR 之間仍可平行跑，因為 group key 包含 `github.ref`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)