### PR TITLE
refactor: give CompanyIsSubscribed a real type, migrate SubscribeNotificationButton to TS

### DIFF
--- a/src/actions/company.js
+++ b/src/actions/company.js
@@ -708,6 +708,16 @@ export const queryCompanyWorkExperiencesAspectExperiences = ({
   }
 };
 
+/**
+ * @type {(
+ *   companyName: string,
+ *   box: import('utils/fetchBox').default<import('apis/queryCompanyIsSubscribed').CompanyIsSubscribed>
+ * ) => {
+ *   type: string;
+ *   companyName: string;
+ *   box: import('utils/fetchBox').default<import('apis/queryCompanyIsSubscribed').CompanyIsSubscribed>
+ * }}
+ */
 const setIsSubscribed = (companyName, box) => ({
   type: SET_IS_SUBSCRIBED,
   companyName,
@@ -851,10 +861,6 @@ export const queryCompanyIsSubscribed = ({ companyName }) => async (
     const state = getState();
     const token = tokenSelector(state);
     const data = await queryCompanyIsSubscribedApi({ companyName, token });
-
-    if (data == null) {
-      return dispatch(setIsSubscribed(companyName, getFetched(data)));
-    }
 
     dispatch(setIsSubscribed(companyName, getFetched(data)));
   } catch (error) {

--- a/src/apis/queryCompanyIsSubscribed.ts
+++ b/src/apis/queryCompanyIsSubscribed.ts
@@ -16,13 +16,20 @@ type QueryCompanyIsSubscribedData = {
   } | null;
 };
 
+export type CompanyIsSubscribed = {
+  // isSubscribed 反映使用者目前（後端確認或本地樂觀更新）是否訂閱該公司
+  isSubscribed: boolean;
+  // companyId 為 null 代表查無此公司（company 不存在）；為 string 時才可實際訂閱/取消訂閱
+  companyId: string | null;
+};
+
 const queryCompanyIsSubscribed = async ({
   companyName,
   token,
 }: {
   companyName: string;
   token?: string;
-}): Promise<{ isSubscribed: boolean; companyId: string | null }> => {
+}): Promise<CompanyIsSubscribed> => {
   const data = await graphqlClient<QueryCompanyIsSubscribedData>({
     query: queryCompanyIsSubscribedGql,
     token,

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.tsx
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -7,13 +7,24 @@ import {
   queryCompanyIsSubscribed,
   toggleSubscribeCompany,
 } from 'actions/company';
+import { CompanyIsSubscribed } from 'apis/queryCompanyIsSubscribed';
 import BellBlackImage from 'common/icons/bellBlack.svg';
 import BellWhiteImage from 'common/icons/bellWhite.svg';
 import useLoginFlow from 'components/ExperienceDetail/hooks/useLoginFlow';
 import { companyIsSubscribedBoxSelectorByName } from 'selectors/companyAndJobTitle';
-import { isFetched } from 'utils/fetchBox';
+import FetchBox, { isFetched } from 'utils/fetchBox';
 
 import styles from './SubscribeNotificationButton.module.css';
+
+const useCompanyIsSubscribedBox = (
+  companyName: string,
+): FetchBox<CompanyIsSubscribed> => {
+  const selector = useMemo(
+    () => companyIsSubscribedBoxSelectorByName(companyName),
+    [companyName],
+  );
+  return useSelector(selector);
+};
 
 type SubscribeNotificationButtonProps = {
   companyName: string;
@@ -23,9 +34,7 @@ const SubscribeNotificationButton: React.FC<
   SubscribeNotificationButtonProps
 > = ({ companyName }) => {
   const dispatch = useDispatch();
-  const box = useSelector(companyIsSubscribedBoxSelectorByName(companyName));
-  const fetched = isFetched(box);
-  const { isSubscribed } = box.data || {};
+  const box = useCompanyIsSubscribedBox(companyName);
 
   const handleToggleSubscribeCompany = useCallback(async () => {
     await dispatch(toggleSubscribeCompany({ companyName }));
@@ -39,9 +48,11 @@ const SubscribeNotificationButton: React.FC<
     dispatch(queryCompanyIsSubscribed({ companyName }));
   }, [dispatch, companyName]);
 
-  if (!fetched) {
+  if (!isFetched(box)) {
     return <Skeleton width={144} height={30} borderRadius={5} />;
   }
+
+  const { isSubscribed } = box.data;
 
   return (
     <button

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.tsx
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/SubscribeNotificationButton.tsx
@@ -1,5 +1,4 @@
 import cn from 'classnames';
-import PropTypes from 'prop-types';
 import React, { useCallback, useEffect } from 'react';
 import Skeleton from 'react-loading-skeleton';
 import { useDispatch, useSelector } from 'react-redux';
@@ -16,16 +15,21 @@ import { isFetched } from 'utils/fetchBox';
 
 import styles from './SubscribeNotificationButton.module.css';
 
-const SubscribeNotificationButton = ({ companyName }) => {
+type SubscribeNotificationButtonProps = {
+  companyName: string;
+};
+
+const SubscribeNotificationButton: React.FC<
+  SubscribeNotificationButtonProps
+> = ({ companyName }) => {
   const dispatch = useDispatch();
   const box = useSelector(companyIsSubscribedBoxSelectorByName(companyName));
   const fetched = isFetched(box);
   const { isSubscribed } = box.data || {};
 
-  const handleToggleSubscribeCompany = useCallback(
-    async () => dispatch(toggleSubscribeCompany({ companyName })),
-    [dispatch, companyName],
-  );
+  const handleToggleSubscribeCompany = useCallback(async () => {
+    await dispatch(toggleSubscribeCompany({ companyName }));
+  }, [dispatch, companyName]);
 
   const [handleSubscribeWithLoginCheck] = useLoginFlow(
     handleToggleSubscribeCompany,
@@ -61,10 +65,6 @@ const SubscribeNotificationButton = ({ companyName }) => {
       <div>{isSubscribed ? '已訂閱新資料通知' : '有新資料時通知我'}</div>
     </button>
   );
-};
-
-SubscribeNotificationButton.propTypes = {
-  companyName: PropTypes.string.isRequired,
 };
 
 export default SubscribeNotificationButton;

--- a/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.ts
+++ b/src/components/CompanyAndJobTitle/SubscribeNotificationButton/index.ts
@@ -1,0 +1,3 @@
+import SubscribeNotificationButton from './SubscribeNotificationButton';
+
+export default SubscribeNotificationButton;

--- a/src/components/ExperienceDetail/hooks/useLoginFlow.js
+++ b/src/components/ExperienceDetail/hooks/useLoginFlow.js
@@ -4,6 +4,9 @@ import { useMountedState } from 'react-use';
 import LoginModalContext from 'contexts/LoginModalContext';
 import { useLogin } from 'hooks/login';
 
+/**
+ * @type {(callback: () => Promise<void>) => [() => void, boolean]}
+ */
 const useLoginFlow = callback => {
   const getIsMounted = useMountedState();
   const [state, setState] = useState('init');

--- a/src/reducers/companyIndex.ts
+++ b/src/reducers/companyIndex.ts
@@ -22,6 +22,7 @@ import {
 } from 'apis/overview';
 import { CompanyInIndex } from 'apis/queryCompanies';
 import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
+import { CompanyIsSubscribed } from 'apis/queryCompanyIsSubscribed';
 import { RatingStatistics } from 'apis/queryCompanyRatingStatistics';
 import { TopNJobTitles } from 'apis/queryCompanyTopNJobTitles';
 import {
@@ -81,9 +82,6 @@ export type CompanyAspectExperienceResult = {
   workExperiencesCount: number;
 };
 
-// TODO: replace with proper CompanyIsSubscribed type
-export type CompanyIsSubscribed = unknown;
-
 type State = {
   indexesByPage: Record<number, FetchBox<CompanyInIndex[]>>;
   indexCountBox: FetchBox<number>;
@@ -117,7 +115,7 @@ type State = {
     string,
     FetchBox<CompanyAspectExperienceResult | null>
   >;
-  isSubscribedByName: Record<string, FetchBox<CompanyIsSubscribed | null>>;
+  isSubscribedByName: Record<string, FetchBox<CompanyIsSubscribed>>;
   topNJobTitlesByName: Record<string, FetchBox<TopNJobTitles | null>>;
   esgSalaryData: Record<string, FetchBox<ESGSalaryData | null>>;
 };
@@ -348,7 +346,7 @@ const reducer = createReducer(preloadedState, {
     {
       companyName,
       box,
-    }: { companyName: string; box: FetchBox<CompanyIsSubscribed | null> },
+    }: { companyName: string; box: FetchBox<CompanyIsSubscribed> },
   ) => {
     return {
       ...state,

--- a/src/selectors/companyAndJobTitle.ts
+++ b/src/selectors/companyAndJobTitle.ts
@@ -3,13 +3,13 @@ import R from 'ramda';
 import { AspectStatisticsData } from 'apis/aspectRatingStatistics';
 import { CompanyInIndex } from 'apis/queryCompanies';
 import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
+import { CompanyIsSubscribed } from 'apis/queryCompanyIsSubscribed';
 import { RatingStatistics } from 'apis/queryCompanyRatingStatistics';
 import { TopNJobTitles } from 'apis/queryCompanyTopNJobTitles';
 import { RootState } from 'reducers';
 import {
   CompanyAspectExperienceResult,
   CompanyInterviewExperienceResult,
-  CompanyIsSubscribed,
   CompanyOverview,
   CompanyOverviewStatistics,
   CompanySalaryWorkTimeResult,
@@ -105,7 +105,7 @@ export const companyWorkExperiencesAspectExperiencesBoxSelectorByName = (
 
 export const companyIsSubscribedBoxSelectorByName = (companyName: string) => (
   state: RootState,
-): FetchBox<CompanyIsSubscribed | null> =>
+): FetchBox<CompanyIsSubscribed> =>
   state.companyIndex.isSubscribedByName[companyName] || getUnfetched();
 
 export const jobTitleIndexesBoxSelectorAtPage = (page: number) => (


### PR DESCRIPTION
## Summary
- Replace the `CompanyIsSubscribed = unknown` TODO placeholder with its actual shape (`{ isSubscribed: boolean; companyId: string | null }`), documented inline: `companyId` is `null` only when the company doesn't exist, `string` when subscribe/unsubscribe is actually possible.
- Drop the vestigial `| null` on `isSubscribedByName`'s `FetchBox` — the box itself is never set to `null`, only `companyId` inside its data can be.
- Add JSDoc types to `setIsSubscribed` (`actions/company.js`) and `useLoginFlow` so the new TS consumer below type-checks correctly.
- Convert `SubscribeNotificationButton` from `index.js` to TypeScript, following the `index.ts`-is-re-export-only convention: component body now lives in `SubscribeNotificationButton.tsx`, `index.ts` just re-exports it.

## Test plan
- [x] `npx tsc --noEmit` passes
- [ ] Manually verify the subscribe/unsubscribe button still works on a company page