### PR TITLE
feat: upgrade production Docker image to Node 20, probe Node 24 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
       - name: Install dependencies
         run: yarn install
@@ -47,12 +47,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18, 20]
+        node: [20, 24]
         include:
-          - node: 18
-            experimental: true
-            node_options: '--openssl-legacy-provider'
           - node: 20
+            node_options: '--openssl-legacy-provider'
+          - node: 24
             experimental: true
             node_options: '--openssl-legacy-provider'
     steps:

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ yarn install
 ```
 
 ### build
+
+Node.js 17 以後版本的 OpenSSL 3 與專案目前使用的 webpack 4（Razzle 3）不相容，`build` 時必須加上 `--openssl-legacy-provider`，否則會出現 `error:0308010C:digital envelope routines::unsupported`：
 ```
-npm run build
+NODE_OPTIONS=--openssl-legacy-provider npm run build
 ```
+（`npm run start` 的開發模式不受影響，不需要加這個 flag。）
 
 ### start
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:20
 
 COPY . /app
 
@@ -26,7 +26,7 @@ ENV RAZZLE_API_HOST="${RAZZLE_API_HOST}" \
     RAZZLE_TAP_PAY_SERVER_TYPE="$RAZZLE_TAP_PAY_SERVER_TYPE" \
     RAZZLE_ORIGIN="$RAZZLE_ORIGIN"
 
-RUN yarn install && yarn run build && yarn cache clean
+RUN yarn install && NODE_OPTIONS=--openssl-legacy-provider yarn run build && yarn cache clean
 
 ENV NODE_ENV=production PORT=3000
 

--- a/package.json
+++ b/package.json
@@ -117,6 +117,6 @@
     "serialize-javascript": "^6.0.2"
   },
   "engines": {
-    "node": ">=16.x"
+    "node": ">=20.x"
   }
 }


### PR DESCRIPTION
## Summary
- `docker/Dockerfile`: bump `FROM node:16` to `FROM node:20` (Node 16 is long past EOL). Scope `NODE_OPTIONS=--openssl-legacy-provider` to just the build `RUN` step (not a global `ENV`), since OpenSSL 3.x on Node >=17 breaks Razzle/webpack 4's Terser step during `yarn run build`. Verified locally via `docker compose -f .github/docker-compose-production.yml build`, which fails without the flag and succeeds with it. The flag is a build-tool workaround and isn't needed by the running server, so it's deliberately not applied to the production runtime (`CMD`).
- `package.json`: `engines.node` `>=16.x` -> `>=20.x`, matching the new Docker baseline.
- `.github/workflows/main.yml`:
  - `lint` / `test` jobs: single required run on Node 24.
  - `build` job: matrix trimmed to `[20, 24]` — Node 20 is the required entry (keeps the `--openssl-legacy-provider` workaround), Node 24 is `continue-on-error: true` as a forward-compat probe.

## Test plan
- [x] Validated all touched workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `npm run stylelint` passes
- [x] `npm run lint` / `CI=true npm run testonly` show only pre-existing, unrelated failures (import/order lint errors and one `history`-package test suite failure present before this change)
- [x] `docker compose -f .github/docker-compose-production.yml build` succeeds end-to-end on Node 20 with the Dockerfile change (client + server compile, image exports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)