### PR TITLE
refactor: standardize employment_type/gender and other enums to documented conventions

### DIFF
--- a/docs/typescript-types.md
+++ b/docs/typescript-types.md
@@ -27,7 +27,7 @@ For API-specific rules see [apis.md](apis.md).
 
 ## Enums
 
-Use for discrete string-valued constant groups that need to be used as both values and types:
+Use for discrete string-valued constant groups that need to be used as both values and types. Always a named export (never `export default`); keys are `SCREAMING_SNAKE_CASE` regardless of the source's original casing, values are left as-is:
 
 ```ts
 export enum Aspect {
@@ -35,6 +35,19 @@ export enum Aspect {
   WORK_LIFE_BALANCE = '工作與生活平衡',
   ...
 }
+```
+
+When an enum's values must match a GraphQL enum, mirror it exactly and mark the sync point with a comment referencing the schema type name, e.g. `// Must be the same as graphql schema (EmploymentType)`.
+
+### Translation / lookup maps
+
+Pair an enum with a `camelCase` `Record<Enum, string>` named `<enumName>Translation` (not the enum's own name):
+
+```ts
+export const employmentTypeTranslation: Record<EmploymentType, string> = {
+  [EmploymentType.FULL_TIME]: '全職',
+  ...
+};
 ```
 
 ## Nullable fields

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -6,7 +6,7 @@ import {
   postAuthGoogle as postAuthGoogleApi,
 } from 'apis/auth';
 import queryMeApi from 'apis/queryMe';
-import AuthStatus from 'constants/authStatus';
+import { AuthStatus } from 'constants/authStatus';
 import {
   ER0001,
   ER0002,

--- a/src/apis/salaryWorkTime.ts
+++ b/src/apis/salaryWorkTime.ts
@@ -1,3 +1,5 @@
+import { EmploymentType } from 'constants/employmentType';
+
 export const fragmentSalaryWorkTimeFields = /* GraphQL */ `
   fragment salaryWorkTimeFields on SalaryWorkTime {
     id
@@ -64,7 +66,7 @@ export type SalaryWorkTime = {
   experience_in_year: number | null;
   estimated_hourly_wage: number | null;
   overtime_frequency: number | null;
-  employment_type: string | null;
+  employment_type: EmploymentType | null;
   gender: string | null;
   job_title: {
     name: string;

--- a/src/components/BuyResultPage/PaymentResult/InProgress.js
+++ b/src/components/BuyResultPage/PaymentResult/InProgress.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import P from 'common/base/P';
-import fetchingStatusMap from 'constants/fetchStatus';
+import { FetchStatus } from 'constants/fetchStatus';
 import useFetchPaymentRecord from 'hooks/payment/useFetchPaymentRecord';
 import useTimer, { countingStatusMap } from 'hooks/useTimer';
 
@@ -25,7 +25,7 @@ const InProgress = ({ paymentRecordId, fetchingStatus }) => {
   const fetch = useFetchPaymentRecord(paymentRecordId);
 
   useEffect(() => {
-    if (isTimerEnabled && fetchingStatus === fetchingStatusMap.FETCHED) {
+    if (isTimerEnabled && fetchingStatus === FetchStatus.FETCHED) {
       setLoopFetchCounting(countingStatusMap.counting);
     }
   }, [fetchingStatus, isTimerEnabled]);
@@ -66,7 +66,7 @@ const InProgress = ({ paymentRecordId, fetchingStatus }) => {
 };
 
 InProgress.propTypes = {
-  fetchingStatus: PropTypes.oneOf(Object.values(fetchingStatusMap)),
+  fetchingStatus: PropTypes.oneOf(Object.values(FetchStatus)),
   paymentRecordId: PropTypes.string,
 };
 

--- a/src/components/BuyResultPage/PaymentResult/helpers.js
+++ b/src/components/BuyResultPage/PaymentResult/helpers.js
@@ -1,17 +1,17 @@
 import { isNil } from 'ramda';
 
-import fetchingStatusMap from 'constants/fetchStatus';
+import { FetchStatus } from 'constants/fetchStatus';
 import { buyStatus, recordStatusToBuyStatus } from 'constants/payment';
 
 export const paymentRecordToBuyStatus = paymentRecord => {
   const paymentRecordData = paymentRecord.data;
   const fetchingStatus = paymentRecord.status;
 
-  if (fetchingStatus === fetchingStatusMap.FETCHING) {
+  if (fetchingStatus === FetchStatus.FETCHING) {
     return buyStatus.inProgress;
   }
 
-  if (fetchingStatus === fetchingStatusMap.UNFETCHED) {
+  if (fetchingStatus === FetchStatus.UNFETCHED) {
     return buyStatus.inProgress;
   }
 
@@ -19,7 +19,7 @@ export const paymentRecordToBuyStatus = paymentRecord => {
     return buyStatus.inProgress;
   }
 
-  if (fetchingStatus === fetchingStatusMap.ERROR) {
+  if (fetchingStatus === FetchStatus.ERROR) {
     return buyStatus.failed;
   }
 

--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/WorkingHourTable/WorkingHourTable.js
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/WorkingHourTable/WorkingHourTable.js
@@ -8,7 +8,7 @@ import Table from 'common/table/Table';
 import ReportZone from 'components/ExperienceDetail/ReportZone';
 import { REPORT_TYPE } from 'components/ExperienceDetail/ReportZone/ReportForm/constants';
 import { PageType } from 'constants/companyJobTitle';
-import { GENDER_TRANSLATION } from 'constants/gender';
+import { genderTranslation } from 'constants/gender';
 import usePermission from 'hooks/usePermission';
 
 import {
@@ -27,7 +27,7 @@ import { InfoSalaryModal, InfoTimeModal } from './InfoModal';
 import injectHideContentBlock from './injectHideContentBlock';
 import styles from './WorkingHourTable.module.css';
 
-const formatGender = gender => GENDER_TRANSLATION[gender] ?? '-';
+const formatGender = gender => genderTranslation[gender] ?? '-';
 
 const SalaryHeader = ({ isInfoSalaryModalOpen, toggleInfoSalaryModal }) => (
   <React.Fragment>

--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/WorkingHourTable/formatter.js
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/WorkingHourTable/formatter.js
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { formatSalaryAmount, formatSalaryType } from 'common/formatter';
 import { generatePageURL, PageType } from 'constants/companyJobTitle';
-import employmentType from 'constants/employmentType';
+import { employmentTypeTranslation } from 'constants/employmentType';
 
 import styles from './formatter.module.css';
 
@@ -30,7 +30,8 @@ export const getNameAsJobTitle = (o, row) => (
   </Link>
 );
 
-export const getEmploymentType = type => (type ? employmentType[type] : '');
+export const getEmploymentType = type =>
+  type ? employmentTypeTranslation[type] : '';
 
 export const getWorkingHour = (val, row) => (
   <div>{`${val === undefined || val === null ? '-' : val} / ${

--- a/src/components/common/FormBuilder/QuestionBuilder/CheckboxRadioElseRadioTextAreaList/ActiveItem.tsx
+++ b/src/components/common/FormBuilder/QuestionBuilder/CheckboxRadioElseRadioTextAreaList/ActiveItem.tsx
@@ -7,8 +7,8 @@ import RadioSubPage from './RadioSubPage';
 import TextSubPage from './TextSubPage';
 
 enum SubPage {
-  Radio = 'radio',
-  Text = 'text',
+  RADIO = 'radio',
+  TEXT = 'text',
 }
 
 type Props = {
@@ -50,7 +50,7 @@ const ActiveItem = ({
     defaultTextValue,
   ] = defaultValue || [optionValue, null, null, ''];
 
-  const [subPage, setSubPage] = useState(SubPage.Radio);
+  const [subPage, setSubPage] = useState(SubPage.RADIO);
   const [radioValue, setOptionValue] = useState<OptionValue>(
     defaultOptionValue as OptionValue,
   );
@@ -72,13 +72,13 @@ const ActiveItem = ({
 
   const handleConfirmRadio = useCallback(() => {
     if (hasNext) {
-      setSubPage(SubPage.Text);
+      setSubPage(SubPage.TEXT);
     } else {
       onChange(currentItem);
     }
   }, [onChange, hasNext, currentItem]);
 
-  const onBackToRadio = useCallback(() => setSubPage(SubPage.Radio), []);
+  const onBackToRadio = useCallback(() => setSubPage(SubPage.RADIO), []);
   const onClear = useCallback(() => onChange(null), [onChange]);
   const onSave = useCallback(
     () => onChange([optionValue, radioValue, elseOptionValue, textValue]),
@@ -86,7 +86,7 @@ const ActiveItem = ({
   );
 
   switch (subPage) {
-    case SubPage.Radio:
+    case SubPage.RADIO:
       return (
         <RadioSubPage
           dataKey={dataKey}
@@ -106,7 +106,7 @@ const ActiveItem = ({
           onCancel={onCancel}
         />
       );
-    case SubPage.Text:
+    case SubPage.TEXT:
       return (
         <TextSubPage
           title={textTitle}

--- a/src/constants/authStatus.ts
+++ b/src/constants/authStatus.ts
@@ -1,8 +1,6 @@
-enum AuthStatus {
+export enum AuthStatus {
   CONNECTED = 'connected',
   NOT_AUTHORIZED = 'not_authorized',
   CANCELED = 'canceled',
   UNKNOWN = 'unknown',
 }
-
-export default AuthStatus;

--- a/src/constants/employmentType.js
+++ b/src/constants/employmentType.js
@@ -1,8 +1,0 @@
-export default {
-  full_time: '全職',
-  part_time: '兼職(含打工)',
-  intern: '實習',
-  temporary: '臨時工',
-  contract: '約聘雇',
-  dispatched_labor: '派遣',
-};

--- a/src/constants/employmentType.ts
+++ b/src/constants/employmentType.ts
@@ -1,0 +1,18 @@
+// Must be the same as graphql schema (EmploymentType)
+export enum EmploymentType {
+  FULL_TIME = 'full_time',
+  PART_TIME = 'part_time',
+  INTERN = 'intern',
+  TEMPORARY = 'temporary',
+  CONTRACT = 'contract',
+  DISPATCHED_LABOR = 'dispatched_labor',
+}
+
+export const employmentTypeTranslation: Record<EmploymentType, string> = {
+  [EmploymentType.FULL_TIME]: '全職',
+  [EmploymentType.PART_TIME]: '兼職(含打工)',
+  [EmploymentType.INTERN]: '實習',
+  [EmploymentType.TEMPORARY]: '臨時工',
+  [EmploymentType.CONTRACT]: '約聘雇',
+  [EmploymentType.DISPATCHED_LABOR]: '派遣',
+};

--- a/src/constants/fetchStatus.ts
+++ b/src/constants/fetchStatus.ts
@@ -1,8 +1,6 @@
-enum FetchStatus {
+export enum FetchStatus {
   UNFETCHED = 'UNFETCHED',
   FETCHED = 'FETCHED',
   FETCHING = 'FETCHING',
   ERROR = 'ERROR',
 }
-
-export default FetchStatus;

--- a/src/constants/gender.ts
+++ b/src/constants/gender.ts
@@ -1,14 +1,17 @@
-export const GENDER_VALUES = ['male', 'female', 'other'] as const;
+export enum Gender {
+  MALE = 'male',
+  FEMALE = 'female',
+  OTHER = 'other',
+}
 
-export type Gender = typeof GENDER_VALUES[number];
-
-export const GENDER_TRANSLATION: Record<Gender, string> = {
-  male: '男',
-  female: '女',
-  other: '其他',
+export const genderTranslation: Record<Gender, string> = {
+  [Gender.MALE]: '男',
+  [Gender.FEMALE]: '女',
+  [Gender.OTHER]: '其他',
 };
 
-export const GENDER_OPTIONS = GENDER_VALUES.map(value => ({
-  value,
-  label: GENDER_TRANSLATION[value],
-}));
+export const GENDER_OPTIONS = [
+  { value: Gender.MALE, label: genderTranslation[Gender.MALE] },
+  { value: Gender.FEMALE, label: genderTranslation[Gender.FEMALE] },
+  { value: Gender.OTHER, label: genderTranslation[Gender.OTHER] },
+];

--- a/src/graphql/inbox.ts
+++ b/src/graphql/inbox.ts
@@ -2,8 +2,8 @@
 
 // Enum for Experience __typename
 export enum ExperienceType {
-  InterviewExperience = 'InterviewExperience',
-  WorkExperience = 'WorkExperience',
+  INTERVIEW_EXPERIENCE = 'InterviewExperience',
+  WORK_EXPERIENCE = 'WorkExperience',
 }
 
 export const queryInboxGql = /* GraphQL */ `

--- a/src/hooks/auth/index.ts
+++ b/src/hooks/auth/index.ts
@@ -1,6 +1,6 @@
 import { useSelector } from 'react-redux';
 
-import AuthStatus from 'constants/authStatus';
+import { AuthStatus } from 'constants/authStatus';
 import { User } from 'reducers/auth';
 import {
   statusSelector,

--- a/src/reducers/auth.ts
+++ b/src/reducers/auth.ts
@@ -1,5 +1,5 @@
 import { SET_LOGIN, SET_USER } from 'actions/auth';
-import AuthStatus from 'constants/authStatus';
+import { AuthStatus } from 'constants/authStatus';
 import createReducer from 'utils/createReducer';
 
 export type User = {

--- a/src/selectors/authSelector.ts
+++ b/src/selectors/authSelector.ts
@@ -1,4 +1,4 @@
-import AuthStatus from 'constants/authStatus';
+import { AuthStatus } from 'constants/authStatus';
 import { RootState } from 'reducers';
 import { User } from 'reducers/auth';
 

--- a/src/utils/fetchBox.ts
+++ b/src/utils/fetchBox.ts
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 
-import FetchStatus from 'constants/fetchStatus';
+import { FetchStatus } from 'constants/fetchStatus';
 
 interface FetchBox<T> {
   data?: T;


### PR DESCRIPTION
## Summary
- Fix `employment_type` on `SalaryWorkTime` (`src/apis/salaryWorkTime.ts`) to use a proper `EmploymentType` enum matching the backend's [GraphQL `EmploymentType` enum](https://github.com/goodjoblife/WorkTimeSurvey-backend/blob/master/schema.graphql) instead of a loose `string | null`.
- Migrate `src/constants/employmentType.js` → `.ts`: `export enum EmploymentType` + `employmentTypeTranslation` lookup map, replacing the old plain JS label object.
- Migrate `src/constants/gender.ts` from an `as const` array + derived type to `export enum Gender` + `genderTranslation`, for consistency with the same convention.
- Document the enum conventions (named export, `SCREAMING_SNAKE_CASE` keys, GraphQL-schema-sync comment, `<enumName>Translation` naming) in `docs/typescript-types.md`.
- Bring the remaining enums in the codebase in line with those documented conventions:
  - `AuthStatus` / `FetchStatus` were `export default` — switched to named exports, updated every import site.
  - `ExperienceType` (`graphql/inbox.ts`) and `SubPage` (`ActiveItem.tsx`) had non-`SCREAMING_SNAKE_CASE` keys — renamed keys only, enum values (which back GraphQL `__typename` / internal state strings) are unchanged.
- Renamed the misleading `fetchingStatusMap` local alias (was actually the `FetchStatus` enum, imported under a different name) to `FetchStatus` at its two call sites for clarity.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [x] `eslint` passes on all touched files (also ran via `lint-staged` pre-commit hook)
- [ ] Manually verify the working-hour table on a Company/JobTitle page still renders 職務型態/性別 columns correctly
- [ ] Manually verify auth login/logout flow and the payment result "in progress" polling screen still behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)