### PR TITLE
feat(esg): ESG 區塊 UX enhancement（年份切換自動展開、手機版下拉同卡片寬）

### DIFF
--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.module.css
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.module.css
@@ -149,7 +149,5 @@
 }
 
 .mobileYearSelect {
-  display: flex;
-  justify-content: center;
   padding: 1rem 0;
 }

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.test.tsx
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.test.tsx
@@ -82,6 +82,34 @@ test('只有單一年份時不顯示年份下拉，但仍顯示卡片', () => {
   expect(screen.getAllByText('2024 年')).toHaveLength(4);
 });
 
+test('toggle 按鈕以 aria-expanded 反映收合狀態', () => {
+  render(<EsgBlock data={esgSalaryData} hasPreviewed />);
+  const toggle = screen.getByRole('button');
+  expect(toggle).toHaveAttribute('aria-expanded', 'false'); // hasPreviewed 初始為收合
+  fireEvent.click(toggle);
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('收合狀態下切換年份會自動展開區塊', () => {
+  render(<EsgBlock data={esgSalaryData} hasPreviewed />);
+  const toggle = screen.getByRole('button');
+  expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  fireEvent.change(screen.getByRole('combobox'), {
+    target: { value: '2023' },
+  });
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('展開狀態下切換年份維持展開', () => {
+  render(<EsgBlock data={esgSalaryData} />);
+  const toggle = screen.getByRole('button');
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  fireEvent.change(screen.getByRole('combobox'), {
+    target: { value: '2023' },
+  });
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
+});
+
 test('空資料不會 crash，仍顯示標題', () => {
   const empty = {
     avgSalaryStatistics: [],

--- a/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.tsx
+++ b/src/components/CompanyAndJobTitle/TimeAndSalary/EsgBlock/EsgBlock.tsx
@@ -108,6 +108,7 @@ const EsgBlock: React.FC<EsgBlockProps> = ({
   const handleYearChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       setSelectedYear(Number(e.target.value));
+      setCollapsed(false);
     },
     [],
   );
@@ -135,6 +136,7 @@ const EsgBlock: React.FC<EsgBlockProps> = ({
           {showsToggle && (
             <button
               className={cn(styles.toggle, { [styles.collapsed]: isCollapsed })}
+              aria-expanded={!isCollapsed}
               onClick={toggleCollapsed}
             >
               <Caret />


### PR DESCRIPTION
## 這個 PR 是？

實作 #1726 review 中 @barry800414 提出的兩個 UX enhancement（[comment 1](https://github.com/goodjoblife/GoodJobShare/pull/1726#issuecomment-comment)、[comment 2](https://github.com/goodjoblife/GoodJobShare/pull/1726)）：

## Screenshot
1. **收合狀態下切換年份自動展開區塊**
<img width="2564" height="1628" alt="2026-07-05 15 17 59" src="https://github.com/user-attachments/assets/044e0f5d-3915-4951-b7ff-7750f81a3857" />

2. **手機版年份下拉選單與卡片同寬**
<img width="828" height="799" alt="image" src="https://github.com/user-attachments/assets/c2b807d9-f009-4334-85a9-22f12808dd45" />

## 有哪些 dependency？

- Front-end PR：#1726（本 PR target branch 為 `feature/esg`，需在 #1726 merge 前先合入該 branch）

## 我應該從何看起？

- `EsgBlock.tsx`：`handleYearChange` 的 `setCollapsed(false)` 與 toggle 按鈕的 `aria-expanded`
- `EsgBlock.module.css`：`.mobileYearSelect` 移除 `display: flex; justify-content: center`
- `EsgBlock.test.tsx`：新增 3 個測項（收合後改年份會展開、展開時改年份維持展開、toggle 正確反映 `aria-expanded`）

## 我應該如何手動測試？

- [x] `npm run start` 後開啟有 ESG 資料的上市公司頁面 `http://localhost:3000/companies/<公司名>/salary-work-times`
- [x] 桌機版：點 ESG 區塊 toggle 收合 → 在 header 的年份下拉切換年份 → 區塊自動展開且卡片為所選年份
- [x] 手機版（縮小視窗）：ESG 區塊內的年份下拉選單寬度與卡片同寬

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013npRAGSSJ1nKTnShLDxqPR