### PR TITLE
fix: prevent iOS auto-zoom when focusing a text field

### DIFF
--- a/src/components/App/Header/SearchBar.module.css
+++ b/src/components/App/Header/SearchBar.module.css
@@ -10,7 +10,7 @@
     border: solid 1px #8c8c8c;
     background: transparent;
     padding: 12px 6px;
-    font-size: 14px;
+    font-size: 16px;
     letter-spacing: 0.51px;
     color: #ffffff;
     line-height: 32px;

--- a/src/components/App/Header/SearchBar.module.css
+++ b/src/components/App/Header/SearchBar.module.css
@@ -1,4 +1,4 @@
-@value main-yellow from "../../common/variables.module.css";
+@value main-yellow, MIN_TOUCH_FONT_SIZE from "../../common/variables.module.css";
 
 .searchbar {
   display: flex;
@@ -10,7 +10,7 @@
     border: solid 1px #8c8c8c;
     background: transparent;
     padding: 12px 6px;
-    font-size: 16px;
+    font-size: max(14px, MIN_TOUCH_FONT_SIZE);
     letter-spacing: 0.51px;
     color: #ffffff;
     line-height: 32px;

--- a/src/components/Buy/PaymentSection/constants.js
+++ b/src/components/Buy/PaymentSection/constants.js
@@ -1,3 +1,5 @@
+import variables from 'common/variables.module.css';
+
 export const fields = {
   number: {
     element: '#card-number',
@@ -16,8 +18,8 @@ export const fields = {
 export const styles = {
   input: {
     color: 'gray',
-    // iOS Safari auto-zooms on focus when the font is smaller than 16px
-    'font-size': '16px',
+    // TapPay renders these in iframes, so there is no parent size to inherit
+    'font-size': variables.MIN_TOUCH_FONT_SIZE,
   },
   ':focus': {
     color: 'black',

--- a/src/components/Buy/PaymentSection/constants.js
+++ b/src/components/Buy/PaymentSection/constants.js
@@ -16,9 +16,8 @@ export const fields = {
 export const styles = {
   input: {
     color: 'gray',
-  },
-  'input.ccv': {
-    'font-size': '15px',
+    // iOS Safari auto-zooms on focus when the font is smaller than 16px
+    'font-size': '16px',
   },
   ':focus': {
     color: 'black',

--- a/src/components/CompanyAndJobTitle/SearchBar.module.css
+++ b/src/components/CompanyAndJobTitle/SearchBar.module.css
@@ -10,7 +10,7 @@
     border: solid 1px #bdbdbd;
     background: #ffffff;
     padding: 12px 6px;
-    font-size: 14px;
+    font-size: 16px;
     letter-spacing: 0.51px;
     line-height: 32px;
     transition: border-color 0.4s;

--- a/src/components/CompanyAndJobTitle/SearchBar.module.css
+++ b/src/components/CompanyAndJobTitle/SearchBar.module.css
@@ -1,4 +1,4 @@
-@value main-yellow from "../common/variables.module.css";
+@value main-yellow, MIN_TOUCH_FONT_SIZE from "../common/variables.module.css";
 
 .searchbar {
   display: flex;
@@ -10,7 +10,7 @@
     border: solid 1px #bdbdbd;
     background: #ffffff;
     padding: 12px 6px;
-    font-size: 16px;
+    font-size: max(14px, MIN_TOUCH_FONT_SIZE);
     letter-spacing: 0.51px;
     line-height: 32px;
     transition: border-color 0.4s;

--- a/src/components/common/SearchBar/SearchBar.module.css
+++ b/src/components/common/SearchBar/SearchBar.module.css
@@ -23,7 +23,7 @@ $warning: #d50000;
   height: 40px;
   border: solid 1px #bdbdbd;
   padding: 8px;
-  font-size: 15px;
+  font-size: 16px;
   line-height: 24px;
 }
 

--- a/src/components/common/SearchBar/SearchBar.module.css
+++ b/src/components/common/SearchBar/SearchBar.module.css
@@ -1,3 +1,5 @@
+@value MIN_TOUCH_FONT_SIZE from "../variables.module.css";
+
 $below-small: 850px;
 $gray: #b4b4b4;
 $warning: #d50000;
@@ -23,7 +25,7 @@ $warning: #d50000;
   height: 40px;
   border: solid 1px #bdbdbd;
   padding: 8px;
-  font-size: 16px;
+  font-size: max(15px, MIN_TOUCH_FONT_SIZE);
   line-height: 24px;
 }
 

--- a/src/components/common/form/Select.module.css
+++ b/src/components/common/form/Select.module.css
@@ -1,4 +1,4 @@
-@value INPUT_HEIGHT, main-gray from "../variables.module.css";
+@value INPUT_HEIGHT, main-gray, MIN_TOUCH_FONT_SIZE from "../variables.module.css";
 
 .wrapper {
   position: relative;
@@ -27,6 +27,5 @@
   padding-right: 31.5px;
   height: INPUT_HEIGHT;
   line-height: INPUT_HEIGHT;
-  /* iOS Safari auto-zooms on focus when the font is smaller than 16px */
-  font-size: 16px;
+  font-size: max(1em, MIN_TOUCH_FONT_SIZE);
 }

--- a/src/components/common/form/Select.module.css
+++ b/src/components/common/form/Select.module.css
@@ -27,4 +27,6 @@
   padding-right: 31.5px;
   height: INPUT_HEIGHT;
   line-height: INPUT_HEIGHT;
+  /* iOS Safari auto-zooms on focus when the font is smaller than 16px */
+  font-size: 16px;
 }

--- a/src/components/common/form/TextInput/TextInput.module.css
+++ b/src/components/common/form/TextInput/TextInput.module.css
@@ -16,6 +16,8 @@
   padding: 13px 16px;
   height: INPUT_HEIGHT;
   line-height: calc(INPUT_HEIGHT / 2);
+  /* iOS Safari auto-zooms on focus when the font is smaller than 16px */
+  font-size: 16px;
   border: 1px solid main-gray;
 
   textarea& {

--- a/src/components/common/form/TextInput/TextInput.module.css
+++ b/src/components/common/form/TextInput/TextInput.module.css
@@ -1,4 +1,4 @@
-@value main-yellow, border-gray, main-gray, warning-red, INPUT_HEIGHT, main-gray from "../../variables.module.css";
+@value main-yellow, border-gray, main-gray, warning-red, INPUT_HEIGHT, MIN_TOUCH_FONT_SIZE from "../../variables.module.css";
 
 .wrapper {
   position: relative;
@@ -16,8 +16,7 @@
   padding: 13px 16px;
   height: INPUT_HEIGHT;
   line-height: calc(INPUT_HEIGHT / 2);
-  /* iOS Safari auto-zooms on focus when the font is smaller than 16px */
-  font-size: 16px;
+  font-size: max(1em, MIN_TOUCH_FONT_SIZE);
   border: 1px solid main-gray;
 
   textarea& {

--- a/src/components/common/variables.module.css
+++ b/src/components/common/variables.module.css
@@ -19,8 +19,7 @@
 
 @value INPUT_HEIGHT: 45px;
 
-/* Mobile Safari zooms the viewport when focusing a field below this size.
- * Use it as a floor, e.g. font-size: max(1em, MIN_TOUCH_FONT_SIZE). */
+/* Mobile Safari zooms the viewport when focusing a field below this size. */
 @value MIN_TOUCH_FONT_SIZE: 16px;
 
 /* ------------------------------------

--- a/src/components/common/variables.module.css
+++ b/src/components/common/variables.module.css
@@ -19,6 +19,10 @@
 
 @value INPUT_HEIGHT: 45px;
 
+/* Mobile Safari zooms the viewport when focusing a field below this size.
+ * Use it as a floor, e.g. font-size: max(1em, MIN_TOUCH_FONT_SIZE). */
+@value MIN_TOUCH_FONT_SIZE: 16px;
+
 /* ------------------------------------
  *  Color
  * ------------------------------------ */


### PR DESCRIPTION
## 問題

mobile Safari 在 focus 字體小於 16px 的欄位時，會自動放大整個頁面。

## 修法：用 floor，不寫死

`font-size` 裡的 `1em` 指的是父層字級，也就是會被繼承下來的值，所以：

```css
font-size: max(1em, MIN_TOUCH_FONT_SIZE);   /* 16px，定義在 variables.module.css */
```

= 「照原本繼承，但不低於 16px」。繼承保留，只墊高下限。

- **`common/form/TextInput` / `Select`** 原本沒有自己的 `font-size`，純靠繼承 —— 多數是 body 的 16px，但 FormBuilder 的 `SelectText` / `Date` 外層是 15px，就繼承成 15px。改用 floor 後：15px 墊到 16px，若外層是 18px 仍維持 18px。
- **三個 search bar**（Header / CompanyAndJobTitle / common/SearchBar）自己寫死 14、15px，改成 `max(14px, …)`，讓設計值與觸控下限都留在程式碼裡。
- **TapPay 信用卡欄位** 在 iframe 內、沒有父層可繼承，維持固定值，改為引用同一個 constant（沿用 `ReportForm/Reason.js` 既有的 `import variables from 'common/variables.module.css'`）。

框的尺寸沒動：這些欄位 `height` / `width` 都是固定值（`INPUT_HEIGHT: 45px`、search bar 32/40px），只有裡面的字變大。

沒有改 viewport 的 `maximum-scale` —— 一行就能解，但會一併關掉使用者自己 pinch zoom。

## 驗證

Chrome 實測 floor 行為：

```
parent 15px, max(1em,16px)   -> 16px            ← 下限生效
parent 18px, max(1em,16px)   -> 18px            ← 繼承沒被壓掉
<input> parent 15px          -> 16px (h 45px)   ← 字變大、框不變
```

`max()` 是否被 build pipeline 吃掉（cssnano 4 + postcss-calc 7）也實跑 production build 確認，`@value` 正確代入且 minify 後保留：`max(1em,16px)` / `max(14px,16px)` / `max(15px,16px)`。

lint、stylelint、testonly（12 suites / 67 tests）皆通過。

<details><summary>兩個與本 PR 無關的既有狀況</summary>

- build 的 server 階段在本機失敗於 `error:0308010C`（webpack 4 在 Node 20 的 MD4 問題），clean tree 上完全相同；client bundle 正常產出。
- IE11 不支援 `max()`，該宣告會整條失效並退回純繼承，即改動前的行為（IE 本來也沒有這個 auto-zoom）。

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)