### PR TITLE
refactor(esg): EsgBlock 遷移到 TypeScript，抽出 esgYearUtils

### DIFF
--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/EsgBlock.test.tsx
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/EsgBlock.test.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
+
+import EsgBlock from './EsgBlock';
+
+const esgSalaryData: ESGSalaryData = {
+  avgSalaryStatistics: [
+    { year: 2023, average: 973000, sameIndustryAverage: 1000000 },
+    { year: 2024, average: 1010000, sameIndustryAverage: 1020000 },
+  ],
+  nonManagerAvgSalaryStatistics: [
+    { year: 2023, average: 994000, sameIndustryAverage: 900000 },
+    { year: 2024, average: 1005000, sameIndustryAverage: 950000 },
+  ],
+  nonManagerMedianSalaryStatistics: [
+    { year: 2023, median: 871000 },
+    { year: 2024, median: 880000 },
+  ],
+  femaleManagerStatistics: [
+    { year: 2023, percentage: 0.189 },
+    { year: 2024, percentage: 0.2 },
+  ],
+};
+
+test('顯示最新年份 2024，四張卡片皆為該年', () => {
+  render(<EsgBlock data={esgSalaryData} hasPreviewed />);
+  expect(screen.getAllByText('2024 年')).toHaveLength(4);
+  expect(screen.getByText('101.0')).toBeInTheDocument(); // 1010000 / 10000
+});
+
+test('某指標缺最新年份資料 → 該卡片不渲染', () => {
+  const partial = {
+    avgSalaryStatistics: [
+      { year: 2025, average: 1100000, sameIndustryAverage: 1100000 },
+    ],
+    nonManagerAvgSalaryStatistics: [],
+    nonManagerMedianSalaryStatistics: [],
+    femaleManagerStatistics: [],
+  };
+  render(<EsgBlock data={partial} hasPreviewed />);
+  expect(screen.getAllByText('2025 年')).toHaveLength(1);
+});
+
+test('toggle 按鈕以 aria-expanded 反映收合狀態', () => {
+  render(<EsgBlock data={esgSalaryData} hasPreviewed />);
+  const toggle = screen.getByRole('button');
+  expect(toggle).toHaveAttribute('aria-expanded', 'false'); // hasPreviewed 初始為收合
+  fireEvent.click(toggle);
+  expect(toggle).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('未預覽過時預設為展開', () => {
+  render(<EsgBlock data={esgSalaryData} />);
+  expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+});
+
+test('空資料不會 crash，仍顯示標題', () => {
+  const empty = {
+    avgSalaryStatistics: [],
+    nonManagerAvgSalaryStatistics: [],
+    nonManagerMedianSalaryStatistics: [],
+    femaleManagerStatistics: [],
+  };
+  render(<EsgBlock data={empty} hasPreviewed />);
+  expect(screen.getByText('企業ESG公開薪資揭露')).toBeInTheDocument();
+});

--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/EsgBlock.tsx
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/EsgBlock.tsx
@@ -1,7 +1,7 @@
 import cn from 'classnames';
-import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
+import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
 import linkStyles from 'common/base/Link.module.css';
 import Card from 'common/Card';
 import Caret from 'common/icons/Caret';
@@ -9,9 +9,26 @@ import Info from 'common/icons/Info';
 import { formatNumberWithSign } from 'utils/stringUtil';
 
 import styles from './EsgBlock.module.css';
+import { getAvailableYears, getStatisticsByYear } from './esgYearUtils';
 import overviewStyles from '../../Overview/Overview.module.css';
 
-const EsgItemBlock = ({
+type EsgItemBlockProps = {
+  className?: string;
+  title: string;
+  year: number;
+  value: number;
+  valueCompared?: number;
+  unit?: string;
+};
+
+type EsgBlockProps = {
+  className?: string;
+  showsToggle?: boolean;
+  hasPreviewed?: boolean;
+  data: ESGSalaryData;
+};
+
+const EsgItemBlock: React.FC<EsgItemBlockProps> = ({
   className,
   title,
   year,
@@ -36,38 +53,38 @@ const EsgItemBlock = ({
       <span
         className={cn(
           styles.value,
-          value >= valueCompared ? styles.positive : styles.negative,
+          valueCompared && value >= valueCompared
+            ? styles.positive
+            : styles.negative,
         )}
       >
-        {formatNumberWithSign(
-          ((value - valueCompared) / valueCompared) * 100,
-          0,
-        )}
+        {valueCompared &&
+          formatNumberWithSign(
+            ((value - valueCompared) / valueCompared) * 100,
+            0,
+          )}
         %
       </span>
     </div>
   </Card>
 );
 
-EsgItemBlock.propTypes = {
-  className: PropTypes.string,
-  title: PropTypes.string.isRequired,
-  unit: PropTypes.string,
-  value: PropTypes.number.isRequired,
-  valueCompared: PropTypes.number,
-  year: PropTypes.number.isRequired,
-};
-
-const EsgBlock = ({
+const EsgBlock: React.FC<EsgBlockProps> = ({
   className,
   showsToggle = true,
   hasPreviewed,
-  avgSalaryStatisticsItem,
-  nonManagerAvgSalaryStatisticsItem,
-  nonManagerMedianSalaryStatisticsItem,
-  femaleManagerStatisticsItem,
+  data,
 }) => {
   const [isCollapsed, setCollapsed] = useState(hasPreviewed);
+
+  const latestYear = useMemo(() => getAvailableYears(data)[0], [data]);
+
+  const {
+    avgSalaryStatisticsItem,
+    nonManagerAvgSalaryStatisticsItem,
+    nonManagerMedianSalaryStatisticsItem,
+    femaleManagerStatisticsItem,
+  } = useMemo(() => getStatisticsByYear(data, latestYear), [data, latestYear]);
 
   const toggleCollapsed = useCallback(() => {
     setCollapsed(isCollapsed => !isCollapsed);
@@ -80,6 +97,7 @@ const EsgBlock = ({
         {showsToggle && (
           <button
             className={cn(styles.toggle, { [styles.collapsed]: isCollapsed })}
+            aria-expanded={!isCollapsed}
             onClick={toggleCollapsed}
           >
             <Caret />
@@ -149,30 +167,6 @@ const EsgBlock = ({
       </div>
     </Card>
   );
-};
-
-EsgBlock.propTypes = {
-  avgSalaryStatisticsItem: PropTypes.shape({
-    average: PropTypes.number,
-    sameIndustryAverage: PropTypes.number,
-    year: PropTypes.number,
-  }),
-  className: PropTypes.string,
-  femaleManagerStatisticsItem: PropTypes.shape({
-    percentage: PropTypes.number,
-    year: PropTypes.number,
-  }),
-  hasPreviewed: PropTypes.bool,
-  nonManagerAvgSalaryStatisticsItem: PropTypes.shape({
-    average: PropTypes.number,
-    sameIndustryAverage: PropTypes.number,
-    year: PropTypes.number,
-  }),
-  nonManagerMedianSalaryStatisticsItem: PropTypes.shape({
-    median: PropTypes.number,
-    year: PropTypes.number,
-  }),
-  showsToggle: PropTypes.bool,
 };
 
 export default EsgBlock;

--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/esgYearUtils.test.ts
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/esgYearUtils.test.ts
@@ -1,0 +1,59 @@
+import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
+
+import { getAvailableYears, getStatisticsByYear } from './esgYearUtils';
+
+const sample: ESGSalaryData = {
+  avgSalaryStatistics: [
+    { year: 2023, average: 973000, sameIndustryAverage: 1000000 },
+    { year: 2024, average: 1010000, sameIndustryAverage: 1020000 },
+  ],
+  nonManagerAvgSalaryStatistics: [
+    { year: 2024, average: 1005000, sameIndustryAverage: 950000 },
+  ],
+  nonManagerMedianSalaryStatistics: [{ year: 2023, median: 871000 }],
+  femaleManagerStatistics: [{ year: 2023, percentage: 0.189 }],
+};
+
+describe('getAvailableYears', () => {
+  test('四陣列年份取聯集、由大到小排序、去重', () => {
+    expect(getAvailableYears(sample)).toEqual([2024, 2023]);
+  });
+
+  test('全部陣列為空 → 空陣列', () => {
+    expect(
+      getAvailableYears({
+        avgSalaryStatistics: [],
+        nonManagerAvgSalaryStatistics: [],
+        nonManagerMedianSalaryStatistics: [],
+        femaleManagerStatistics: [],
+      }),
+    ).toEqual([]);
+  });
+});
+
+describe('getStatisticsByYear', () => {
+  test('取出指定年份的四個 item', () => {
+    expect(getStatisticsByYear(sample, 2024)).toEqual({
+      avgSalaryStatisticsItem: {
+        year: 2024,
+        average: 1010000,
+        sameIndustryAverage: 1020000,
+      },
+      nonManagerAvgSalaryStatisticsItem: {
+        year: 2024,
+        average: 1005000,
+        sameIndustryAverage: 950000,
+      },
+      nonManagerMedianSalaryStatisticsItem: undefined,
+      femaleManagerStatisticsItem: undefined,
+    });
+  });
+
+  test('該年缺資料的指標回 undefined', () => {
+    const r = getStatisticsByYear(sample, 2023);
+    expect(r.nonManagerAvgSalaryStatisticsItem).toBeUndefined();
+    expect(r.avgSalaryStatisticsItem && r.avgSalaryStatisticsItem.year).toBe(
+      2023,
+    );
+  });
+});

--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/esgYearUtils.ts
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/EsgBlock/esgYearUtils.ts
@@ -1,0 +1,40 @@
+import { ESGSalaryData } from 'apis/queryCompanyEsgSalaryData';
+
+type AvgSalaryStatisticsItem = ESGSalaryData['avgSalaryStatistics'][number];
+type NonManagerMedianSalaryStatisticsItem = ESGSalaryData['nonManagerMedianSalaryStatistics'][number];
+type FemaleManagerStatisticsItem = ESGSalaryData['femaleManagerStatistics'][number];
+
+type StatisticsByYear = {
+  avgSalaryStatisticsItem: AvgSalaryStatisticsItem | undefined;
+  nonManagerAvgSalaryStatisticsItem: AvgSalaryStatisticsItem | undefined;
+  nonManagerMedianSalaryStatisticsItem:
+    | NonManagerMedianSalaryStatisticsItem
+    | undefined;
+  femaleManagerStatisticsItem: FemaleManagerStatisticsItem | undefined;
+};
+
+export const getAvailableYears = (esgSalaryData: ESGSalaryData): number[] => {
+  const years = new Set<number>();
+  Object.values(esgSalaryData).forEach(items => {
+    items.forEach(item => years.add(item.year));
+  });
+  return Array.from(years).sort((a, b) => b - a);
+};
+
+export const getStatisticsByYear = (
+  esgSalaryData: ESGSalaryData,
+  year: number,
+): StatisticsByYear => ({
+  avgSalaryStatisticsItem: esgSalaryData.avgSalaryStatistics.find(
+    item => item.year === year,
+  ),
+  nonManagerAvgSalaryStatisticsItem: esgSalaryData.nonManagerAvgSalaryStatistics.find(
+    item => item.year === year,
+  ),
+  nonManagerMedianSalaryStatisticsItem: esgSalaryData.nonManagerMedianSalaryStatistics.find(
+    item => item.year === year,
+  ),
+  femaleManagerStatisticsItem: esgSalaryData.femaleManagerStatistics.find(
+    item => item.year === year,
+  ),
+});

--- a/src/components/CompanyAndJobTitle/SalaryWorkTime/index.tsx
+++ b/src/components/CompanyAndJobTitle/SalaryWorkTime/index.tsx
@@ -75,29 +75,9 @@ const SalaryWorkTime: React.FC<Props> = ({
           box={esgSalaryDataBox}
           render={(data): React.ReactNode => {
             if (!data) return null;
-
-            const {
-              avgSalaryStatistics: [avgSalaryStatisticsItem],
-              nonManagerAvgSalaryStatistics: [
-                nonManagerAvgSalaryStatisticsItem,
-              ],
-              nonManagerMedianSalaryStatistics: [
-                nonManagerMedianSalaryStatisticsItem,
-              ],
-              femaleManagerStatistics: [femaleManagerStatisticsItem],
-            } = data;
             return (
               <Wrapper size="l">
-                <EsgBlock
-                  avgSalaryStatisticsItem={avgSalaryStatisticsItem}
-                  nonManagerAvgSalaryStatisticsItem={
-                    nonManagerAvgSalaryStatisticsItem
-                  }
-                  nonManagerMedianSalaryStatisticsItem={
-                    nonManagerMedianSalaryStatisticsItem
-                  }
-                  femaleManagerStatisticsItem={femaleManagerStatisticsItem}
-                />
+                <EsgBlock data={data} />
               </Wrapper>
             );
           }}


### PR DESCRIPTION
## 這個 PR 做什麼

把 `EsgBlock` 從 JS 遷移到 TS，並將「挑哪一年的資料」這件事從呼叫端抽成獨立的 utils。這是 ESG 年份下拉選單功能（#1726）的前置重構，下拉選單 UI 本身不在這個 PR。

- `EsgBlock.js` → `EsgBlock.tsx`，移除 PropTypes 改用 `React.FC<Props>`
- 新增 `esgYearUtils.ts`：`getAvailableYears` / `getStatisticsByYear`
- `EsgBlock` 改吃整包 `data: ESGSalaryData`，不再由 `SalaryWorkTime/index.tsx` 解構四個 item 傳入
- 修正 `valueCompared` 為 `undefined` 時會算出並顯示 `NaN%` 的問題
- toggle 按鈕補上 `aria-expanded`
- 補上 `EsgBlock` 與 `esgYearUtils` 的單元測試

## ⚠️ 行為變更

原本 `SalaryWorkTime/index.tsx` 是四個統計陣列各自取 `[0]`，理論上四張卡片可能顯示**不同年份**。改動後統一對齊到所有指標中**最新的年份**，該年缺資料的指標卡片不渲染。

實務上後端各指標年份通常一致，畫面應無變化；但若某指標年份落後，改動後該卡片會消失而非顯示舊年份。

## 測試

`CI=true npx razzle test --env=jsdom` 全綠（9 suites / 51 tests），`tsc -b` 與 eslint 無錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)