### PR TITLE
fix: 移除尚未實作的 policyReviewGroupList 查詢

### DIFF
--- a/src/apis/me.js
+++ b/src/apis/me.js
@@ -5,9 +5,6 @@ export const queryMyPublishIdsApi = ({ token }) =>
   graphqlClient({ query: queryMyPublishIdsGql, token }).then(data => [
     ...data.me.experiences.map(({ id }) => id),
     ...data.me.salary_work_times.map(({ id }) => id),
-    ...data.me.policyReviewGroupList.flatMap(({ policyReviews }) =>
-      policyReviews.map(({ id }) => id),
-    ),
   ]);
 
 export const queryMyPublishesApi = ({ token }) =>

--- a/src/graphql/me.js
+++ b/src/graphql/me.js
@@ -17,11 +17,6 @@ export const queryMyPublishIdsGql = /* GraphQL */ `
       salary_work_times {
         id
       }
-      policyReviewGroupList {
-        policyReviews {
-          id
-        }
-      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- WorkTimeSurvey-backend 尚未實作 `User.policyReviewGroupList` 欄位 (goodjoblife/WorkTimeSurvey-backend#1357)，導致 `queryMyPublishIdsGql` 打到後端會收到 `Cannot query field "policyReviewGroupList" on type "User"` 錯誤
- 先移除前端這段查詢（`src/graphql/me.js`、`src/apis/me.js`），待後端實作 #1357 後再加回來

## Test plan
- [x] `npx eslint src/graphql/me.js src/apis/me.js`
- [x] `npx tsc --noEmit`
- [ ] 手動確認登入後發布經驗分享 / 薪資工時 / 制度評價後，`queryMyPublishIds` 相關流程正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)