### PR TITLE
fix: 職稱頁隱藏「家庭/育兒」與「性別友善」分頁

### DIFF
--- a/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.tsx
+++ b/src/components/CompanyAndJobTitle/CompanyAndJobTitleWrapper.tsx
@@ -12,6 +12,7 @@ import {
   PageType,
   TabType,
   tabTypeDetailTranslation as TAB_TYPE_DETAIL_TRANSLATION,
+  tabTypesByPageType,
   tabTypeTranslation,
 } from 'constants/companyJobTitle';
 
@@ -35,17 +36,15 @@ const CompanyAndJobTitleWrapper: React.FC<CompanyAndJobTitleWrapperProps> = ({
 }) => {
   const tabLinkOptions = useMemo(
     () =>
-      (Object.entries(tabTypeTranslation) as [TabType, string][]).map(
-        ([type, label]) => ({
-          label,
-          to: generateTabURL({
-            pageType,
-            pageName,
-            tabType: type,
-          }),
-          exact: type === TabType.OVERVIEW,
+      tabTypesByPageType[pageType].map(type => ({
+        label: tabTypeTranslation[type],
+        to: generateTabURL({
+          pageType,
+          pageName,
+          tabType: type,
         }),
-      ),
+        exact: type === TabType.OVERVIEW,
+      })),
     [pageType, pageName],
   );
 

--- a/src/constants/companyJobTitle.ts
+++ b/src/constants/companyJobTitle.ts
@@ -55,7 +55,6 @@ const tabTypeURLMap: Record<TabType, string> = {
   [TabType.GENDER_FRIENDLY]: 'gender-friendly',
 };
 
-// 家庭/育兒、性別友善只有公司頁才有對應的路由與資料，職稱頁不應該顯示這兩個分頁
 export const tabTypesByPageType: Record<PageType, TabType[]> = {
   [PageType.COMPANY]: [
     TabType.OVERVIEW,

--- a/src/constants/companyJobTitle.ts
+++ b/src/constants/companyJobTitle.ts
@@ -55,6 +55,19 @@ const tabTypeURLMap: Record<TabType, string> = {
   [TabType.GENDER_FRIENDLY]: 'gender-friendly',
 };
 
+// 家庭/育兒、性別友善只有公司頁才有對應的路由與資料，職稱頁不應該顯示這兩個分頁
+const companyOnlyTabTypes: TabType[] = [
+  TabType.FAMILY_CHILDCARE,
+  TabType.GENDER_FRIENDLY,
+];
+
+export const tabTypesByPageType: Record<PageType, TabType[]> = {
+  [PageType.COMPANY]: Object.values(TabType),
+  [PageType.JOB_TITLE]: Object.values(TabType).filter(
+    tabType => !companyOnlyTabTypes.includes(tabType),
+  ),
+};
+
 export enum Aspect {
   GENDER = '性別友善度',
   WORK_LIFE_BALANCE = '工作與生活平衡',

--- a/src/constants/companyJobTitle.ts
+++ b/src/constants/companyJobTitle.ts
@@ -55,7 +55,6 @@ const tabTypeURLMap: Record<TabType, string> = {
   [TabType.GENDER_FRIENDLY]: 'gender-friendly',
 };
 
-// 家庭/育兒、性別友善只有公司頁才有對應的路由與資料，職稱頁不應該顯示這兩個分頁
 const companyOnlyTabTypes: TabType[] = [
   TabType.FAMILY_CHILDCARE,
   TabType.GENDER_FRIENDLY,

--- a/src/constants/companyJobTitle.ts
+++ b/src/constants/companyJobTitle.ts
@@ -55,16 +55,22 @@ const tabTypeURLMap: Record<TabType, string> = {
   [TabType.GENDER_FRIENDLY]: 'gender-friendly',
 };
 
-const companyOnlyTabTypes: TabType[] = [
-  TabType.FAMILY_CHILDCARE,
-  TabType.GENDER_FRIENDLY,
-];
-
+// 家庭/育兒、性別友善只有公司頁才有對應的路由與資料，職稱頁不應該顯示這兩個分頁
 export const tabTypesByPageType: Record<PageType, TabType[]> = {
-  [PageType.COMPANY]: Object.values(TabType),
-  [PageType.JOB_TITLE]: Object.values(TabType).filter(
-    tabType => !companyOnlyTabTypes.includes(tabType),
-  ),
+  [PageType.COMPANY]: [
+    TabType.OVERVIEW,
+    TabType.TIME_AND_SALARY,
+    TabType.WORK_EXPERIENCE,
+    TabType.INTERVIEW_EXPERIENCE,
+    TabType.FAMILY_CHILDCARE,
+    TabType.GENDER_FRIENDLY,
+  ],
+  [PageType.JOB_TITLE]: [
+    TabType.OVERVIEW,
+    TabType.TIME_AND_SALARY,
+    TabType.WORK_EXPERIENCE,
+    TabType.INTERVIEW_EXPERIENCE,
+  ],
 };
 
 export enum Aspect {


### PR DESCRIPTION
## 這個 PR 是？

家庭/育兒、性別友善這兩個分頁目前只有公司頁有對應的路由與資料（`routes.js` 只在 `/companies` 底下註冊），但 `CompanyAndJobTitleWrapper` 產生分頁列時是不分頁面類型、列出所有 `TabType`，導致職稱頁也會顯示這兩個分頁，點下去會直接 404。

這個 PR 在 `constants/companyJobTitle.ts` 新增 `tabTypesByPageType`（公司頁拿到全部分頁；職稱頁排除這兩個公司限定分頁），並讓 `CompanyAndJobTitleWrapper` 依此產生分頁列，而不是無條件列出所有 `TabType`。

## 我應該如何手動測試？

- [ ] 前往任一職稱頁，確認分頁列沒有「家庭/育兒」、「性別友善」
      http://localhost:3000/job-titles/PT

- [ ] 前往任一公司頁，確認「家庭/育兒」、「性別友善」可以正常點擊進入
      http://localhost:3000/companies/%E6%98%9F%E5%B7%B4%E5%85%8B

## Screenshots

|公司|職稱|
|-|-|
|<img width="2880" height="1800" alt="畫面擷取於 2026-08-22 00 31 01" src="https://github.com/user-attachments/assets/cbc5948b-b169-47fe-8a32-c8076935e401" />|<img width="2880" height="1800" alt="畫面擷取於 2026-08-22 00 31 03" src="https://github.com/user-attachments/assets/87502a69-32b4-4c61-b687-0fb2c0459528" />|