### PR TITLE
refactor: 處理 #1769 的 review comment

### DIFF
--- a/src/components/CompanyAndJobTitle/PageContextProvider.test.tsx
+++ b/src/components/CompanyAndJobTitle/PageContextProvider.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+
+import { PageType, TabType } from 'constants/companyJobTitle';
+
+import {
+  PageContextProvider,
+  useCompanyName,
+  usePageContext,
+} from './PageContextProvider';
+
+const wrapperFor = (
+  pageType: PageType,
+  pageName: string,
+): React.FC<React.PropsWithChildren> => {
+  const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <PageContextProvider
+      pageType={pageType}
+      pageName={pageName}
+      tabType={TabType.OVERVIEW}
+    >
+      {children}
+    </PageContextProvider>
+  );
+  return Wrapper;
+};
+
+describe('usePageContext', () => {
+  it('returns the page identity provided by PageContextProvider', () => {
+    const { result } = renderHook(() => usePageContext(), {
+      wrapper: wrapperFor(PageType.COMPANY, 'Foo'),
+    });
+
+    expect(result.current).toEqual({
+      pageType: PageType.COMPANY,
+      pageName: 'Foo',
+      tabType: TabType.OVERVIEW,
+    });
+  });
+
+  it('throws when used outside the provider', () => {
+    const { result } = renderHook(() => usePageContext());
+
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('usePageContext 只能用在'),
+      }),
+    );
+  });
+});
+
+describe('useCompanyName', () => {
+  it('returns pageName on a company page', () => {
+    const { result } = renderHook(() => useCompanyName(), {
+      wrapper: wrapperFor(PageType.COMPANY, 'Foo'),
+    });
+
+    expect(result.current).toBe('Foo');
+  });
+
+  // 這是 #1769 的重點：職稱頁的 pageName 是職稱，拿去當公司名會靜靜查無資料
+  it('throws on a job title page instead of handing back the job title', () => {
+    const { result } = renderHook(() => useCompanyName(), {
+      wrapper: wrapperFor(PageType.JOB_TITLE, 'Engineer'),
+    });
+
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('useCompanyName 只能用在公司頁'),
+      }),
+    );
+  });
+});

--- a/src/components/CompanyAndJobTitle/PageContextProvider.tsx
+++ b/src/components/CompanyAndJobTitle/PageContextProvider.tsx
@@ -30,11 +30,11 @@ export const PageContextProvider: React.FC<PageContextProviderProps> = ({
 };
 
 export const usePageContext = (): PageContextValue => {
-  const value = useContext(PageContext);
-  if (value === undefined) {
+  const context = useContext(PageContext);
+  if (context === undefined) {
     throw new Error('usePageContext 只能用在 CompanyAndJobTitleWrapper 之下');
   }
-  return value;
+  return context;
 };
 
 // 公司名只有公司頁有。在職稱頁呼叫代表元件被掛在不該掛的地方，

--- a/src/pages/Company/useCompanyNameParam.test.tsx
+++ b/src/pages/Company/useCompanyNameParam.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+import useCompanyNameParam, {
+  companyNameSelector,
+} from './useCompanyNameParam';
+
+// 掛在哪個 route 之下決定 useParams 拿不拿得到 companyName，
+// 因此連 route path 一起模擬，而不是 mock useParams
+// @types/react-router-dom 自帶一份舊的 @types/react，Route 的 render 因此
+// 收不下本專案的 ReactElement。全 repo 沒有其他 .tsx 渲染過 Route，
+// 這個 cast 只為了在測試裡拿到真正的 route match
+const RouteWithChildren = (Route as unknown) as React.FC<{
+  path: string;
+  children: React.ReactNode;
+}>;
+
+const wrapperAt = (
+  path: string,
+  entry: string,
+): React.FC<React.PropsWithChildren> => {
+  const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <MemoryRouter initialEntries={[entry]}>
+      <RouteWithChildren path={path}>{children}</RouteWithChildren>
+    </MemoryRouter>
+  );
+  return Wrapper;
+};
+
+describe('companyNameSelector', () => {
+  it('decodes the param', () => {
+    expect(companyNameSelector({ companyName: 'Foo%20Bar' })).toBe('Foo Bar');
+  });
+
+  it('throws instead of returning the string "undefined" when the param is absent', () => {
+    expect(() => companyNameSelector({})).toThrow('companyName 不存在');
+  });
+});
+
+describe('useCompanyNameParam', () => {
+  it('decodes the param under /companies/:companyName', () => {
+    const { result } = renderHook(() => useCompanyNameParam(), {
+      wrapper: wrapperAt('/companies/:companyName', '/companies/Foo%20Bar'),
+    });
+
+    expect(result.current).toBe('Foo Bar');
+  });
+
+  it('throws when mounted outside /companies/:companyName', () => {
+    const { result } = renderHook(() => useCompanyNameParam(), {
+      wrapper: wrapperAt('/job-titles/:jobTitle', '/job-titles/Engineer'),
+    });
+
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('companyName 不存在'),
+      }),
+    );
+  });
+});

--- a/src/pages/Company/useCompanyNameParam.ts
+++ b/src/pages/Company/useCompanyNameParam.ts
@@ -22,6 +22,6 @@ export const companyNameSelector = (params: Params): string =>
 // 名字帶 Param 是為了與 components/CompanyAndJobTitle/PageContextProvider 的
 // useCompanyName 區分：那支讀 PageContext，這支讀 route param，只給 Provider 層用
 const useCompanyNameParam = (): string =>
-  decodeCompanyName(useParams<Params>().companyName);
+  companyNameSelector(useParams<Params>());
 
 export default useCompanyNameParam;

--- a/src/pages/JobTitle/useJobTitleParam.test.tsx
+++ b/src/pages/JobTitle/useJobTitleParam.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { MemoryRouter, Route } from 'react-router-dom';
+
+import useJobTitleParam, { jobTitleSelector } from './useJobTitleParam';
+
+// 掛在哪個 route 之下決定 useParams 拿不拿得到 jobTitle，
+// 因此連 route path 一起模擬，而不是 mock useParams
+// @types/react-router-dom 自帶一份舊的 @types/react，Route 的 render 因此
+// 收不下本專案的 ReactElement。全 repo 沒有其他 .tsx 渲染過 Route，
+// 這個 cast 只為了在測試裡拿到真正的 route match
+const RouteWithChildren = (Route as unknown) as React.FC<{
+  path: string;
+  children: React.ReactNode;
+}>;
+
+const wrapperAt = (
+  path: string,
+  entry: string,
+): React.FC<React.PropsWithChildren> => {
+  const Wrapper: React.FC<React.PropsWithChildren> = ({ children }) => (
+    <MemoryRouter initialEntries={[entry]}>
+      <RouteWithChildren path={path}>{children}</RouteWithChildren>
+    </MemoryRouter>
+  );
+  return Wrapper;
+};
+
+describe('jobTitleSelector', () => {
+  it('decodes the param', () => {
+    expect(jobTitleSelector({ jobTitle: '軟體%20工程師' })).toBe('軟體 工程師');
+  });
+
+  it('throws instead of returning the string "undefined" when the param is absent', () => {
+    expect(() => jobTitleSelector({})).toThrow('jobTitle 不存在');
+  });
+});
+
+describe('useJobTitleParam', () => {
+  it('decodes the param under /job-titles/:jobTitle', () => {
+    const { result } = renderHook(() => useJobTitleParam(), {
+      wrapper: wrapperAt('/job-titles/:jobTitle', '/job-titles/軟體%20工程師'),
+    });
+
+    expect(result.current).toBe('軟體 工程師');
+  });
+
+  it('throws when mounted outside /job-titles/:jobTitle', () => {
+    const { result } = renderHook(() => useJobTitleParam(), {
+      wrapper: wrapperAt('/companies/:companyName', '/companies/Foo'),
+    });
+
+    expect(result.error).toEqual(
+      expect.objectContaining({
+        message: expect.stringContaining('jobTitle 不存在'),
+      }),
+    );
+  });
+});

--- a/src/pages/JobTitle/useJobTitleParam.ts
+++ b/src/pages/JobTitle/useJobTitleParam.ts
@@ -20,7 +20,6 @@ export const jobTitleSelector = (params: Params): string =>
   decodeJobTitle(params.jobTitle);
 
 // 名字帶 Param 的理由見 pages/Company/useCompanyNameParam
-const useJobTitleParam = (): string =>
-  decodeJobTitle(useParams<Params>().jobTitle);
+const useJobTitleParam = (): string => jobTitleSelector(useParams<Params>());
 
 export default useJobTitleParam;


### PR DESCRIPTION
## 這個 PR 是？

處理 #1769 merge 後 @peteranny 留下的三則 review comment，並補上該 PR 缺的單元測試。沒有行為變更。

**review comment**

| Comment | 處理 |
|---|---|
| `useJobTitleParam.ts` suggestion | 改成 `jobTitleSelector(useParams<Params>())` |
| `useCompanyNameParam.ts` suggestion | 改成 `companyNameSelector(useParams<Params>())` |
| `PageContextProvider.tsx` — prefer `context` over `value` | `usePageContext` 的區域變數更名 |

前兩則除了照建議寫得更短，也讓 hook 與 selector 共用同一條解碼路徑，不會各自呼叫 `decodeXxx` 而有機會分岔。`PageContextProvider` 裡傳給 `PageContext.Provider` 的那個 `value` 沒有動 —— 那是 React 的 prop 名。

**單元測試**

#1769 修掉的是一個「靜靜回傳字串 `"undefined"`」的 bug，防線全在幾個 throw 上，而型別擋不住有人把它們改回 fallback。補了 12 個 case：

- `companyNameSelector` / `jobTitleSelector`：解碼，以及 param 不存在時 throw
- `useCompanyNameParam` / `useJobTitleParam`：掛在對的 route 下取得值，掛錯 route 時 throw
- `usePageContext`：Provider 之外 throw
- `useCompanyName`：職稱頁 throw，而不是把職稱當公司名回傳

param hook 用 `MemoryRouter` + `Route` 給真正的 route match，沒有 mock `useParams` —— 這樣「掛錯路由」才是真的掛錯，而不是餵一個假物件。

## 我應該從何看起？

先看 `31187c46`（三則 comment，各一處），再看 `69ca0f4e`（測試）。

兩點想先說明：

1. `useCompanyNameParam.test.tsx` / `useJobTitleParam.test.tsx` 裡有一個 `RouteWithChildren` cast。原因是 `@types/react-router-dom` 自帶一份舊的 `@types/react`，`Route` 的 render/children 收不下本專案的 `ReactElement`；全 repo 沒有其他 `.tsx` 渲染過 `Route`，所以選擇用一個帶註解的 cast 圈住，而不是動 tsconfig 或把測試降級成 `.js`。
2. 改完之後 `decodeCompanyName` / `decodeJobTitle` 各自只剩 selector 一個呼叫端，要不要併進 selector 本身可以再討論，我沒有自作主張。

## Questions:

- 我需要更新 Packages 嗎？ No
- 有哪些文件需要被更新嗎？ No

## 我應該如何手動測試？

`tsc --noEmit` 乾淨、`eslint` 0 errors、單元測試 **63 passed / 63**（原本 51，新增 12）。

驗證過測試擋得住退化：把 `useCompanyName` 的 `pageType` 判斷、`decodeCompanyName` 的 undefined 判斷各拿掉一次重跑，3 個 case 如期轉紅。

改動不影響 render 結果，但 route param 的讀取路徑有換，仍建議確認：

- [x] 公司頁與職稱頁的四個分頁（overview、薪水加班、評價、面試經驗）都正常，麵包屑與標題顯示的名稱正確
- [x] 名稱含特殊字元的公司／職稱（需要 `decodeURIComponent` 的）顯示正常
- [x] 直接輸入網址做一次 SSR 載入，確認 `fetchData` 走 selector 那條路沒有拋錯
